### PR TITLE
UI: fix nested card layout; separate water stats and tips cards into side-by-side layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -15,28 +15,24 @@
         body { font-family: 'Vazirmatn', sans-serif; background-color: #f0f4f8; }
         .main-title { font-weight: 800; color: #1e3a8a; }
         /* --- Cards --- */
+        .card-row {
+            display: flex;
+            gap: 1.5rem;
+            flex-wrap: wrap;
+        }
         .card {
             background: #fff;
             border-radius: 18px;
-            box-shadow: 0 12px 28px rgba(0,0,0,.06);
-            padding: 24px;
-        }
-        /* جلوگیری از کادر تو در تو */
-        .card .card {
-            background: transparent !important;
-            box-shadow: none !important;
-            border: 0 !important;
-            border-radius: 0 !important;
-            padding: 0 !important;
+            box-shadow: 0 8px 20px rgba(0,0,0,.05);
+            padding: 1.5rem;
+            flex: 1;
+            min-width: 280px;
         }
 
-        /* --- Callout (جعبه‌ی راهنما) --- */
-        .callout {
-            background: #eef6ff;
-            border: 1px solid #dbeafe;
-            border-radius: 14px;
-            padding: 16px;
-            box-shadow: none;
+        @media (max-width: 768px) {
+            .card-row {
+                flex-direction: column;
+            }
         }
         .water-drop-container { position: relative; width: 100px; height: 100px; margin: 0 auto; }
         .water-drop-background { position: absolute; bottom: 0; left: 0; right: 0; background-color: #3b82f6; border-radius: 0 0 50px 50px; transition: height 1s ease-out; }
@@ -131,9 +127,51 @@
                 <div id="tips-result-container" class="mt-8 hidden"><div id="tips-loader" class="text-center"><i class="fas fa-spinner fa-spin fa-3x text-blue-500"></i><p class="mt-2 text-slate-600">در حال آماده‌سازی راهکارهای هوشمند...</p></div><div id="tips-result" class="p-6 bg-white rounded-lg shadow-inner prose prose-vazir max-w-none"></div></div>
             </div>
         </section>
-        <section class="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
-            <div class="card"><h2 class="text-2xl font-bold text-slate-800 text-center mb-6">آب ما کجا مصرف می‌شود؟</h2><div class="space-y-5"><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-leaf fa-2x text-green-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">کشاورزی</span><span class="text-sm font-bold text-green-600">57%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-green-500 h-4 rounded-full" style="width: 57%"></div></div></div></div><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-home fa-2x text-cyan-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">شرب و بهداشت</span><span class="text-sm font-bold text-cyan-600">31%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-cyan-500 h-4 rounded-full" style="width: 31%"></div></div></div></div><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-building fa-2x text-purple-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">خدمات</span><span class="text-sm font-bold text-purple-600">7%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-purple-500 h-4 rounded-full" style="width: 7%"></div></div></div></div><div class="flex items-center"><div class="w-16 text-center"><i class="fas fa-industry fa-2x text-slate-500"></i></div><div class="flex-1 mx-4"><div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">صنعت</span><span class="text-sm font-bold text-slate-600">3%</span></div><div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-slate-500 h-4 rounded-full" style="width: 3%"></div></div></div></div></div>
-            <div class="callout mt-6 lg:mt-0 lg:order-1 lg:mr-6 lg:justify-self-end"><h2 class="text-2xl font-bold text-blue-800 text-center mb-6">چگونه می‌توانیم کمک کنیم؟</h2><ul class="space-y-4 text-slate-700"><li class="flex items-start"><i class="fas fa-faucet-drip fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>شیرهای آب چکه کن را تعمیر کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-shower fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>زمان حمام را کوتاه کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-car fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>برای شستن ماشین از سطل آب استفاده کنیم.</strong> ...</span></li><li class="flex items-start"><i class="fas fa-tooth fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>هنگام مسواک زدن شیر آب را ببندیم.</strong> ...</span></li></ul></div>
+        <section class="mb-12">
+            <div class="card-row">
+                <div class="card stats-card">
+                    <h2 class="text-2xl font-bold text-slate-800 text-center mb-6">آب ما کجا مصرف می‌شود؟</h2>
+                    <div class="space-y-5">
+                        <div class="flex items-center">
+                            <div class="w-16 text-center"><i class="fas fa-leaf fa-2x text-green-500"></i></div>
+                            <div class="flex-1 mx-4">
+                                <div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">کشاورزی</span><span class="text-sm font-bold text-green-600">57%</span></div>
+                                <div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-green-500 h-4 rounded-full" style="width: 57%"></div></div>
+                            </div>
+                        </div>
+                        <div class="flex items-center">
+                            <div class="w-16 text-center"><i class="fas fa-home fa-2x text-cyan-500"></i></div>
+                            <div class="flex-1 mx-4">
+                                <div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">شرب و بهداشت</span><span class="text-sm font-bold text-cyan-600">31%</span></div>
+                                <div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-cyan-500 h-4 rounded-full" style="width: 31%"></div></div>
+                            </div>
+                        </div>
+                        <div class="flex items-center">
+                            <div class="w-16 text-center"><i class="fas fa-building fa-2x text-purple-500"></i></div>
+                            <div class="flex-1 mx-4">
+                                <div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">خدمات</span><span class="text-sm font-bold text-purple-600">7%</span></div>
+                                <div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-purple-500 h-4 rounded-full" style="width: 7%"></div></div>
+                            </div>
+                        </div>
+                        <div class="flex items-center">
+                            <div class="w-16 text-center"><i class="fas fa-industry fa-2x text-slate-500"></i></div>
+                            <div class="flex-1 mx-4">
+                                <div class="flex justify-between mb-1"><span class="text-base font-semibold text-slate-700">صنعت</span><span class="text-sm font-bold text-slate-600">3%</span></div>
+                                <div class="w-full bg-gray-200 rounded-full h-4"><div class="bg-slate-500 h-4 rounded-full" style="width: 3%"></div></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="card tips-card">
+                    <h2 class="text-2xl font-bold text-blue-800 text-center mb-6">چگونه می‌توانیم کمک کنیم؟</h2>
+                    <ul class="space-y-4 text-slate-700">
+                        <li class="flex items-start"><i class="fas fa-faucet-drip fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>شیرهای آب چکه کن را تعمیر کنیم.</strong> ...</span></li>
+                        <li class="flex items-start"><i class="fas fa-shower fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>زمان حمام را کوتاه کنیم.</strong> ...</span></li>
+                        <li class="flex items-start"><i class="fas fa-car fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>برای شستن ماشین از سطل آب استفاده کنیم.</strong> ...</span></li>
+                        <li class="flex items-start"><i class="fas fa-tooth fa-lg text-blue-500 mt-1 ml-4"></i><span><strong>هنگام مسواک زدن شیر آب را ببندیم.</strong> ...</span></li>
+                    </ul>
+                </div>
+            </div>
         </section>
         <footer class="text-center mt-12 text-slate-500 text-sm">
             <p>این داشبورد بر اساس داده‌های «آمارنامه آب مشهد مقدس - شماره ۱۷۰» ...</p>


### PR DESCRIPTION
## Summary
- Refactor water stats and tips sections into separate `.card` elements within a new flex-based `.card-row` container.
- Simplify card styling and drop nested card/callout rules to prevent duplicate shadows.
- Ensure mobile layout stacks cards vertically via responsive CSS.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2f4011888328a8db61cea2405020