### PR TITLE
feat: replace header logo

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -43,15 +43,6 @@
         input[type=range]:hover{ opacity:1; }
         input[type=range]::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; width:24px; height:24px; background:#3b82f6; cursor:pointer; border-radius:50%; border:3px solid white; box-shadow:0 0 5px rgba(0,0,0,.2); }
         input[type=range]::-moz-range-thumb{ width:24px; height:24px; background:#3b82f6; cursor:pointer; border-radius:50%; border:3px solid white; box-shadow:0 0 5px rgba(0,0,0,.2); }
-        .site-logo {
-            position: fixed;
-            top: 10px;
-            right: 10px;
-            width: 120px;
-            height: auto;
-            z-index: 1000;
-        }
-
         #out-footprint, #simulate-result, #solution-result {
             margin-top: .75rem;
             line-height: 1.9;
@@ -60,7 +51,9 @@
     </style>
 </head>
 <body class="p-4 sm:p-6 md:p-8">
-    <img src="../Logo.png" alt="Logo" class="site-logo">
+    <header class="w-full flex justify-center mt-4">
+      <img src="header2.jpg" alt="هدر سایت" class="max-w-full h-auto rounded-lg shadow-md">
+    </header>
     <div class="max-w-7xl mx-auto">
         <header class="text-center mb-12">
             <h1 class="text-4xl md:text-5xl font-extrabold main-title">وضعیت بحرانی آب در مشهد</h1>


### PR DESCRIPTION
## Summary
- replace floating site logo with centered header image

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c18d6f8708328b2089a87867bd76d