### PR TITLE
feat: clarify Gemini API errors

### DIFF
--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -49,7 +49,13 @@ export const handler = async (event) => {
     if (!prompt) return { statusCode: 400, headers: hdrs, body: JSON.stringify({ error: 'prompt required' }) };
 
     const apiKey = process.env.GEMINI_API_KEY;
-    if (!apiKey) return { statusCode: 500, headers: hdrs, body: JSON.stringify({ error: 'missing GEMINI_API_KEY' }) };
+    if (!apiKey) {
+      return {
+        statusCode: 500,
+        headers: hdrs,
+        body: JSON.stringify({ error: 'GEMINI_API_KEY not set' })
+      };
+    }
 
     const model = 'gemini-1.5-flash';
     const url = `https://generativeai.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
@@ -63,9 +69,21 @@ export const handler = async (event) => {
       })
     });
 
+    if (r.status === 401) {
+      return {
+        statusCode: 401,
+        headers: hdrs,
+        body: JSON.stringify({ error: 'invalid GEMINI_API_KEY' })
+      };
+    }
+
     if (!r.ok) {
       const t = await r.text();
-      return { statusCode: r.status, headers: hdrs, body: JSON.stringify({ error: t }) };
+      return {
+        statusCode: r.status,
+        headers: hdrs,
+        body: JSON.stringify({ error: t })
+      };
     }
 
     const data = await r.json();


### PR DESCRIPTION
## Summary
- refine Gemini proxy to report missing API key with 500
- return 401 for invalid GEMINI_API_KEY

## Testing
- `npx netlify env:list`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af517e4c8832894078ac9ab725263