### PR TITLE
Make landing logo responsive

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
   <picture>
     <source srcset="page/landing/logo2.avif" type="image/avif">
     <source srcset="page/landing/logo2.webp" type="image/webp">
-    <img src="page/landing/logo2.jfif" alt="لوگوی سایت" class="landing-logo max-w-full h-auto object-contain block" width="400" height="400" loading="lazy">
+    <img src="page/landing/logo2.jfif" alt="لوگوی سایت" class="landing-logo max-w-full h-auto object-contain block" loading="lazy">
   </picture>
   <main id="main" class="w-full text-center space-y-12">
     <h1 class="welcome-text">به wesh360 خوش آمدید</h1>

--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -2,12 +2,10 @@
 .landing-option:hover { transform: translateY(-4px); box-shadow: 0 4px 14px rgba(0,0,0,.1); }
 
 .landing-logo {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  margin-top: 10px;
-  margin-right: 10px;
-  max-width: 100%;
+  position: relative;
+  margin: 10px auto;
+  width: 100%;
+  max-width: 60%;
   height: auto;
   object-fit: contain;
   display: block;


### PR DESCRIPTION
## Summary
- make landing page logo relative and center horizontally for better mobile display
- constrain logo width to 60% of screen and remove fixed size attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a09e976083289bf920fc51fb7362