### PR TITLE
style: add gradient color to landing curtain

### DIFF
--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -3,7 +3,12 @@ body { font-family: 'Vazirmatn', sans-serif; }
 .landing-option { transition: transform .2s, box-shadow .2s; }
 .landing-option:hover { transform: translateY(-4px); box-shadow: 0 4px 14px rgba(0,0,0,.1); }
 .curtain { position: fixed; inset: 0; display: flex; z-index: 50; }
-.curtain-half { flex: 1; background: #f1f5f9; transform: translateX(0); transition: transform .8s ease-in-out; }
+.curtain-half {
+  flex: 1;
+  background: linear-gradient(135deg, #3b82f6, #06b6d4);
+  transform: translateX(0);
+  transition: transform .8s ease-in-out;
+}
 .curtain.open .left { transform: translateX(-100%); }
 .curtain.open .right { transform: translateX(100%); }
 


### PR DESCRIPTION
## Summary
- add a blue-to-teal gradient to the landing page curtain for a more colorful slide effect

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689c7ddf0d108328a1d9c7e94e56481e