### PR TITLE
feat: render clean Persian AI results

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -1,197 +1,154 @@
+// === Utils (بالای فایل) ===
 const nf = new Intl.NumberFormat('fa-IR');
 const pf = new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 1 });
 
-async function parseMaybeJson(res) {
-  const raw = await res.text();
-  console.log('[AI raw]', res.status, raw);
-  try { return JSON.parse(raw); } catch { return raw; }
-}
-
-function pickByType(payload, type) {
-  if (!payload) return null;
-  if (Array.isArray(payload)) {
-    const found = payload.find(x => x && x.type === type);
-    if (found) return found;
-    if (payload.length === 1) return payload[0];
-    return null;
-  }
-  if (payload.type === type) return payload;
-  return null;
-}
-
-function toNum(v) {
-  const n = typeof v === 'string' ? Number(v.replace(/[^\d\.\-]/g,'')) : Number(v);
+function toNum(v){
+  const n = typeof v === 'string' ? Number(v.replace(/[^\d.\-]/g,'')) : Number(v);
   return Number.isFinite(n) ? n : 0;
 }
+async function parseMaybeJson(res){
+  const raw = await res.text();
+  try { return JSON.parse(raw); } catch { return raw; }
+}
+function pickByType(payload, type){
+  if (!payload) return null;
+  if (Array.isArray(payload)) return payload.find(x => x && x.type === type) || payload[0] || null;
+  return payload.type === type ? payload : payload;
+}
+const faStatus = s => ({normal:'عادی', improving:'روبه‌بهبود', critical:'بحرانی'}[(s||'').toLowerCase()] || (s||''));
 
-function renderSkeleton(target) {
-  const wrapper = document.createElement('div');
-  wrapper.className = 'space-y-2 animate-pulse';
-  const line1 = document.createElement('div');
-  line1.className = 'h-4 bg-gray-200 rounded';
-  const line2 = document.createElement('div');
-  line2.className = 'h-4 bg-gray-200 rounded w-5/6';
-  const line3 = document.createElement('div');
-  line3.className = 'h-4 bg-gray-200 rounded w-4/6';
-  wrapper.append(line1, line2, line3);
-  target.replaceChildren(wrapper);
+function skeleton(){
+  return '<div class="space-y-2 animate-pulse"><div class="h-4 bg-slate-200 rounded"></div><div class="h-4 bg-slate-200 rounded w-5/6"></div><div class="h-4 bg-slate-200 rounded w-4/6"></div></div>';
 }
 
-function showThinking(btn, thinkingEl, inputEls = []) {
-  thinkingEl.classList.remove('hidden');
-  btn.disabled = true;
-  btn.dataset.orig = btn.textContent;
-  btn.textContent = '✨ در حال پردازش…';
-  btn.classList.add('opacity-90');
-  inputEls.forEach(el => el.setAttribute('aria-busy', 'true'));
+function showThinkingUI(){}
+function hideThinkingUI(){}
+
+// شبیه‌ساز ---------------------------------------------------------------
+async function handleSimulation(){
+  showThinkingUI();
+  const btn = document.getElementById('simulate-btn');
+  const thinking = document.getElementById('simulate-thinking');
+  const out = document.getElementById('simulate-result');
+  thinking?.classList.remove('hidden');
+  btn?.setAttribute('disabled','true');
+  out.innerHTML = skeleton();
+  try {
+    const payload = {
+      feature: 'simulate',
+      rainfall: toNum(document.getElementById('rain-slider')?.value),
+      reduction: toNum(document.getElementById('cut-slider')?.value)
+    };
+    const res = await fetch('/api/gemini', {
+      method:'POST', headers:{'Content-Type':'application/json'},
+      body: JSON.stringify(payload)
+    });
+    const data = await parseMaybeJson(res);
+    const block = pickByType(data, 'simulate');
+    const fc = block?.forecast || {};
+    const pct = toNum(fc.reservoirChangePct);
+    const status = faStatus(fc.status);
+
+    out.innerHTML = '';
+    out.append(
+      Object.assign(document.createElement('p'), { className:'font-bold', textContent:`وضعیت: ${status}` }),
+      Object.assign(document.createElement('p'), { textContent:`تغییر مخزن: ${pf.format(pct)}٪` }),
+      Object.assign(document.createElement('p'), { className:'text-slate-600', textContent: fc.notes || '' })
+    );
+
+    if (window.renderShareBar) renderShareBar(document.getElementById('simulate-share'), {
+      feature:'simulate',
+      state:{ rainfall:payload.rainfall, reduction:payload.reduction },
+      result:{ forecast: fc }
+    });
+  } catch(e){
+    console.error('[simulate]', e); out.textContent = '⚠ خطا در شبیه‌سازی.';
+  } finally {
+    thinking?.classList.add('hidden');
+    btn?.removeAttribute('disabled');
+    hideThinkingUI?.();
+  }
 }
 
-function hideThinking(btn, thinkingEl, inputEls = []) {
-  thinkingEl.classList.add('hidden');
-  btn.disabled = false;
-  btn.textContent = btn.dataset.orig || btn.textContent;
-  btn.classList.remove('opacity-90');
-  inputEls.forEach(el => el.removeAttribute('aria-busy'));
+// راهکارها --------------------------------------------------------------
+async function handleSolutions(){
+  showThinkingUI();
+  const btn = document.getElementById('solution-btn');
+  const thinking = document.getElementById('solution-thinking');
+  const out = document.getElementById('solution-result');
+  thinking?.classList.remove('hidden');
+  btn?.setAttribute('disabled','true');
+  out.innerHTML = skeleton();
+  try {
+    const payload = {
+      feature:'solutions',
+      family: toNum(document.getElementById('family-input')?.value),
+      shower: toNum(document.getElementById('shower-input')?.value)
+    };
+    const res = await fetch('/api/gemini', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload) });
+    const data = await parseMaybeJson(res);
+    const block = pickByType(data, 'solutions');
+    const tips = block?.tips || [];
+
+    out.innerHTML = '';
+    const ul = Object.assign(document.createElement('ul'), { className:'list-disc pr-5 space-y-1' });
+    tips.forEach(t => {
+      const li = document.createElement('li');
+      li.textContent = `${t.title} — صرفه‌جویی: ${nf.format(toNum(t.impact_liters))} لیتر/روز`;
+      ul.append(li);
+    });
+    out.append(ul);
+
+    if (window.renderShareBar) renderShareBar(document.getElementById('solution-share'), {
+      feature:'solutions', state:{ family:payload.family, shower:payload.shower }, result:{ tips }
+    });
+  } catch(e){
+    console.error('[solutions]', e); out.textContent = '⚠ خطا در تولید راهکار.';
+  } finally {
+    thinking?.classList.add('hidden');
+    btn?.removeAttribute('disabled');
+    hideThinkingUI?.();
+  }
 }
 
-// 1) ردپای آب غذا -------------------------------------------------------
-(function () {
+// ردپای آب --------------------------------------------------------------
+async function handleWater(){
+  showThinkingUI();
   const btn = document.getElementById('calc-water-btn');
   const inp = document.getElementById('food-input');
-  const out = document.getElementById('water-result');
   const thinking = document.getElementById('ai-thinking');
-  if (!btn || !inp || !out || !thinking) return;
+  const out = document.getElementById('water-result');
+  thinking?.classList.remove('hidden');
+  btn?.setAttribute('disabled','true');
+  out.innerHTML = skeleton();
+  try {
+    const q = inp?.value || '';
+    const res = await fetch('/api/gemini', { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({ feature:'water', q }) });
+    const data = await parseMaybeJson(res);
+    const block = pickByType(data, 'water') || {};
+    const total = toNum(block.totalWater);
+    const items = block.items || [];
 
-  btn.addEventListener('click', async () => {
-    const foods = (inp.value || '').trim();
-    if (!foods) { out.textContent = 'لطفاً مواد غذایی را وارد کنید.'; return; }
+    out.innerHTML = '';
+    const head = Object.assign(document.createElement('div'), { className:'font-bold mb-1', textContent:`مجموع ردپای آب: ${nf.format(total)} لیتر` });
+    const ul = Object.assign(document.createElement('ul'), { className:'list-disc pr-5 space-y-1' });
+    items.forEach(it => {
+      const li = document.createElement('li');
+      li.textContent = `${it.name}: ${nf.format(toNum(it.water))} لیتر`;
+      ul.append(li);
+    });
+    out.append(head, ul);
 
-    renderSkeleton(out);
-    showThinking(btn, thinking, [inp]);
-    try {
-      const res = await fetch('/api/gemini', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ feature: 'water', q: foods })
-      });
-      const data = await parseMaybeJson(res);
-      const block = pickByType(data, 'water');
-      if (!block) throw new Error('water: invalid block');
+    if (window.renderShareBar) renderShareBar(document.getElementById('water-share'), { feature:'water', state:{ q }, result:{ totalWater: total, items } });
+  } catch(e){
+    console.error('[water]', e); out.textContent = '⚠ پاسخ نامعتبر.';
+  } finally {
+    thinking?.classList.add('hidden');
+    btn?.removeAttribute('disabled');
+    hideThinkingUI?.();
+  }
+}
 
-      const total = toNum(block.totalWater);
-      out.innerHTML = '';
-      const h = document.createElement('div');
-      h.className = 'font-bold mb-1';
-      h.textContent = `مجموع ردپای آب: ${nf.format(total)} لیتر`;
-      const ul = document.createElement('ul');
-      ul.className = 'list-disc pr-4';
-      (block.items || []).forEach(it => {
-        const li = document.createElement('li');
-        li.textContent = `${it.name}: ${nf.format(toNum(it.water))} لیتر`;
-        ul.append(li);
-      });
-      out.append(h, ul);
-    } catch (e) {
-      console.error('[water]', e);
-      out.textContent = '⚠ پاسخ نامعتبر.';
-    } finally {
-      hideThinking(btn, thinking, [inp]);
-    }
-  });
-})();
-
-// 2) شبیه‌ساز آینده آب ---------------------------------------------------
-(function () {
-  const btn = document.getElementById('simulate-btn');
-  const rain = document.getElementById('rain-slider');
-  const cut = document.getElementById('cut-slider');
-  const out = document.getElementById('simulate-result');
-  const thinking = document.getElementById('simulate-thinking');
-  if (!btn || !rain || !cut || !out || !thinking) return;
-
-  btn.addEventListener('click', async () => {
-    renderSkeleton(out);
-    showThinking(btn, thinking, [rain, cut]);
-    try {
-      const payload = {
-        feature: 'simulate',
-        rainfall: toNum(rain.value || rain.getAttribute('value') || '0'),
-        reduction: toNum(cut.value || cut.getAttribute('value') || '0')
-      };
-      const res = await fetch('/api/gemini', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      });
-      const data = await parseMaybeJson(res);
-      const block = pickByType(data, 'simulate');
-      if (!block || !block.forecast) throw new Error('simulate: invalid block');
-
-      const fc = block.forecast;
-      const pct = toNum(fc.reservoirChangePct);
-      const status = fc.status || '';
-      const notes = fc.notes || '';
-
-      out.innerHTML = '';
-      const p1 = document.createElement('p');
-      p1.className = 'font-bold';
-      p1.textContent = `وضعیت: ${status}`;
-      const p2 = document.createElement('p');
-      p2.textContent = `تغییر مخزن: ${pf.format(pct)}%`;
-      const p3 = document.createElement('p');
-      p3.textContent = notes;
-      out.append(p1, p2, p3);
-    } catch (e) {
-      console.error('[simulate]', e);
-      out.textContent = '⚠ خطا در شبیه‌سازی.';
-    } finally {
-      hideThinking(btn, thinking, [rain, cut]);
-    }
-  });
-})();
-
-// 3) راهکارهای صرفه‌جویی -------------------------------------------------
-(function () {
-  const btn = document.getElementById('solution-btn');
-  const fam = document.getElementById('family-input');
-  const shw = document.getElementById('shower-input');
-  const out = document.getElementById('solution-result');
-  const thinking = document.getElementById('solution-thinking');
-  if (!btn || !fam || !shw || !out || !thinking) return;
-
-  btn.addEventListener('click', async () => {
-    renderSkeleton(out);
-    showThinking(btn, thinking, [fam, shw]);
-    try {
-      const payload = {
-        feature: 'solutions',
-        family: toNum(fam.value),
-        shower: toNum(shw.value)
-      };
-      const res = await fetch('/api/gemini', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload)
-      });
-      const data = await parseMaybeJson(res);
-      const block = pickByType(data, 'solutions');
-      if (!block || !Array.isArray(block.tips)) throw new Error('solutions: invalid block');
-
-      out.innerHTML = '';
-      const ul = document.createElement('ul');
-      ul.className = 'list-disc pr-4 space-y-1';
-      block.tips.forEach(t => {
-        const li = document.createElement('li');
-        li.textContent = `${t.title} — صرفه‌جویی: ${nf.format(toNum(t.impact_liters))} لیتر/روز`;
-        ul.append(li);
-      });
-      out.append(ul);
-    } catch (e) {
-      console.error('[solutions]', e);
-      out.textContent = '⚠ خطا در تولید راهکار.';
-    } finally {
-      hideThinking(btn, thinking, [fam, shw]);
-    }
-  });
-})();
-
+document.getElementById('simulate-btn')?.addEventListener('click', handleSimulation);
+document.getElementById('solution-btn')?.addEventListener('click', handleSolutions);
+document.getElementById('calc-water-btn')?.addEventListener('click', handleWater);

--- a/docs/index.html
+++ b/docs/index.html
@@ -135,6 +135,7 @@
                         </div>
                     </div>
                     <div id="water-result" class="mt-4 p-4 bg-white/70 rounded-xl shadow-inner" aria-live="polite" tabindex="-1"></div>
+                    <div id="water-share" class="mt-2"></div>
                 </div>
             </div>
         </section>
@@ -161,6 +162,7 @@
                       <div class="mt-3 h-8 w-20 rounded-full border-2 border-dashed border-purple-400 animate-spin mx-auto"></div>
                     </div>
                     <div id="simulate-result" class="mt-4 p-4 bg-white/70 rounded-xl shadow-inner" aria-live="polite"></div>
+                    <div id="simulate-share" class="mt-2"></div>
                 </div>
             </div>
         </section>
@@ -187,6 +189,7 @@
                       <div class="mt-3 h-8 w-20 rounded-full border-2 border-dashed border-blue-400 animate-spin mx-auto"></div>
                     </div>
                     <div id="solution-result" class="mt-4 p-4 bg-white/70 rounded-xl shadow-inner" aria-live="polite"></div>
+                    <div id="solution-share" class="mt-2"></div>
                 </div>
             </div>
         </section>

--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -125,8 +125,8 @@ export default async function handler(req) {
   }
 
   const systemPromptText = `
-You are an API. Return ONLY valid JSON for the requested feature.
-No prose, no markdown, no code fences.
+You are an API. Output ONLY valid JSON.
+All explanatory texts (notes, tips.title) MUST be in Persian (fa-IR).
 Schemas:
 - water: {"type":"water","totalWater":number,"items":[{"name":string,"water":number}]}
 - simulate: {"type":"simulate","forecast":{"status":string,"reservoirChangePct":number,"notes":string}}


### PR DESCRIPTION
## Summary
- parse AI JSON and render Persian numbers and statuses in simulator, solutions, and water footprint
- add share bar placeholders and Persian status helpers
- instruct Gemini backend to output Persian notes and tips titles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c52b9b2548328a15a0c6e4f5c0f1e