### PR TITLE
Style simulation output and unify fonts

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -56,25 +56,27 @@ async function handleSimulation(){
       raw = SAMPLE_SIMULATION;
     }
     const data = JSON.parse(raw);
-    const newDay = data.newZeroDay || '';
+    const newDayRaw = data.newZeroDay ?? '';
+    const days = toNum(newDayRaw);
+    const newDay = Number.isFinite(days) && days !== 0 ? nf.format(days) : newDayRaw;
     const delta = toNum(data.daysChange);
     const note = data.note || data.description || '';
 
     const color = delta >= 0 ? 'text-green-600' : 'text-red-600';
-    const container = Object.assign(document.createElement('div'), { className: 'space-y-2 text-center' });
-    const p1 = Object.assign(document.createElement('p'), {
-      innerHTML: `روز صفر جدید: <span class="font-bold">${newDay}</span>`
-    });
-    const p2 = Object.assign(document.createElement('p'), {
-      innerHTML: `تغییر تعداد روزها: <span class="${color} font-bold">${nf.format(delta)}</span> روز`
-    });
-    const p3 = Object.assign(document.createElement('p'), {
-      className: 'text-slate-600 text-sm',
-      textContent: note
-    });
-    container.append(p1, p2, p3);
-    out.innerHTML = '';
-    out.append(container);
+    const sign = delta >= 0 ? '+' : '-';
+    const deltaHtml = `<span class="${color} font-bold text-xl">(${sign}${nf.format(Math.abs(delta))} روز)</span>`;
+
+    out.className = 'mt-4 bg-green-50 rounded-xl p-6 shadow-sm text-right space-y-2';
+    out.setAttribute('dir','rtl');
+    out.innerHTML = `
+        <p class="text-slate-600">روز صفر جدید:</p>
+        <div class="flex items-baseline gap-2">
+          <span class="result-number text-blue-600 text-6xl">${newDay}</span>
+          <span class="text-blue-600 text-2xl">روز</span>
+          ${deltaHtml}
+        </div>
+        <p class="text-slate-700">${note}</p>
+      `;
 
     if (window.renderShareBar) renderShareBar(document.getElementById('simulate-share'), {
       feature:'simulate',

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,6 +1,11 @@
 /* فونت‌های ایموجی رنگی در سیستم‌های مختلف */
 body {
   font-family: 'Vazirmatn', sans-serif;
+  font-weight: 400;
+}
+
+h1, h2, h3, .result-number {
+  font-weight: 900;
 }
 
 .emoji-flag{

--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -11,9 +11,9 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
     <title>برق - wesh360</title>
+      <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn/Vazirmatn-Variable-font-face.css" rel="stylesheet" type="text/css" />
       <link rel="stylesheet" href="../assets/tailwind.css">
-      <link rel="stylesheet" href="../assets/styles.css">
-      <link rel="stylesheet" href="../fonts/fonts.css"></head>
+      <link rel="stylesheet" href="../assets/styles.css"></head>
 <body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <main id="main" class="text-center space-y-6">

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -11,9 +11,9 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
     <title>گاز - wesh360</title>
+      <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn/Vazirmatn-Variable-font-face.css" rel="stylesheet" type="text/css" />
       <link rel="stylesheet" href="../assets/tailwind.css">
-      <link rel="stylesheet" href="../assets/styles.css">
-      <link rel="stylesheet" href="../fonts/fonts.css"></head>
+      <link rel="stylesheet" href="../assets/styles.css"></head>
 <body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <main id="main" class="text-center space-y-6">

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,10 +11,9 @@
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif" />
   <title>wesh360</title>
-  <style>@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700;800&display=swap');</style>
+  <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn/Vazirmatn-Variable-font-face.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="assets/tailwind.css" />
     <link rel="stylesheet" href="assets/styles.css" />
-    <link rel="stylesheet" href="fonts/fonts.css" />
     <link rel="stylesheet" href="page/landing/landing.css" /></head>
 <body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>

--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -12,12 +12,11 @@
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
     <title>داشبورد وضعیت آب مشهد (مجهز به Gemini)</title>
-    <style>@import url('https://fonts.googleapis.com/css2?family=Vazirmatn:wght@400;700;800&display=swap');</style>
+    <link href="https://cdn.jsdelivr.net/gh/rastikerdar/vazirmatn/Vazirmatn-Variable-font-face.css" rel="stylesheet" type="text/css" />
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%231f7aff'/%3E%3Cpath d='M20 36c8 4 16-4 24 0' stroke='white' stroke-width='4' fill='none'/%3E%3C/svg%3E" />
       <link rel="stylesheet" href="assets/tailwind.css">
       <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
       <link rel="stylesheet" href="assets/styles.css">
-      <link rel="stylesheet" href="fonts/fonts.css">
       <style>
           body { background-color: #f0f4f8; }
         .main-title { font-weight: 800; color: #1e3a8a; }
@@ -162,7 +161,7 @@
                         <div><label for="cut-slider" class="font-semibold text-slate-700 block mb-2">کاهش مصرف همگانی:</label><input type="range" id="cut-slider" min="0" max="30" value="10" class="w-full" aria-describedby="cut-value"><div class="text-center font-bold text-xl text-blue-600 mt-2"><span id="cut-value" data-fa-digits>10</span>%</div></div>
                         <div><label for="rain-slider" class="font-semibold text-slate-700 block mb-2">بارش باران در ماه آینده:</label><input type="range" id="rain-slider" min="0" max="50" value="5" class="w-full" aria-describedby="rain-value"><div class="text-center font-bold text-xl text-blue-600 mt-2"><span id="rain-value" data-fa-digits>5</span> میلی‌متر</div></div>
                     </div>
-                    <div class="text-center"><button id="simulate-btn" type="button" class="btn-gemini text-white font-bold py-3 px-8 rounded-full text-lg shadow-lg bg-green-500 hover:bg-green-600"><i class="fas fa-chart-line ml-2" aria-hidden="true"></i>آینده را شبیه‌سازی کن</button></div>
+                    <div class="text-center"><button id="simulate-btn" type="button" class="text-white font-bold py-3 px-8 rounded-full text-lg shadow-lg bg-indigo-600 hover:bg-indigo-700"><i class="fas fa-chart-line ml-2" aria-hidden="true"></i>آینده را شبیه‌سازی کن</button></div>
                     <div id="simulate-thinking" class="mt-4 hidden">
                       <div class="flex items-center gap-2 text-gray-700">
                         <span class="text-xl">✨</span>
@@ -175,7 +174,7 @@
                       </div>
                       <div class="mt-3 h-8 w-20 rounded-full border-2 border-dashed border-purple-400 animate-spin mx-auto"></div>
                     </div>
-                    <div id="simulate-result" data-fa-digits class="mt-4 p-4 bg-white/70 rounded-xl shadow-inner" aria-live="polite" tabindex="-1"></div>
+                    <div id="simulate-result" data-fa-digits class="mt-4" aria-live="polite" tabindex="-1"></div>
                     <div id="simulate-share" class="mt-2"></div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Switch to variable Vazirmatn font across pages and set body/headings weights.
- Revamp water simulator result rendering with colored deltas and RTL, styled container.
- Restyle simulation button and clean up result container markup.

## Testing
- ✅ `npm test`
- ✅ `npm run build:css`
- ⚠️ `npm run flag:test` (missing libatk-1.0.so.0)


------
https://chatgpt.com/codex/tasks/task_e_689dfe0759048328bde506b7c6b7d54f