### PR TITLE
Refactor dash structure for modular dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,26 @@
 
 This repository hosts a simple dashboard served from the `/docs` directory and a proxy for Gemini API requests.
 
+## Dash application
+
+The interactive dashboards live in `/dash` and are organized by resource type:
+
+```
+/dash
+  /components       # shared UI pieces
+  /pages
+    /water
+      /water-crisis/water-crisis.js
+      /dam-monitoring/dam-monitoring.js
+      /bills-tariffs/bills-tariffs.js
+      /future-prediction/future-prediction.js
+    /electricity/electricity.js
+    /gas/gas.js
+    /oil/oil.js
+```
+
+`/dash/components` contains reusable pieces such as `Card`, `Header`, and `Footer` to avoid code duplication.  Routing is file based; paths mirror their folder names (e.g. `/water/water-crisis`).  New dashboards can be added by creating a folder and descriptive file under `/dash/pages`.
+
 ## GitHub Pages
 
 GitHub Pages is configured to deploy the `docs` directory. To use a custom subdomain:

--- a/dash/components/Card.js
+++ b/dash/components/Card.js
@@ -1,0 +1,7 @@
+export default function Card({ children }) {
+  return (
+    <div className="card">
+      {children}
+    </div>
+  );
+}

--- a/dash/components/Footer.js
+++ b/dash/components/Footer.js
@@ -1,0 +1,7 @@
+export default function Footer() {
+  return (
+    <footer>
+      <small>&copy; 2024 Utilities Dashboard</small>
+    </footer>
+  );
+}

--- a/dash/components/Header.js
+++ b/dash/components/Header.js
@@ -1,0 +1,7 @@
+export default function Header({ title }) {
+  return (
+    <header>
+      <h1>{title}</h1>
+    </header>
+  );
+}

--- a/dash/pages/electricity/electricity.js
+++ b/dash/pages/electricity/electricity.js
@@ -1,0 +1,17 @@
+import Header from '../../components/Header.js';
+import Footer from '../../components/Footer.js';
+import Card from '../../components/Card.js';
+
+export default function Electricity() {
+  return (
+    <>
+      <Header title="Electricity Dashboard" />
+      <main>
+        <Card>
+          Electricity dashboard content goes here.
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/dash/pages/gas/gas.js
+++ b/dash/pages/gas/gas.js
@@ -1,0 +1,17 @@
+import Header from '../../components/Header.js';
+import Footer from '../../components/Footer.js';
+import Card from '../../components/Card.js';
+
+export default function Gas() {
+  return (
+    <>
+      <Header title="Gas Dashboard" />
+      <main>
+        <Card>
+          Gas dashboard content goes here.
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/dash/pages/oil/oil.js
+++ b/dash/pages/oil/oil.js
@@ -1,0 +1,17 @@
+import Header from '../../components/Header.js';
+import Footer from '../../components/Footer.js';
+import Card from '../../components/Card.js';
+
+export default function Oil() {
+  return (
+    <>
+      <Header title="Oil Dashboard" />
+      <main>
+        <Card>
+          Oil dashboard content goes here.
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/dash/pages/water/bills-tariffs/bills-tariffs.js
+++ b/dash/pages/water/bills-tariffs/bills-tariffs.js
@@ -1,0 +1,17 @@
+import Header from '../../../components/Header.js';
+import Footer from '../../../components/Footer.js';
+import Card from '../../../components/Card.js';
+
+export default function BillsTariffs() {
+  return (
+    <>
+      <Header title="Bills and Tariffs" />
+      <main>
+        <Card>
+          Billing and tariff dashboard content goes here.
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/dash/pages/water/dam-monitoring/dam-monitoring.js
+++ b/dash/pages/water/dam-monitoring/dam-monitoring.js
@@ -1,0 +1,17 @@
+import Header from '../../../components/Header.js';
+import Footer from '../../../components/Footer.js';
+import Card from '../../../components/Card.js';
+
+export default function DamMonitoring() {
+  return (
+    <>
+      <Header title="Dam Monitoring" />
+      <main>
+        <Card>
+          Dam monitoring dashboard content goes here.
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/dash/pages/water/future-prediction/future-prediction.js
+++ b/dash/pages/water/future-prediction/future-prediction.js
@@ -1,0 +1,17 @@
+import Header from '../../../components/Header.js';
+import Footer from '../../../components/Footer.js';
+import Card from '../../../components/Card.js';
+
+export default function FuturePrediction() {
+  return (
+    <>
+      <Header title="Future Prediction" />
+      <main>
+        <Card>
+          Future prediction dashboard content goes here.
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/dash/pages/water/water-crisis/water-crisis.js
+++ b/dash/pages/water/water-crisis/water-crisis.js
@@ -1,0 +1,17 @@
+import Header from '../../../components/Header.js';
+import Footer from '../../../components/Footer.js';
+import Card from '../../../components/Card.js';
+
+export default function WaterCrisis() {
+  return (
+    <>
+      <Header title="Water Crisis" />
+      <main>
+        <Card>
+          Water crisis dashboard content goes here.
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/dash/routes.js
+++ b/dash/routes.js
@@ -1,0 +1,11 @@
+export const routes = {
+  water: {
+    crisis: '/water/water-crisis',
+    damMonitoring: '/water/dam-monitoring',
+    billsTariffs: '/water/bills-tariffs',
+    futurePrediction: '/water/future-prediction',
+  },
+  electricity: '/electricity/electricity',
+  gas: '/gas/gas',
+  oil: '/oil/oil',
+};


### PR DESCRIPTION
## Summary
- organize dashboards under `dash/pages` with dedicated folders for water, electricity, gas, and oil
- extract shared `Card`, `Header`, and `Footer` components into `dash/components`
- document new layout and routing map in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a155be482083289f3a441036ee0444