### PR TITLE
Fix broken styles in water dashboard

### DIFF
--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -65,8 +65,14 @@
         input[type=range]:hover{ opacity:1; }
         input[type=range]::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; width:24px; height:24px; background:#3b82f6; cursor:pointer; border-radius:50%; border:3px solid white; box-shadow:0 0 5px rgba(0,0,0,.2); }
         input[type=range]::-moz-range-thumb{ width:24px; height:24px; background:#3b82f6; cursor:pointer; border-radius:50%; border:3px solid white; box-shadow:0 0 5px rgba(0,0,0,.2); }
- codex/replace-logo-with-header2.jpg
-        #out-footprint, #simulate-result, #solution-result {
+        #out-footprint,
+        #water-result,
+        #simulate-result,
+        #solution-result {
+            margin-top: .75rem;
+            line-height: 1.9;
+            font-size: .9rem;
+        }
 
         .site-logo {
             position: fixed;
@@ -75,13 +81,6 @@
             width: 120px;
             height: auto;
             z-index: 1000;
-        }
-
-        #water-result, #simulate-result, #solution-result {
- main
-            margin-top: .75rem;
-            line-height: 1.9;
-            font-size: .9rem;
         }
     </style>
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/twemoji.min.js"


### PR DESCRIPTION
## Summary
- remove stray text and restore style rules for result containers and site logo

## Testing
- `npm test`
- `npm run flag:test`


------
https://chatgpt.com/codex/tasks/task_e_68a09f5c487c83289cc8055a99fcdf9b