### PR TITLE
Move CSP to Netlify headers (prod/preview); remove meta-CSP

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,14 @@ Gemini API calls are routed through a serverless function so the API key is kept
 - Files under `netlify/` contain a function at `/api/gemini`.
 - Set the `GEMINI_API_KEY` environment variable in Netlify.
 - Deploy the repo and the site will serve from `docs`.
+- Content-Security-Policy headers are configured in `netlify.toml` rather than HTML meta tags; production blocks all framing while Deploy Previews allow Netlify embeds to avoid console errors.
 
 ### Vercel
 - Files under `api/` with `vercel.json` implement the same endpoint.
 - Add `GEMINI_API_KEY` in Project Settings on Vercel.
 
 Set `window.API_BASE` in `docs/index.html` to the deployed function host so the frontend knows where to send requests.
+
+## Backlog
+
+- Migrate from `cdn.tailwindcss.com` to CSS compiled with Tailwind CLI at build time.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>داشبورد وضعیت آب مشهد (مجهز به Gemini)</title>
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com https://cdnjs.cloudflare.com; font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; script-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://cdnjs.cloudflare.com; connect-src 'self'; frame-ancestors 'self'; form-action 'self';">
+    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%231f7aff'/%3E%3Cpath d='M20 36c8 4 16-4 24 0' stroke='white' stroke-width='4' fill='none'/%3E%3C/svg%3E" />
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
     <script>

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,3 +10,46 @@
 from = "/api/*"
 to = "/.netlify/functions/:splat"
 status = 200
+
+# هدرهای عمومی
+[[headers]]
+  for = "/*"
+  [headers.values]
+    Referrer-Policy = "strict-origin-when-cross-origin"
+    X-Content-Type-Options = "nosniff"
+
+# Production: فریم‌گذاری بسته و CSP سفت
+[[context.production.headers]]
+  for = "/*"
+  [context.production.headers.values]
+    Content-Security-Policy = """
+      default-src 'self';
+      base-uri 'self';
+      object-src 'none';
+      img-src 'self' data: blob:;
+      style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com;
+      font-src 'self' https://fonts.gstatic.com;
+      script-src 'self' https://cdn.tailwindcss.com https://cdnjs.cloudflare.com;
+      connect-src 'self';
+      frame-src 'self';
+      frame-ancestors 'none';
+      form-action 'self'
+    """
+
+# Deploy Preview: اجازه‌ی embed شدن در Netlify برای حذف ارورهای کنسول
+[[context.deploy-preview.headers]]
+  for = "/*"
+  [context.deploy-preview.headers.values]
+    Content-Security-Policy = """
+      default-src 'self';
+      base-uri 'self';
+      object-src 'none';
+      img-src 'self' data: blob:;
+      style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com https://fonts.googleapis.com;
+      font-src 'self' https://fonts.gstatic.com;
+      script-src 'self' https://cdn.tailwindcss.com https://cdnjs.cloudflare.com;
+      connect-src 'self';
+      frame-src 'self' https://app.netlify.com;
+      frame-ancestors 'self' https://app.netlify.com;
+      form-action 'self'
+    """


### PR DESCRIPTION
## Summary
- remove meta-based Content-Security-Policy and inline an SVG favicon to silence console 404s
- configure CSP via Netlify headers with a stricter production policy and a preview policy that allows Netlify embeds
- document CSP header management and Tailwind CLI migration task

## Testing
- `curl -s -I https://wesh360.ir | grep -i "content-security-policy"`
- `curl -s -I https://deploy-preview-1--example.netlify.app | grep -i "content-security-policy"`
- `curl -s https://wesh360.ir/index.html | grep -i "content-security-policy"`
- `curl -I https://wesh360.ir/favicon.ico`
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0ccc6ab083288d94ac8ffe99f71b