### PR TITLE
Strip code block markers before JSON parse in wireFootprint

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -317,8 +317,18 @@ All numbers must be numeric (no units attached in JSON).
 `;
 
         const text = await askGemini(`${basePrompt}\nFood list: ${foods}`, { model: 'gemini-2.0-flash' });
+        console.log("Raw API response:", text);
+        const clean = text.replace(/```json|```/g, '').trim();
 
-        let data; try { data = JSON.parse(text); } catch(_) { clearSkeleton(); out.textContent = '⚠️ پاسخ نامعتبر.'; return; }
+        let data;
+        try {
+          data = JSON.parse(clean);
+        } catch (e) {
+          clearSkeleton();
+          out.textContent = '⚠️ پاسخ نامعتبر.';
+          console.error('Invalid JSON', e);
+          return;
+        }
         if (
           typeof data.total_liters !== 'number' ||
           !Array.isArray(data.details) ||


### PR DESCRIPTION
## Summary
- Sanitize Gemini responses in `wireFootprint` by logging raw text, stripping Markdown code fences, and parsing safely with error handling.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c082ae3208328bb68a9a4a74aa551