### PR TITLE
refactor: desktop-first CSS with mobile overrides

### DIFF
--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -4,9 +4,9 @@
 /* ===== Base (desktop) styles ===== */
 .landing-logo {
   position: relative;
-  margin: 10px auto;
-  width: 40vw;
-  max-width: 400px;
+  margin: 20px auto;
+  width: 400px;
+  max-width: 100%;
   height: auto;
   object-fit: contain;
   display: block;
@@ -23,7 +23,7 @@
 @media (max-width: 768px) {
   .landing-logo {
     width: 60vw;
-    max-width: 60%;
+    max-width: 300px;
   }
 
   .welcome-text {

--- a/docs/water/water.css
+++ b/docs/water/water.css
@@ -7,6 +7,7 @@ body { background-color: #f0f4f8; }
   display: flex;
   gap: 1.5rem;
   flex-wrap: wrap;
+  justify-content: center;
 }
 
 .card {
@@ -16,7 +17,7 @@ body { background-color: #f0f4f8; }
   padding: 1.5rem;
   flex: 1;
   min-width: 0;
-  width: 280px;
+  width: 320px;
   max-width: 100%;
 }
 
@@ -36,8 +37,8 @@ body { background-color: #f0f4f8; }
 
 .water-drop-container {
   position: relative;
-  width: 100px;
-  height: 100px;
+  width: 150px;
+  height: 150px;
   margin: 0 auto;
 }
 
@@ -136,23 +137,36 @@ input[type=range]::-moz-range-thumb {
   position: fixed;
   top: 10px;
   right: 10px;
-  width: 120px;
+  width: 150px;
   height: auto;
-  max-width: 120px;
-  max-height: 120px;
+  max-width: 150px;
+  max-height: 150px;
   z-index: 1000;
 }
 
 /* ===== Mobile overrides ===== */
 @media (max-width: 768px) {
-  .card-row { flex-direction: column; }
-  .card { width: 100%; }
-  .site-logo { width: 25vw; }
+  .card-row {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .card {
+    width: 90%;
+  }
+
+  .site-logo {
+    position: static;
+    margin: 10px auto;
+    width: 35vw;
+    max-width: 120px;
+  }
+
   .water-drop-container {
-    width: 25vw;
-    height: 25vw;
-    max-width: 100px;
-    max-height: 100px;
+    width: 35vw;
+    height: 35vw;
+    max-width: 120px;
+    max-height: 120px;
   }
 }
 


### PR DESCRIPTION
## Summary
- enlarge landing logo and card layout for desktop view
- center and resize site logo and water drop on mobile via media queries
- ensure mobile overrides only apply at `max-width: 768px`

## Testing
- `npm test`
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68a14a688c448328b91312cb0a68a660