### PR TITLE
Handle JSON responses consistently

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -125,7 +125,7 @@ async function callGeminiAPI(prompt, isJson=false){
     body: JSON.stringify({ prompt, json: !!isJson })
   });
   if(!res.ok) throw new Error(`API error ${res.status}`);
-  if(isJson){ const txt = await res.text(); return JSON.parse(txt); }
+  if(isJson){ return res.json(); }
   else { const data = await res.json(); return data.text; }
 }
     </script>

--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -20,7 +20,8 @@ export const handler = async (event) => {
   const hdrs = {
     'Access-Control-Allow-Origin': allowed.includes(origin) ? origin : 'https://dashboard.YOURDOMAIN.ir',
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type'
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Content-Type': 'application/json'
   };
 
   if (event.httpMethod === 'OPTIONS') {
@@ -61,8 +62,11 @@ export const handler = async (event) => {
 
     const data = await r.json();
     const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
-
-    return { statusCode: 200, headers: hdrs, body: json ? text : JSON.stringify({ text }) };
+    if (json) {
+      const obj = JSON.parse(text);
+      return { statusCode: 200, headers: hdrs, body: JSON.stringify(obj) };
+    }
+    return { statusCode: 200, headers: hdrs, body: JSON.stringify({ text }) };
   } catch (e) {
     return { statusCode: 500, headers: hdrs, body: JSON.stringify({ error: e.message }) };
   }


### PR DESCRIPTION
## Summary
- Parse Gemini JSON responses and stringify before returning
- Ensure all Netlify function replies include `Content-Type: application/json`
- Use `res.json()` directly in docs `callGeminiAPI`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af42c3a588328a5a2c3262b7af435