### PR TITLE
Add dedicated Gemini API redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -7,6 +7,11 @@
   node_bundler = "esbuild"
 
 [[redirects]]
+from = "/api/gemini"
+to   = "/.netlify/functions/gemini"
+status = 200
+
+[[redirects]]
 from = "/api/*"
 to = "/.netlify/functions/:splat"
 status = 200


### PR DESCRIPTION
## Summary
- add high-priority redirect for `/api/gemini` to the Gemini serverless function

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4894f77c8328bb392e43f0c3453d