### PR TITLE
feat(water): add CTA link to cost calculator page

### DIFF
--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -304,6 +304,9 @@
                 </div>
             </div>
         </section>
+        <div class="text-center mt-8">
+            <a href="./cost-calculator.html" class="inline-block px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus:outline-none">باز کردن ماشین‌حساب قیمت تمام‌شده آب</a>
+        </div>
         <footer class="text-center mt-12 text-slate-500 text-sm">
             <p>کلیه حقوق مادی و معنوی این داشبورد متعلق به «خانه هم‌افزایی انرژی و آب استان خراسان رضوی» است. <span class="emoji-flag" role="img" aria-label="پرچم ایران">🇮🇷</span></p>
             <p>طراحی و تولید: خانه هم‌افزایی انرژی و آب خراسان رضوی</p>


### PR DESCRIPTION
## Summary
- add a centered CTA link to open the water cost calculator

## Testing
- `npm test`
- `npm run flag:test`


------
https://chatgpt.com/codex/tasks/task_e_68a15e21ea1c8328b5b24a13658e04c1