### PR TITLE
fix: maintain landing logo aspect ratio

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,7 @@
   <picture>
     <source srcset="page/landing/logo2.avif" type="image/avif">
     <source srcset="page/landing/logo2.webp" type="image/webp">
-    <img src="page/landing/logo2.jfif" alt="لوگوی wesh360" class="logo-fixed" width="400" height="400" loading="lazy">
+    <img src="page/landing/logo2.jfif" alt="لوگوی سایت" class="landing-logo max-w-full h-auto object-contain block" width="400" height="400" loading="lazy">
   </picture>
   <main id="main" class="w-full text-center space-y-12">
     <h1 class="welcome-text">به wesh360 خوش آمدید</h1>

--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -1,13 +1,16 @@
 .landing-option { transition: transform .2s, box-shadow .2s; }
 .landing-option:hover { transform: translateY(-4px); box-shadow: 0 4px 14px rgba(0,0,0,.1); }
 
-.logo-fixed {
+.landing-logo {
   position: absolute;
   top: 10px;
   right: 10px;
-  max-height: 60px;
   margin-top: 10px;
   margin-right: 10px;
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
+  display: block;
 }
 
 .welcome-text {


### PR DESCRIPTION
## Summary
- prevent landing logo squish by using real dimensions and responsive styles
- replace old `.logo-fixed` with `.landing-logo` class and utility classes for proper scaling

## Testing
- `npx image-size docs/page/landing/logo2.jfif`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689df26298248328a990d3d7dc78d900