### PR TITLE
Respect configurable API base

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,9 +8,9 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
     <script>
-      window.API_BASE = window.location.origin;
+      window.API_BASE = window.API_BASE || window.location.origin;
       async function askGemini(prompt, opts={}) {
-        const res = await fetch('/api/gemini', {
+        const res = await fetch(`${window.API_BASE || window.location.origin}/api/gemini`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ q: prompt, ...opts })


### PR DESCRIPTION
## Summary
- Allow overriding API base in docs `askGemini` function
- Request Gemini endpoint relative to optional `window.API_BASE`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b4d9098b08328865e46c2e137297f