### PR TITLE
Include Referer header in Gemini proxy

### DIFF
--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -100,6 +100,7 @@ export const handler = async (event) => {
           headers: {
             'Content-Type': 'application/json',
             'X-goog-api-key': API_KEY, // ← ارسال کلید در هدر
+            'Referer': 'https://wesh360.ir',
           },
           body: JSON.stringify(payload),
           timeout: 12000,


### PR DESCRIPTION
## Summary
- add `Referer` header to server-side Gemini API request to satisfy API key restrictions

## Testing
- `curl -i -X OPTIONS https://wesh360.ir/api/gemini -H "Origin: https://wesh360.ir" -H "Access-Control-Request-Method: POST`
- `curl -i -X POST https://wesh360.ir/api/gemini -H "Origin: https://wesh360.ir" -H "Content-Type: application/json" --data '{"q":"ping"}'`
- `netlify deploy --prod --dir=docs --functions=netlify/functions` *(fails: Unable to open browser automatically: Running inside a docker container)*

------
https://chatgpt.com/codex/tasks/task_e_689b55e9675083288e83d0a633ddc662