### PR TITLE
feat(i18n): set <html lang="fa" dir="rtl"> and add Content-Language meta across pages

### DIFF
--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -2,6 +2,7 @@
 <html lang="fa" dir="rtl">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Language" content="fa-IR">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>برق - wesh360</title>
       <link rel="stylesheet" href="../assets/tailwind.css">

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -2,6 +2,7 @@
 <html lang="fa" dir="rtl">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Language" content="fa-IR">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>گاز - wesh360</title>
       <link rel="stylesheet" href="../assets/tailwind.css">

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html lang="fa" dir="rtl">
 <head>
   <meta charset="UTF-8" />
+  <meta http-equiv="Content-Language" content="fa-IR" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>wesh360</title>
     <link rel="stylesheet" href="assets/tailwind.css" />

--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -3,6 +3,7 @@
 <head>
     <base href="..">
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Language" content="fa-IR">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>داشبورد وضعیت آب مشهد (مجهز به Gemini)</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%231f7aff'/%3E%3Cpath d='M20 36c8 4 16-4 24 0' stroke='white' stroke-width='4' fill='none'/%3E%3C/svg%3E" />


### PR DESCRIPTION
## Summary
- add `Content-Language` meta tag to all static HTML pages
- ensure each page keeps `<html lang="fa" dir="rtl">`

## Testing
- `FILES=$(git ls-files '*.html'); for f in $FILES; do grep -E '<html[^>]*\blang="fa"[^>]*\bdir="rtl"[^>]*>' "$f" >/dev/null || { echo "MISSING lang/dir in $f"; exit 1; }; grep -E '<meta[^>]+http-equiv="Content-Language"[^>]+content="fa-IR"' "$f" >/dev/null || { echo "MISSING Content-Language in $f"; exit 1; }; done; echo "All good ✅"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d6596f0d88328b4662128f323fc05