### PR TITLE
Switch to dynamic API_BASE + tighten CORS (Vary: Origin), CSP connect-src 'self'

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,10 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>داشبورد وضعیت آب مشهد (مجهز به Gemini)</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com data:; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdnjs.cloudflare.com; connect-src 'self' https://689a0a959fa2471e109de0c8--polite-zuccutto-cdf931.netlify.app https://polite-zuccutto-cdf931.netlify.app; form-action 'self'; frame-ancestors 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdnjs.cloudflare.com; connect-src 'self'; frame-ancestors 'self'; form-action 'self';">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-    <script>window.API_BASE=window.location.origin;</script>
+    <script>
+      window.API_BASE = window.location.origin;
+    </script>
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700;800&display=swap');
         body { font-family: 'Vazirmatn', sans-serif; background-color: #f0f4f8; }
@@ -119,14 +121,13 @@
     <div id="error-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4"><div class="bg-white p-6 rounded-lg shadow-lg max-w-sm mx-auto text-center"><div class="text-red-500 mb-4"><i class="fas fa-exclamation-circle fa-3x"></i></div><h3 class="text-lg font-bold text-red-600 mb-2">خطا در ارتباط با سرور</h3><p id="error-message" class="text-slate-700">متاسفانه مشکلی در دریافت اطلاعات پیش آمد. لطفا دوباره تلاش کنید.</p><button id="close-modal-btn" class="mt-6 bg-red-500 text-white px-6 py-2 rounded-lg hover:bg-red-600 transition">بستن</button></div></div>
     <script>
 async function callGeminiAPI(prompt, isJson=false){
-  const apiUrl = (window.API_BASE ?? '') + '/api/gemini';
-  const res = await fetch(apiUrl, {
-    method:'POST', headers:{'Content-Type':'application/json'},
+  const res = await fetch(`${window.API_BASE}/api/gemini`, {
+    method:'POST',
+    headers:{'Content-Type':'application/json'},
     body: JSON.stringify({ prompt, json: !!isJson })
   });
   if(!res.ok) throw new Error(`API error ${res.status}`);
-  if(isJson){ return res.json(); }
-  else { const data = await res.json(); return data.text; }
+  return isJson ? await res.json() : (await res.json()).text;
 }
     </script>
     <script>

--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -14,41 +14,50 @@ function isRateLimited(ip) {
   return entry.count > limit;
 }
 
-export const handler = async (event) => {
-  const allowlist = [
-    'https://689a0a959fa2471e109de0c8--polite-zuccutto-cdf931.netlify.app',
-    'https://polite-zuccutto-cdf931.netlify.app',
-    process.env.ALLOWED_ORIGIN
-  ].filter(Boolean);
-  const origin = event.headers.origin || '';
-  const allowOrigin = allowlist.includes(origin) ? origin : allowlist[1] || origin;
+const allowlist = [
+  'https://wesh360.ir',
+  process.env.PREVIEW_ORIGIN, // اگر پریویو لازم است، در نتلیفای ست شود
+].filter(Boolean);
 
-  const headers = {
-    'Access-Control-Allow-Origin': allowOrigin,
-    'Access-Control-Allow-Methods': 'POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
+export const handler = async (event) => {
+  const origin = (event.headers && (event.headers.origin || event.headers.Origin)) || '';
+  const allowed = allowlist.includes(origin);
+
+  const baseHeaders = {
     'Vary': 'Origin',
-    'Content-Type': 'application/json'
+    'Access-Control-Allow-Methods': 'POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400'
   };
+  const corsHeaders = allowed ? { ...baseHeaders, 'Access-Control-Allow-Origin': origin } : baseHeaders;
 
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 204, headers, body: '' };
+    return { statusCode: 204, headers: corsHeaders };
   }
+
+  if (!allowed) {
+    return {
+      statusCode: 403,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Origin not allowed' })
+    };
+  }
+
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ error: 'Method Not Allowed' }) };
+    return { statusCode: 405, headers: { ...corsHeaders, 'Content-Type': 'application/json' }, body: JSON.stringify({ error: 'Method Not Allowed' }) };
   }
 
   const ip = event.headers['x-forwarded-for'] || event.headers['client-ip'] || event.ip || '';
   if (isRateLimited(ip)) {
-    return { statusCode: 429, headers, body: JSON.stringify({ error: 'Too Many Requests' }) };
+    return { statusCode: 429, headers: { ...corsHeaders, 'Content-Type': 'application/json' }, body: JSON.stringify({ error: 'Too Many Requests' }) };
   }
 
   try {
     const { prompt, json } = JSON.parse(event.body || '{}');
-    if (!prompt) return { statusCode: 400, headers, body: JSON.stringify({ error: 'Missing prompt' }) };
+    if (!prompt) return { statusCode: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' }, body: JSON.stringify({ error: 'Missing prompt' }) };
 
     const key = process.env.GEMINI_API_KEY;
-    if (!key) return { statusCode: 500, headers, body: JSON.stringify({ error: 'Server misconfig: GEMINI_API_KEY' }) };
+    if (!key) return { statusCode: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' }, body: JSON.stringify({ error: 'Server misconfig: GEMINI_API_KEY' }) };
 
     const url = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-preview-05-20:generateContent?key=' + encodeURIComponent(key);
     const payload = { contents: [{ parts: [{ text: prompt }] }], ...(json ? { generationConfig: { responseMimeType: 'application/json' } } : {}) };
@@ -57,13 +66,13 @@ export const handler = async (event) => {
     const data = await r.json().catch(() => ({}));
 
     if (!r.ok) {
-      return { statusCode: 502, headers, body: JSON.stringify({ error: 'Upstream error', status: r.status, details: data?.error || data }) };
+      return { statusCode: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' }, body: JSON.stringify({ error: 'Upstream error', status: r.status, details: data?.error || data }) };
     }
 
     const text = data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
     const body = json ? JSON.stringify(JSON.parse(text || '{}')) : JSON.stringify({ text });
-    return { statusCode: 200, headers, body };
+    return { statusCode: 200, headers: { ...corsHeaders, 'Content-Type': 'application/json' }, body };
   } catch (e) {
-    return { statusCode: 500, headers, body: JSON.stringify({ error: 'Unhandled', message: String(e?.message || e) }) };
+    return { statusCode: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' }, body: JSON.stringify({ error: 'Unhandled', message: String(e?.message || e) }) };
   }
 };


### PR DESCRIPTION
## Summary
- drop hardcoded API_BASE and use window origin with relative `/api/gemini`, tightening CSP to `connect-src 'self'`
- restrict Netlify function CORS to allowlisted origins with `Vary: Origin` and 403 for unauthorized requests

## Testing
- `curl -i -X OPTIONS https://wesh360.ir/api/gemini -H "Origin: https://wesh360.ir" -H "Access-Control-Request-Method: POST"` (204, CORS headers)
- `curl -i -X POST https://wesh360.ir/api/gemini -H "Origin: https://wesh360.ir" -H "Content-Type: application/json" --data '{"prompt":"ping"}'` (200, JSON)

## Checklist
- [x] curl pass
- [x] UI OK
- [ ] Console clean


------
https://chatgpt.com/codex/tasks/task_e_689b0493cd6083289007c80d1041c181