### PR TITLE
feat: add sector landing page with quick entry

### DIFF
--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -14,7 +14,10 @@
   <main class="text-center space-y-6">
     <h1 class="text-3xl font-extrabold text-slate-700">صفحه برق</h1>
     <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
-    <a href="/" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>
+    <a href="../" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>
   </main>
+  <script>
+    localStorage.setItem('sector', 'electricity');
+  </script>
 </body>
 </html>

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -14,7 +14,10 @@
   <main class="text-center space-y-6">
     <h1 class="text-3xl font-extrabold text-slate-700">صفحه گاز و فرآورده‌های نفتی</h1>
     <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
-    <a href="/" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>
+    <a href="../" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>
   </main>
+  <script>
+    localStorage.setItem('sector', 'gas');
+  </script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,34 +1,47 @@
 <!DOCTYPE html>
 <html lang="fa" dir="rtl">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ورود - wesh360</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      @import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap');
-      body { font-family: 'Vazirmatn', sans-serif; }
-      .landing-option { transition: transform .2s, box-shadow .2s; }
-      .landing-option:hover { transform: translateY(-4px); box-shadow: 0 4px 14px rgba(0,0,0,.1); }
-    </style>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>wesh360</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="page/landing/landing.css" />
 </head>
 <body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
-  <main class="text-center space-y-12 w-full">
-    <h1 class="text-3xl md:text-4xl font-extrabold text-slate-700">به wesh360 خوش‌آمدید</h1>
+  <main class="w-full text-center space-y-12">
+    <img src="page/landing/logo2.jfif" alt="لوگوی wesh360" class="mx-auto w-32 h-32 object-contain" />
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-3xl mx-auto">
-      <a href="/water/" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
+      <a href="water/" data-sector="water" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
         <span class="text-5xl mb-4">💧</span>
         آب
       </a>
-      <a href="/electricity/" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
+      <a href="electricity/" data-sector="electricity" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
         <span class="text-5xl mb-4">⚡</span>
         برق
       </a>
-      <a href="/gas/" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
+      <a href="gas/" data-sector="gas" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
         <span class="text-5xl mb-4">🛢</span>
         گاز و فرآورده‌های نفتی
       </a>
     </div>
+    <a id="quick-entry" href="#" class="hidden landing-option bg-blue-600 text-white rounded-xl py-4 px-8 inline-block font-bold"></a>
   </main>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      document.querySelectorAll('[data-sector]').forEach(function (el) {
+        el.addEventListener('click', function () {
+          localStorage.setItem('sector', el.getAttribute('data-sector'));
+        });
+      });
+      var sector = localStorage.getItem('sector');
+      if (sector) {
+        var names = { water: 'آب', electricity: 'برق', gas: 'گاز و فرآورده‌های نفتی' };
+        var quick = document.getElementById('quick-entry');
+        quick.href = sector + '/';
+        quick.textContent = 'ورود سریع به ' + (names[sector] || sector);
+        quick.classList.remove('hidden');
+      }
+    });
+  </script>
 </body>
 </html>

--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -1,0 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700&display=swap');
+body { font-family: 'Vazirmatn', sans-serif; }
+.landing-option { transition: transform .2s, box-shadow .2s; }
+.landing-option:hover { transform: translateY(-4px); box-shadow: 0 4px 14px rgba(0,0,0,.1); }


### PR DESCRIPTION
## Summary
- add landing page with logo and sector buttons
- show quick entry button when a sector is saved
- add simple electricity and gas placeholder pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c77f0d9048328b70cded578e7f9d4