### PR TITLE
fix: make water drop and logo responsive

### DIFF
--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -54,7 +54,7 @@
                 flex-direction: column;
             }
         }
-        .water-drop-container { position: relative; width: 100px; height: 100px; margin: 0 auto; }
+        .water-drop-container { position: relative; width: 25vw; height: 25vw; max-width: 100px; max-height: 100px; margin: 0 auto; }
         .water-drop-background { position: absolute; bottom: 0; left: 0; right: 0; background-color: #3b82f6; border-radius: 0 0 50px 50px; transition: height 1s ease-out; }
         .water-drop-icon { position: absolute; top: 0; left: 0; width: 100%; height: 100%; -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat; -webkit-mask-position: center; mask-position: center; background-color: #e0e0e0; }
         .days-left-card { background: linear-gradient(135deg, #ef4444, #b91c1c); color: white; }
@@ -79,8 +79,10 @@
             position: fixed;
             top: 10px;
             right: 10px;
-            width: 120px;
+            width: 25vw;
             height: auto;
+            max-width: 120px;
+            max-height: 120px;
             z-index: 1000;
         }
     </style>


### PR DESCRIPTION
## Summary
- make water drop responsive using vw units with max size
- scale site logo with vw and limit to 120px

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0a33466d483289f54fa5f722022c2