### PR TITLE
Expose simulation summary fields at top level

### DIFF
--- a/netlify/functions/gemini.js
+++ b/netlify/functions/gemini.js
@@ -129,7 +129,7 @@ You are an API. Output ONLY valid JSON.
 All explanatory texts (notes, tips.title) MUST be in Persian (fa-IR).
 Schemas:
 - water: {"type":"water","totalWater":number,"items":[{"name":string,"water":number}]}
-- simulate: {"type":"simulate","forecast":{"status":string,"reservoirChangePct":number,"notes":string}}
+ - simulate: {"type":"simulate","newZeroDay":string,"daysChange":number,"note":string}
 - solutions: {"type":"solutions","tips":[{"title":string,"impact_liters":number}]}
 `;
 
@@ -183,6 +183,15 @@ Schemas:
         status: 502,
         headers: { ...headers, 'Content-Type': 'application/json', 'Cache-Control': 'no-store' },
       });
+    }
+
+    if (feature === 'simulate' && out && typeof out === 'object') {
+      out = {
+        type: 'simulate',
+        newZeroDay: out.newZeroDay,
+        daysChange: out.daysChange,
+        note: out.note,
+      };
     }
 
     return new Response(JSON.stringify(out), {


### PR DESCRIPTION
## Summary
- prompt Gemini to return newZeroDay, daysChange, and note in simulate responses
- normalize simulate output to top-level fields

## Testing
- `npm test`
- `GEMINI_API_KEY=1 node /tmp/test.mjs`


------
https://chatgpt.com/codex/tasks/task_e_689e06d04c308328becf4e64cd0ef2d8