### PR TITLE
fix: avoid duplicate animated navigation handlers

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -90,6 +90,7 @@
     }
 
     document.querySelectorAll('[data-sector]').forEach(el => {
+      el.removeEventListener('click', animatedNavigate);
       el.addEventListener('click', animatedNavigate);
     });
 
@@ -102,6 +103,7 @@
         quick.textContent = 'ورود سریع به ' + (names[sector] || sector);
         quick.setAttribute('data-sector', sector);
         quick.classList.remove('hidden');
+        quick.removeEventListener('click', animatedNavigate);
         quick.addEventListener('click', animatedNavigate);
       }
     }


### PR DESCRIPTION
## Summary
- prevent duplicate animatedNavigate event handlers on sector links
- ensure quick-entry link only binds one animatedNavigate listener

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_689cad6a5e888328bf9f9c8915e71c6d