### PR TITLE
feat: enhance simulation display and font

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,4 +1,8 @@
 /* فونت‌های ایموجی رنگی در سیستم‌های مختلف */
+body {
+  font-family: 'Vazirmatn', sans-serif;
+}
+
 .emoji-flag{
   font-family: inherit, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji",
                "EmojiOne Color", "Twemoji Mozilla", sans-serif;

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif" />
   <title>wesh360</title>
+  <style>@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700;800&display=swap');</style>
     <link rel="stylesheet" href="assets/tailwind.css" />
     <link rel="stylesheet" href="assets/styles.css" />
     <link rel="stylesheet" href="fonts/fonts.css" />

--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -12,6 +12,7 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
     <title>داشبورد وضعیت آب مشهد (مجهز به Gemini)</title>
+    <style>@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700;800&display=swap');</style>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%231f7aff'/%3E%3Cpath d='M20 36c8 4 16-4 24 0' stroke='white' stroke-width='4' fill='none'/%3E%3C/svg%3E" />
       <link rel="stylesheet" href="assets/tailwind.css">
       <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">


### PR DESCRIPTION
## Summary
- parse simulation API response from string and render formatted Persian result with Tailwind styling
- ensure API helper returns raw string and include sample output for testing
- add Vazirmatn font across site via Google Fonts import

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_689df8106d38832899436dd5b1530802