### PR TITLE
Setup GitHub Pages and Gemini proxy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,24 @@
+name: Deploy Pages
+
+on:
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs
+      - uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# zero-day-of-water2
+# Water Dashboard
+
+This repository hosts a simple dashboard served from the `/docs` directory and a proxy for Gemini API requests.
+
+## GitHub Pages
+
+GitHub Pages is configured to deploy the `docs` directory. To use a custom subdomain:
+
+1. Create a `CNAME` DNS record for `dashboard.YOURDOMAIN.ir` pointing to `USERNAME.github.io.`
+2. Ensure `/docs/CNAME` contains `dashboard.YOURDOMAIN.ir`.
+3. Push to `main`; the GitHub Action will publish the site.
+
+## Serverless proxy
+
+Gemini API calls are routed through a serverless function so the API key is kept server side. Two example providers are included:
+
+### Netlify
+- Files under `netlify/` contain a function at `/api/gemini`.
+- Set the `GEMINI_API_KEY` environment variable in Netlify.
+- Deploy the repo and the site will serve from `docs`.
+
+### Vercel
+- Files under `api/` with `vercel.json` implement the same endpoint.
+- Add `GEMINI_API_KEY` in Project Settings on Vercel.
+
+Set `window.API_BASE` in `docs/index.html` to the deployed function host so the frontend knows where to send requests.

--- a/api/gemini.js
+++ b/api/gemini.js
@@ -1,0 +1,55 @@
+const rateMap = new Map();
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const windowMs = 60 * 1000;
+  const limit = 60;
+  const entry = rateMap.get(ip) || { count: 0, start: now };
+  if (now - entry.start > windowMs) {
+    entry.count = 0;
+    entry.start = now;
+  }
+  entry.count += 1;
+  rateMap.set(ip, entry);
+  return entry.count > limit;
+}
+
+export default async function handler(req, res) {
+  const allowed = ['https://dashboard.YOURDOMAIN.ir'];
+  const origin = req.headers.origin || '';
+  res.setHeader('Access-Control-Allow-Origin', allowed.includes(origin) ? origin : 'https://dashboard.YOURDOMAIN.ir');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).send('Method Not Allowed');
+
+  const ip = req.headers['x-forwarded-for'] || req.socket.remoteAddress || '';
+  if (isRateLimited(ip)) return res.status(429).json({ error: 'Too Many Requests' });
+
+  try {
+    const { prompt, json } = req.body || {};
+    if (!prompt) return res.status(400).json({ error: 'prompt required' });
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) return res.status(500).json({ error: 'missing GEMINI_API_KEY' });
+
+    const model = 'gemini-1.5-flash';
+    const url = `https://generativeai.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: prompt }]}],
+        ...(json ? { generationConfig: { responseMimeType: 'application/json' } } : {})
+      })
+    });
+
+    if (!r.ok) return res.status(r.status).json({ error: await r.text() });
+    const data = await r.json();
+    const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+    return json ? res.status(200).send(text) : res.status(200).json({ text });
+  } catch (e) {
+    return res.status(500).json({ error: e.message });
+  }
+}

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+dashboard.YOURDOMAIN.ir

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>داشبورد پایش آب</title>
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; connect-src 'self' https://YOUR_FUNC_HOST;">
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;700&display=swap" rel="stylesheet">
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>window.API_BASE='https://YOUR_FUNC_HOST';</script>
+</head>
+<body class="font-[Vazirmatn] bg-gray-50 text-gray-800 p-4">
+  <div class="max-w-4xl mx-auto space-y-6">
+    <header class="text-center">
+      <h1 class="text-3xl font-bold mb-2">داشبورد پایش آب</h1>
+      <p class="text-gray-600">نمایش کیفیت آب و ابزارهای تحلیلی</p>
+    </header>
+
+    <section id="cards" class="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div class="bg-white shadow rounded p-4 flex flex-col items-center">
+        <i class="fa-solid fa-droplet text-blue-500 text-3xl mb-2"></i>
+        <h2 class="text-lg font-semibold mb-1">سختی آب</h2>
+        <p id="hardness" class="text-2xl">--</p>
+      </div>
+      <div class="bg-white shadow rounded p-4 flex flex-col items-center">
+        <i class="fa-solid fa-flask text-green-500 text-3xl mb-2"></i>
+        <h2 class="text-lg font-semibold mb-1">PH</h2>
+        <p id="ph" class="text-2xl">--</p>
+      </div>
+      <div class="bg-white shadow rounded p-4 flex flex-col items-center">
+        <i class="fa-solid fa-radiation text-red-500 text-3xl mb-2"></i>
+        <h2 class="text-lg font-semibold mb-1">نیترات</h2>
+        <p id="nitrate" class="text-2xl">--</p>
+      </div>
+    </section>
+
+    <section id="slider" class="bg-white shadow rounded p-4">
+      <h2 class="font-semibold mb-4">شبیه‌سازی کیفیت آب</h2>
+      <input id="qualityRange" type="range" min="0" max="100" class="w-full mb-2">
+      <div class="flex justify-between text-sm"><span>0</span><span>100</span></div>
+      <div id="qualityLabel" class="text-center mt-2"></div>
+    </section>
+
+    <section id="tips" class="bg-white shadow rounded p-4">
+      <h2 class="font-semibold mb-4">نکات نگهداری آب</h2>
+      <textarea id="tipPrompt" class="w-full border p-2 mb-2" rows="3" placeholder="سؤال خود را درباره‌ی نگهداری آب بنویسید..."></textarea>
+      <button id="tipBtn" class="bg-blue-500 text-white px-4 py-2 rounded">ارسال</button>
+      <pre id="tipOutput" class="mt-3 whitespace-pre-wrap"></pre>
+    </section>
+
+    <section id="simulator" class="bg-white shadow rounded p-4">
+      <h2 class="font-semibold mb-4">شبیه‌ساز پاسخ</h2>
+      <textarea id="simPrompt" class="w-full border p-2 mb-2" rows="3" placeholder='دستور JSON مانند: {"city":"تهران"}'></textarea>
+      <button id="simBtn" class="bg-green-600 text-white px-4 py-2 rounded">اجرا</button>
+      <pre id="simOutput" class="mt-3 whitespace-pre-wrap"></pre>
+    </section>
+  </div>
+
+  <div id="errorModal" class="fixed inset-0 bg-black bg-opacity-50 hidden items-center justify-center">
+    <div class="bg-white p-6 rounded shadow max-w-sm w-full">
+      <h3 class="text-lg font-semibold mb-2">خطا</h3>
+      <p id="errorText" class="mb-4"></p>
+      <button id="closeModal" class="bg-red-500 text-white px-4 py-2 rounded">بستن</button>
+    </div>
+  </div>
+
+  <script>
+const apiUrl = (window.API_BASE ?? 'https://YOUR_FUNC_HOST') + '/api/gemini';
+async function callGeminiAPI(prompt, isJson=false){
+  const payload = { prompt, json: !!isJson };
+  const res = await fetch(apiUrl, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+  if(!res.ok) throw new Error(`API error ${res.status}`);
+  if(isJson){ const txt = await res.text(); return JSON.parse(txt); }
+  else { const data = await res.json(); return data.text; }
+}
+
+const range = document.getElementById('qualityRange');
+const label = document.getElementById('qualityLabel');
+const qualities = ['خیلی بد','بد','متوسط','خوب','عالی'];
+range.addEventListener('input', ()=>{
+  const idx = Math.min(qualities.length-1, Math.floor(range.value/20));
+  label.textContent = qualities[idx];
+});
+
+document.getElementById('tipBtn').addEventListener('click', async ()=>{
+  const prompt = document.getElementById('tipPrompt').value.trim();
+  if(!prompt) return;
+  try{
+    const txt = await callGeminiAPI(prompt,false);
+    document.getElementById('tipOutput').textContent = txt;
+  }catch(e){
+    showError(e.message);
+  }
+});
+
+document.getElementById('simBtn').addEventListener('click', async ()=>{
+  const prompt = document.getElementById('simPrompt').value.trim();
+  if(!prompt) return;
+  try{
+    const data = await callGeminiAPI(prompt,true);
+    document.getElementById('simOutput').textContent = JSON.stringify(data,null,2);
+  }catch(e){
+    showError(e.message);
+  }
+});
+
+function showError(msg){
+  document.getElementById('errorText').textContent = msg;
+  document.getElementById('errorModal').classList.remove('hidden');
+  document.getElementById('errorModal').classList.add('flex');
+}
+
+document.getElementById('closeModal').addEventListener('click', ()=>{
+  document.getElementById('errorModal').classList.add('hidden');
+  document.getElementById('errorModal').classList.remove('flex');
+});
+  </script>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,12 @@
+[build]
+  publish = "docs"
+  command = "echo skip-build"
+
+[functions]
+  directory = "netlify/functions"
+  node_bundler = "esbuild"
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
+  status = 200

--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -1,0 +1,69 @@
+const rateMap = new Map();
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const windowMs = 60 * 1000;
+  const limit = 60;
+  const entry = rateMap.get(ip) || { count: 0, start: now };
+  if (now - entry.start > windowMs) {
+    entry.count = 0;
+    entry.start = now;
+  }
+  entry.count += 1;
+  rateMap.set(ip, entry);
+  return entry.count > limit;
+}
+
+export const handler = async (event) => {
+  const allowed = ['https://dashboard.YOURDOMAIN.ir'];
+  const origin = event.headers.origin || '';
+  const hdrs = {
+    'Access-Control-Allow-Origin': allowed.includes(origin) ? origin : 'https://dashboard.YOURDOMAIN.ir',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: hdrs, body: '' };
+  }
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: hdrs, body: 'Method Not Allowed' };
+  }
+
+  const ip = event.headers['x-forwarded-for'] || event.headers['client-ip'] || event.ip || '';
+  if (isRateLimited(ip)) {
+    return { statusCode: 429, headers: hdrs, body: JSON.stringify({ error: 'Too Many Requests' }) };
+  }
+
+  try {
+    const { prompt, json } = JSON.parse(event.body || '{}');
+    if (!prompt) return { statusCode: 400, headers: hdrs, body: JSON.stringify({ error: 'prompt required' }) };
+
+    const apiKey = process.env.GEMINI_API_KEY;
+    if (!apiKey) return { statusCode: 500, headers: hdrs, body: JSON.stringify({ error: 'missing GEMINI_API_KEY' }) };
+
+    const model = 'gemini-1.5-flash';
+    const url = `https://generativeai.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
+
+    const r = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        contents: [{ role: 'user', parts: [{ text: prompt }]}],
+        ...(json ? { generationConfig: { responseMimeType: 'application/json' } } : {})
+      })
+    });
+
+    if (!r.ok) {
+      const t = await r.text();
+      return { statusCode: r.status, headers: hdrs, body: JSON.stringify({ error: t }) };
+    }
+
+    const data = await r.json();
+    const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
+
+    return { statusCode: 200, headers: hdrs, body: json ? text : JSON.stringify({ text }) };
+  } catch (e) {
+    return { statusCode: 500, headers: hdrs, body: JSON.stringify({ error: e.message }) };
+  }
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,6 @@
+{
+  "functions": { "api/*.js": { "runtime": "nodejs20.x" } },
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Serve dashboard from `docs` with CSP, configurable proxy base, and Gemini frontend helpers
- Add Netlify and Vercel serverless proxies with IP rate limiting
- Configure GitHub Pages workflow and deployment docs
- Replace dashboard with full Farsi layout and proxy-based Gemini calls

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e49487608328b819e6ee667f5a23