### PR TITLE
UI: flatten nested cards; add `.card` and `.callout`; prevent nested shadows

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -14,8 +14,30 @@
         @import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700;800&display=swap');
         body { font-family: 'Vazirmatn', sans-serif; background-color: #f0f4f8; }
         .main-title { font-weight: 800; color: #1e3a8a; }
-        .card { background-color: white; border-radius: 1.5rem; padding: 2rem; box-shadow: 0 10px 15px -3px rgba(0,0,0,.05), 0 4px 6px -2px rgba(0,0,0,.05); transition: transform .3s ease, box-shadow .3s ease; }
-        .card:hover { transform: translateY(-5px); box-shadow: 0 20px 25px -5px rgba(0,0,0,.1), 0 10px 10px -5px rgba(0,0,0,.04); }
+        /* --- Cards --- */
+        .card {
+            background: #fff;
+            border-radius: 18px;
+            box-shadow: 0 12px 28px rgba(0,0,0,.06);
+            padding: 24px;
+        }
+        /* جلوگیری از کادر تو در تو */
+        .card .card {
+            background: transparent !important;
+            box-shadow: none !important;
+            border: 0 !important;
+            border-radius: 0 !important;
+            padding: 0 !important;
+        }
+
+        /* --- Callout (جعبه‌ی راهنما) --- */
+        .callout {
+            background: #eef6ff;
+            border: 1px solid #dbeafe;
+            border-radius: 14px;
+            padding: 16px;
+            box-shadow: none;
+        }
         .water-drop-container { position: relative; width: 100px; height: 100px; margin: 0 auto; }
         .water-drop-background { position: absolute; bottom: 0; left: 0; right: 0; background-color: #3b82f6; border-radius: 0 0 50px 50px; transition: height 1s ease-out; }
         .water-drop-icon { position: absolute; top: 0; left: 0; width: 100%; height: 100%; -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat; -webkit-mask-position: center; mask-position: center; background-color: #e0e0e0; }
@@ -109,9 +131,9 @@
                 <div id="tips-result-container" class="mt-8 hidden"><div id="tips-loader" class="text-center"><i class="fas fa-spinner fa-spin fa-3x text-blue-500"></i><p class="mt-2 text-slate-600">در حال آماده‌سازی راهکارهای هوشمند...</p></div><div id="tips-result" class="p-6 bg-white rounded-lg shadow-inner prose prose-vazir max-w-none"></div></div>
             </div>
         </section>
-        <section class="grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+        <section class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
             <div class="card"><h2 class="text-2xl font-bold text-slate-800 text-center mb-6">آب ما کجا مصرف می‌شود؟</h2><div class="space-y-5"><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-leaf fa-2x text-green-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">کشاورزی</span><span class="text-sm font-bold text-green-600">57%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-green-500 h-4 rounded-full" style="width: 57%"></div></div></div></div><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-home fa-2x text-cyan-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">شرب و بهداشت</span><span class="text-sm font-bold text-cyan-600">31%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-cyan-500 h-4 rounded-full" style="width: 31%"></div></div></div></div><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-building fa-2x text-purple-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">خدمات</span><span class="text-sm font-bold text-purple-600">7%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-purple-500 h-4 rounded-full" style="width: 7%"></div></div></div></div><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-industry fa-2x text-slate-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">صنعت</span><span class="text-sm font-bold text-slate-600">3%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-slate-500 h-4 rounded-full" style="width: 3%"></div></div></div></div></div>
-            <div class="card bg-blue-50 border-2 border-blue-200 mt-6 lg:mt-0 lg:order-2 lg:ml-6 lg:translate-x-[-8px] lg:justify-self-start"><h2 class="text-2xl font-bold text-blue-800 text-center mb-6">چگونه می‌توانیم کمک کنیم؟</h2><ul class="space-y-4 text-slate-700"><li class="flex items-start"><i class="fas fa-faucet-drip fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>شیرهای آب چکه کن را تعمیر کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-shower fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>زمان حمام را کوتاه کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-car fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>برای شستن ماشین از سطل آب استفاده کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-tooth fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>هنگام مسواک زدن شیر آب را ببندیم.</strong> ...</span></li></ul></div>
+            <div class="callout mt-6 lg:mt-0 lg:order-2 lg:ml-6 lg:translate-x-[-8px] lg:justify-self-start"><h2 class="text-2xl font-bold text-blue-800 text-center mb-6">چگونه می‌توانیم کمک کنیم؟</h2><ul class="space-y-4 text-slate-700"><li class="flex items-start"><i class="fas fa-faucet-drip fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>شیرهای آب چکه کن را تعمیر کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-shower fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>زمان حمام را کوتاه کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-car fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>برای شستن ماشین از سطل آب استفاده کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-tooth fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>هنگام مسواک زدن شیر آب را ببندیم.</strong> ...</span></li></ul></div>
         </section>
         <footer class="text-center mt-12 text-slate-500 text-sm">
             <p>این داشبورد بر اساس داده‌های «آمارنامه آب مشهد مقدس - شماره ۱۷۰» ...</p>


### PR DESCRIPTION
## Summary
- refine global `.card` styling and add nested card reset
- introduce `.callout` style for light advisory boxes
- replace inner card with `.callout` in consumption section and adjust grid spacing

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0aa7a4588328a475549a5909c2e5