### PR TITLE
Log invalid JSON in footprint calculator

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -350,8 +350,8 @@ All numbers must be numeric (no units attached in JSON).
           data = JSON.parse(clean);
         } catch (e) {
           clearSkeleton();
-          out.textContent = '⚠️ پاسخ نامعتبر.';
-          console.error('Invalid JSON', e);
+          out.textContent = '⚠️ پاسخ نامعتبر';
+          console.error("Invalid JSON:", text);
           return;
         }
         if (
@@ -360,7 +360,7 @@ All numbers must be numeric (no units attached in JSON).
           !data.details.every(d => typeof d.item === 'string' && typeof d.liters === 'number')
         ) {
           clearSkeleton();
-          out.textContent = '⚠️ پاسخ نامعتبر.';
+          out.textContent = '⚠️ پاسخ نامعتبر';
           return;
         }
 


### PR DESCRIPTION
## Summary
- Log invalid JSON text when the footprint calculator cannot parse AI output
- Normalize error message to "⚠️ پاسخ نامعتبر"

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c0af938508328bfec27a5446043b2