### PR TITLE
refactor responsive styles

### DIFF
--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -1,11 +1,12 @@
 .landing-option { transition: transform .2s, box-shadow .2s; }
 .landing-option:hover { transform: translateY(-4px); box-shadow: 0 4px 14px rgba(0,0,0,.1); }
 
+/* ===== Base (desktop) styles ===== */
 .landing-logo {
   position: relative;
   margin: 10px auto;
-  width: 100%;
-  max-width: 60%;
+  width: 40vw;
+  max-width: 400px;
   height: auto;
   object-fit: contain;
   display: block;
@@ -16,4 +17,16 @@
   font-weight: 700;
   color: #333;
   text-align: center;
+}
+
+/* ===== Mobile overrides ===== */
+@media (max-width: 768px) {
+  .landing-logo {
+    width: 60vw;
+    max-width: 60%;
+  }
+
+  .welcome-text {
+    font-size: 20px;
+  }
 }

--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -16,76 +16,7 @@
       <link rel="stylesheet" href="assets/tailwind.css">
       <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
       <link rel="stylesheet" href="assets/styles.css">
-      <style>
-          body { background-color: #f0f4f8; }
-        .main-title { font-weight: 800; color: #1e3a8a; }
-        /* --- Cards --- */
-        .card-row {
-            display: flex;
-            gap: 1.5rem;
-            flex-wrap: wrap;
-        }
-        .card {
-            background: #fff;
-            border-radius: 18px;
-            box-shadow: 0 8px 20px rgba(0,0,0,.05);
-            padding: 1.5rem;
-            flex: 1;
-            min-width: 0;
-            width: min(280px, 100%);
-        }
-
-        .footprint-card {
-            background-color: #FFFBEA;
-            border: 1px solid #F5EAC2;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-        }
-
-        .simulator-card {
-            background-color: #E6FAF0;
-            border: 1px solid #C8EEDA;
-            border-radius: 8px;
-            box-shadow: 0 2px 4px rgba(0,0,0,0.05);
-        }
-
-        @media (max-width: 768px) {
-            .card-row {
-                flex-direction: column;
-            }
-        }
-        .water-drop-container { position: relative; width: 25vw; height: 25vw; max-width: 100px; max-height: 100px; margin: 0 auto; }
-        .water-drop-background { position: absolute; bottom: 0; left: 0; right: 0; background-color: #3b82f6; border-radius: 0 0 50px 50px; transition: height 1s ease-out; }
-        .water-drop-icon { position: absolute; top: 0; left: 0; width: 100%; height: 100%; -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat; -webkit-mask-position: center; mask-position: center; background-color: #e0e0e0; }
-        .days-left-card { background: linear-gradient(135deg, #ef4444, #b91c1c); color: white; }
-        .rain-bar { background-color: #93c5fd; border-radius: .5rem; position: relative; }
-        .rain-bar-fill { background-color: #1d4ed8; border-radius: .5rem; transition: height 1s ease-out; }
-        .btn-gemini { background: linear-gradient(135deg, #4f46e5, #7c3aed); transition: all .3s ease; }
-        .btn-gemini:hover { box-shadow: 0 0 20px rgba(79,70,229,.5); }
-        input[type=range]{ -webkit-appearance:none; appearance:none; width:100%; height:8px; background:#d1d5db; border-radius:5px; outline:none; opacity:.7; transition:opacity .2s; }
-        input[type=range]:hover{ opacity:1; }
-        input[type=range]::-webkit-slider-thumb{ -webkit-appearance:none; appearance:none; width:24px; height:24px; background:#3b82f6; cursor:pointer; border-radius:50%; border:3px solid white; box-shadow:0 0 5px rgba(0,0,0,.2); }
-        input[type=range]::-moz-range-thumb{ width:24px; height:24px; background:#3b82f6; cursor:pointer; border-radius:50%; border:3px solid white; box-shadow:0 0 5px rgba(0,0,0,.2); }
-        #out-footprint,
-        #water-result,
-        #simulate-result,
-        #solution-result {
-            margin-top: .75rem;
-            line-height: 1.9;
-            font-size: .9rem;
-        }
-
-        .site-logo {
-            position: fixed;
-            top: 10px;
-            right: 10px;
-            width: 25vw;
-            height: auto;
-            max-width: 120px;
-            max-height: 120px;
-            z-index: 1000;
-        }
-    </style>
+      <link rel="stylesheet" href="water/water.css">
     <script defer src="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/twemoji.min.js"
             integrity="sha512-3v3L9b5m9q2s0i6gQ0yq+8vJm3a6oI1mG2r3l0X3zv3Y6uFJq1Wc1q9kGmXlM3Yj6fxp2U7N7yqZtCz9D6Qy4A=="
             crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/docs/water/water.css
+++ b/docs/water/water.css
@@ -1,0 +1,158 @@
+/* ===== Base (desktop) styles ===== */
+body { background-color: #f0f4f8; }
+
+.main-title { font-weight: 800; color: #1e3a8a; }
+
+.card-row {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.card {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
+  padding: 1.5rem;
+  flex: 1;
+  min-width: 0;
+  width: 280px;
+  max-width: 100%;
+}
+
+.footprint-card {
+  background-color: #FFFBEA;
+  border: 1px solid #F5EAC2;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.simulator-card {
+  background-color: #E6FAF0;
+  border: 1px solid #C8EEDA;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+}
+
+.water-drop-container {
+  position: relative;
+  width: 100px;
+  height: 100px;
+  margin: 0 auto;
+}
+
+.water-drop-background {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: #3b82f6;
+  border-radius: 0 0 50px 50px;
+  transition: height 1s ease-out;
+}
+
+.water-drop-icon {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>');
+  mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>');
+  -webkit-mask-repeat: no-repeat;
+  mask-repeat: no-repeat;
+  -webkit-mask-position: center;
+  mask-position: center;
+  background-color: #e0e0e0;
+}
+
+.days-left-card { background: linear-gradient(135deg, #ef4444, #b91c1c); color: white; }
+
+.rain-bar {
+  background-color: #93c5fd;
+  border-radius: .5rem;
+  position: relative;
+}
+
+.rain-bar-fill {
+  background-color: #1d4ed8;
+  border-radius: .5rem;
+  transition: height 1s ease-out;
+}
+
+.btn-gemini {
+  background: linear-gradient(135deg, #4f46e5, #7c3aed);
+  transition: all .3s ease;
+}
+
+.btn-gemini:hover { box-shadow: 0 0 20px rgba(79, 70, 229, .5); }
+
+input[type=range] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 8px;
+  background: #d1d5db;
+  border-radius: 5px;
+  outline: none;
+  opacity: .7;
+  transition: opacity .2s;
+}
+
+input[type=range]:hover { opacity: 1; }
+
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 24px;
+  height: 24px;
+  background: #3b82f6;
+  cursor: pointer;
+  border-radius: 50%;
+  border: 3px solid white;
+  box-shadow: 0 0 5px rgba(0, 0, 0, .2);
+}
+
+input[type=range]::-moz-range-thumb {
+  width: 24px;
+  height: 24px;
+  background: #3b82f6;
+  cursor: pointer;
+  border-radius: 50%;
+  border: 3px solid white;
+  box-shadow: 0 0 5px rgba(0, 0, 0, .2);
+}
+
+#out-footprint,
+#water-result,
+#simulate-result,
+#solution-result {
+  margin-top: .75rem;
+  line-height: 1.9;
+  font-size: .9rem;
+}
+
+.site-logo {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  width: 120px;
+  height: auto;
+  max-width: 120px;
+  max-height: 120px;
+  z-index: 1000;
+}
+
+/* ===== Mobile overrides ===== */
+@media (max-width: 768px) {
+  .card-row { flex-direction: column; }
+  .card { width: 100%; }
+  .site-logo { width: 25vw; }
+  .water-drop-container {
+    width: 25vw;
+    height: 25vw;
+    max-width: 100px;
+    max-height: 100px;
+  }
+}
+


### PR DESCRIPTION
## Summary
- centralize water dashboard styles into dedicated `water.css`
- restructure landing styles with desktop base and mobile overrides
- ensure mobile rules run only under `@media (max-width: 768px)`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a145e77ffc8328947d4d9e40237542