### PR TITLE
fix: use relative font path for Vazirmatn

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -1,7 +1,7 @@
 /* فونت‌های ایموجی رنگی در سیستم‌های مختلف */
 @font-face {
   font-family: 'Vazirmatn';
-  src: url('/fonts/vazirmatn/Vazirmatn[wght].woff2') format('woff2');
+  src: url('../fonts/vazirmatn/Vazirmatn[wght].woff2') format('woff2');
   font-weight: 100 900;
   font-style: normal;
   font-display: swap;


### PR DESCRIPTION
## Summary
- use a relative path for the Vazirmatn font in docs/assets/styles.css so it loads correctly on GitHub Pages and subdomains

## Testing
- `npm test`
- `npm run flag:test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a4bb828c8328ac64057ec839ab80