### PR TITLE
Fix real-time slider value displays in simulator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -129,5 +129,35 @@ async function callGeminiAPI(prompt, isJson=false){
   else { const data = await res.json(); return data.text; }
 }
     </script>
+    <script>
+(function(){
+  function initSimulatorUI(){
+    const cs = document.getElementById('consumption-slider');
+    const rs = document.getElementById('rainfall-slider');
+    const cv = document.getElementById('consumption-value');
+    const rv = document.getElementById('rainfall-value');
+    if(!cs || !rs || !cv || !rv) return; // DOM not ready or ids wrong
+
+    const sync = () => {
+      if (cv && cs) cv.textContent = String(cs.value);
+      if (rv && rs) rv.textContent = String(rs.value);
+    };
+
+    ['input','change'].forEach(evt => {
+      cs.addEventListener(evt, sync, { passive: true });
+      rs.addEventListener(evt, sync, { passive: true });
+    });
+
+    // مقدار اولیه
+    sync();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initSimulatorUI, { once:true });
+  } else {
+    initSimulatorUI();
+  }
+})();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the consumption and rainfall sliders keep their numeric displays in sync on `input` and `change` events
- initialize slider display values after DOM ready so UI always reflects current ranges

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689af7b73b7883289e29485fe5a5de49