### PR TITLE
security: move Gemini key to header; add IP rate limiting; minimal prod output; docs & tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,23 @@ GitHub Pages is configured to deploy the `docs` directory. To use a custom subdo
 
 Gemini API calls are routed through a serverless function so the API key is kept server side.
 
-### Netlify
-- Files under `netlify/` contain a function at `/api/gemini`.
-- Set the `GEMINI_API_KEY` environment variable in Netlify.
-- Deploy the repo and the site will serve from `docs`.
-- Content-Security-Policy headers are configured in `netlify.toml` rather than HTML meta tags; production blocks all framing while Deploy Previews allow Netlify embeds to avoid console errors.
+### Netlify (Serverless Function)
+- The frontend calls the relative endpoint `/api/gemini`.
+- Set `GEMINI_API_KEY` (and optional `PREVIEW_ORIGIN`) in Netlify Environment Variables.
+- CSP headers are configured in `netlify.toml`; `connect-src 'self'` is sufficient.
 
-The frontend assumes the function lives on the same origin and calls `/api/gemini` accordingly.
+**Post-deploy tests**
+```bash
+curl -i -X OPTIONS https://wesh360.ir/api/gemini \
+  -H "Origin: https://wesh360.ir" \
+  -H "Access-Control-Request-Method: POST"
+
+curl -i -X POST https://wesh360.ir/api/gemini \
+  -H "Origin: https://wesh360.ir" \
+  -H "Content-Type: application/json" \
+  --data '{"q":"ping"}'
+Expected: 204 for OPTIONS, 200 for POST, and no query ?key= in downstream calls.
+```
 
 ## Backlog
 

--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -1,74 +1,120 @@
+// netlify/functions/gemini.js
+
+const RATE_LIMIT_WINDOW_MS = 60_000; // 1min
+const RATE_LIMIT_MAX = 30;
+const rateMap = new Map();
+
+function getClientIp(event) {
+  const xfwd = event.headers['x-forwarded-for'] || event.headers['X-Forwarded-For'] || '';
+  const ip = (xfwd.split(',')[0] || '').trim() || event.headers['client-ip'] || '';
+  return ip || 'unknown';
+}
+
+function isRateLimited(ip) {
+  const now = Date.now();
+  const entry = rateMap.get(ip) || { count: 0, start: now };
+  if (now - entry.start > RATE_LIMIT_WINDOW_MS) {
+    entry.count = 0; entry.start = now;
+  }
+  entry.count += 1;
+  rateMap.set(ip, entry);
+  return entry.count > RATE_LIMIT_MAX;
+}
+
+const allowlist = [
+  'https://wesh360.ir',
+  process.env.PREVIEW_ORIGIN,
+].filter(Boolean);
+
 export const handler = async (event) => {
   const origin = event.headers.origin || event.headers.Origin || '';
-  const allowlist = ['https://wesh360.ir', process.env.PREVIEW_ORIGIN].filter(Boolean);
   const allowed = allowlist.includes(origin);
 
-  const base = {
+  const baseHeaders = {
     'Vary': 'Origin',
     'Access-Control-Allow-Methods': 'POST,OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type',
     'Access-Control-Max-Age': '86400',
   };
-  const headers = allowed ? { ...base, 'Access-Control-Allow-Origin': origin } : base;
+  const headers = allowed ? { ...baseHeaders, 'Access-Control-Allow-Origin': origin } : baseHeaders;
 
-  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers };
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers };
+  }
 
   if (!allowed) {
     return {
       statusCode: 403,
       headers: { ...headers, 'Content-Type': 'application/json' },
-      body: JSON.stringify({ error: 'Origin not allowed' })
+      body: JSON.stringify({ error: 'Origin not allowed' }),
     };
   }
 
-  const respond = (code, body) =>
-    ({ statusCode: code, headers: { ...headers, 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+  const ip = getClientIp(event);
+  if (isRateLimited(ip)) {
+    return {
+      statusCode: 429,
+      headers: { ...headers, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ error: 'Too Many Requests' }),
+    };
+  }
+
+  const respond = (code, body) => ({
+    statusCode: code,
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
 
   try {
-    const { q, model = 'gemini-2.0-flash', temperature = 0.8, system } = JSON.parse(event.body || '{}');
-    if (!q) return respond(400, { error: 'Missing prompt "q"' });
+    const { q: prompt, model = 'gemini-2.0-flash', temperature = 0.8, system } = JSON.parse(event.body || '{}');
+    if (!prompt) return respond(400, { error: 'Missing prompt "q"' });
 
     const API_KEY = process.env.GEMINI_API_KEY;
-    const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${API_KEY}`;
+    if (!API_KEY) return respond(500, { error: 'GEMINI_API_KEY not set' });
+
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent`;
 
     const payload = {
       contents: [
         ...(system ? [{ role: 'user', parts: [{ text: system }] }] : []),
-        { role: 'user', parts: [{ text: q }] }
+        { role: 'user', parts: [{ text: prompt }] }
       ],
       generationConfig: { temperature }
     };
 
+    // fetch with timeout
     const fetchWithTimeout = (resource, options = {}) => {
       const { timeout = 12000 } = options;
       return Promise.race([
         fetch(resource, options),
-        new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), timeout))
+        new Promise((_, rej) => setTimeout(() => rej(new Error('timeout')), timeout)),
       ]);
     };
 
-    let attempts = 0, resp, errText;
-    while (attempts < 3) {
-      attempts++;
+    // basic retry for 429/5xx
+    let resp;
+    for (let attempt = 0; attempt < 3; attempt++) {
       try {
         resp = await fetchWithTimeout(url, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            'X-goog-api-key': API_KEY, // ← ارسال کلید در هدر
+          },
           body: JSON.stringify(payload),
-          timeout: 12000
+          timeout: 12000,
         });
-        if (resp.ok) break;
-        if (![429, 500, 502, 503, 504].includes(resp.status)) break;
-        await new Promise(r => setTimeout(r, 500 * Math.pow(2, attempts - 1)));
+        if (resp.ok || ![429, 500, 502, 503, 504].includes(resp.status)) break;
+        await new Promise(r => setTimeout(r, 500 * 2 ** attempt));
       } catch (e) {
-        if (attempts >= 3) throw e;
-        await new Promise(r => setTimeout(r, 500 * Math.pow(2, attempts - 1)));
+        if (attempt === 2) throw e;
+        await new Promise(r => setTimeout(r, 500 * 2 ** attempt));
       }
     }
 
     if (!resp || !resp.ok) {
-      errText = resp ? await resp.text() : 'no response';
-      return respond(resp?.status || 502, { error: 'Gemini error', detail: errText });
+      const detail = resp ? await resp.text() : 'no response';
+      return respond(resp?.status || 502, { error: 'Gemini error', detail });
     }
 
     const data = await resp.json();
@@ -76,7 +122,13 @@ export const handler = async (event) => {
       data?.candidates?.[0]?.content?.parts?.map(p => p.text).join('') ??
       data?.candidates?.[0]?.content?.parts?.[0]?.text ?? '';
 
+    // production: فقط متن
+    if (process.env.NODE_ENV === 'production') {
+      return respond(200, { text });
+    }
+    // غیرپرود: متن + خام برای دیباگ
     return respond(200, { text, raw: data });
+
   } catch (e) {
     return respond(500, { error: 'Server error', detail: String(e) });
   }


### PR DESCRIPTION
## Summary
- send Gemini API key via `X-goog-api-key` header and add IP-based rate limiting
- return minimal `{text}` response in production, include full payload only in non-prod
- document Netlify endpoint usage and post-deploy curl tests

## Testing
- `node --input-type=module - <<'NODE' ...` *(imports handler, stubs fetch; got `200 CORS ok`)*
- `curl -i -X OPTIONS https://wesh360.ir/api/gemini -H "Origin: https://wesh360.ir" -H "Access-Control-Request-Method: POST"`
- `curl -i -X POST https://wesh360.ir/api/gemini -H "Origin: https://wesh360.ir" -H "Content-Type: application/json" --data '{"q":"ping"}'`


------
https://chatgpt.com/codex/tasks/task_e_689b389a3b088328b293c32807a4107b