### PR TITLE
feat(water-dashboard): replace drop icon with 10x10 waffle charts; thresholds & a11y added

### DIFF
--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -54,9 +54,14 @@
                 flex-direction: column;
             }
         }
-        .water-drop-container { position: relative; width: 25vw; height: 25vw; max-width: 100px; max-height: 100px; margin: 0 auto; }
-        .water-drop-background { position: absolute; bottom: 0; left: 0; right: 0; background-color: #3b82f6; border-radius: 0 0 50px 50px; transition: height 1s ease-out; }
-        .water-drop-icon { position: absolute; top: 0; left: 0; width: 100%; height: 100%; -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path fill="currentColor" d="M192 512C86 512 0 426 0 320C0 228.8 130.2 57.7 166.6 11.7C172.6 4.2 181.5 0 192 0s19.4 4.2 25.4 11.7C253.8 57.7 384 228.8 384 320c0 106-86 192-192 192z"/></svg>'); -webkit-mask-repeat: no-repeat; mask-repeat: no-repeat; -webkit-mask-position: center; mask-position: center; background-color: #e0e0e0; }
+        .waffle{ --size:10; --gap:6px; --cell:12px; display:grid;
+          grid-template-columns:repeat(var(--size), var(--cell)); gap:var(--gap); place-content:center}
+        .waffle span{ width:var(--cell); height:var(--cell); border-radius:3px; background:#e5e7eb }
+        .waffle span.f{ background:#1d4ed8 }
+        .waffle[data-state="warn"] span.f{ background:#f59e0b }
+        .waffle[data-state="alert"] span.f{ background:#ef4444 }
+        @media (max-width:640px){ .waffle{ --cell:10px; --gap:4px } }
+        .dark .waffle span{ background:#374151 }
         .days-left-card { background: linear-gradient(135deg, #ef4444, #b91c1c); color: white; }
         .rain-bar { background-color: #93c5fd; border-radius: .5rem; position: relative; }
         .rain-bar-fill { background-color: #1d4ed8; border-radius: .5rem; transition: height 1s ease-out; }
@@ -132,10 +137,10 @@
         <section class="mb-12">
             <h2 class="text-3xl font-bold text-slate-800 text-center mb-8">پایش لحظه‌ای سدها</h2>
             <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد دوستی</h3><div class="water-drop-container mb-4"><div class="water-drop-icon"></div><div class="water-drop-background" style="height: 5%;"></div></div><p class="text-5xl font-extrabold text-blue-600">5%</p><p class="text-slate-500 mt-2">حجم: حدود ۶۵ میلیون متر مکعب</p><div class="mt-4 p-3 bg-amber-100 text-amber-800 rounded-lg text-sm font-semibold border border-amber-200"><i class="fas fa-exclamation-triangle mr-2"></i>نیمی از این حجم متعلق به ترکمنستان است.</div></div>
-                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد طرق</h3><div class="water-drop-container mb-4"><div class="water-drop-icon"></div><div class="water-drop-background" style="height: 7%;"></div></div><p class="text-5xl font-extrabold text-blue-600">7%</p><p class="text-slate-500 mt-2">حجم: حدود ۲ میلیون متر مکعب</p></div>
-                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد کارده</h3><div class="water-drop-container mb-4"><div class="water-drop-icon"></div><div class="water-drop-background" style="height: 0%;"></div></div><p class="text-5xl font-extrabold text-blue-600">—</p><p class="text-slate-500 mt-2">حجم: حدود ۵ میلیون متر مکعب</p></div>
-                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد ارداک</h3><div class="water-drop-container mb-4"><div class="water-drop-icon"></div><div class="water-drop-background" style="height: 0%;"></div></div><p class="text-5xl font-extrabold text-blue-600">—</p><p class="text-slate-500 mt-2">حجم: حدود ۴ میلیون متر مکعب</p></div>
+                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد دوستی</h3><div class="waffle mb-4" data-name="سد دوستی" data-pct="5" aria-label="پرشدگی سد دوستی 5 درصد"></div><p class="text-5xl font-extrabold text-blue-600">5%</p><p class="text-slate-500 mt-2">حجم: حدود ۶۵ میلیون متر مکعب</p><div class="mt-4 p-3 bg-amber-100 text-amber-800 rounded-lg text-sm font-semibold border border-amber-200"><i class="fas fa-exclamation-triangle mr-2"></i>نیمی از این حجم متعلق به ترکمنستان است.</div></div>
+                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد طرق</h3><div class="waffle mb-4" data-name="سد طرق" data-pct="7" aria-label="پرشدگی سد طرق 7 درصد"></div><p class="text-5xl font-extrabold text-blue-600">7%</p><p class="text-slate-500 mt-2">حجم: حدود ۲ میلیون متر مکعب</p></div>
+                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد کارده</h3><div class="waffle mb-4" data-name="سد کارده" data-pct="0" aria-label="پرشدگی سد کارده 0 درصد"></div><p class="text-5xl font-extrabold text-blue-600">—</p><p class="text-slate-500 mt-2">حجم: حدود ۵ میلیون متر مکعب</p></div>
+                <div class="card text-center" data-fa-digits><h3 class="text-2xl font-bold text-slate-700 mb-4">سد ارداک</h3><div class="waffle mb-4" data-name="سد ارداک" data-pct="0" aria-label="پرشدگی سد ارداک 0 درصد"></div><p class="text-5xl font-extrabold text-blue-600">—</p><p class="text-slate-500 mt-2">حجم: حدود ۴ میلیون متر مکعب</p></div>
             </div>
         </section>
         <section class="mb-12">
@@ -274,6 +279,26 @@
         </footer>
     </main>
     <div id="error-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4"><div class="bg-white p-6 rounded-lg shadow-lg max-w-sm mx-auto text-center"><div class="text-red-500 mb-4"><i class="fas fa-exclamation-circle fa-3x" aria-hidden="true"></i></div><h3 class="text-lg font-bold text-red-600 mb-2">خطا در ارتباط با سرور</h3><p id="error-message" class="text-slate-700">متاسفانه مشکلی در دریافت اطلاعات پیش آمد. لطفا دوباره تلاش کنید.</p><button id="close-modal-btn" type="button" class="mt-6 bg-red-500 text-white px-6 py-2 rounded-lg hover:bg-red-600 transition">بستن</button></div></div>
+    <script>
+(function(){
+  function renderWaffle(el){
+    const pct = Math.max(0, Math.min(100, Number(el.dataset.pct)||0));
+    const filled = Math.round(pct);
+    const frag = document.createDocumentFragment();
+    for(let i=0;i<100;i++){
+      const s=document.createElement('span');
+      if(i<filled) s.className='f';
+      frag.appendChild(s);
+    }
+    el.replaceChildren(frag);
+    if(pct < 15) el.dataset.state = 'alert';
+    else if(pct < 40) el.dataset.state = 'warn';
+    const name = el.dataset.name || 'سد';
+    el.setAttribute('aria-label', `پرشدگی ${name} ${pct} درصد`);
+  }
+  document.querySelectorAll('.waffle').forEach(renderWaffle);
+})();
+    </script>
     <script>
 (function(){
   function initSimulatorUI(){


### PR DESCRIPTION
## Summary
- swap water-drop graphics for 10×10 waffle charts in dam cards
- style waffle grid with responsive CSS and alert thresholds
- script renders waffles and sets accessible aria-labels

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a146542bcc8328a9055719dd32856b