### PR TITLE
feat(water): add calculator UI, move logic to isolated JS with RTL/fa-IR fixes

### DIFF
--- a/docs/assets/water-cost.js
+++ b/docs/assets/water-cost.js
@@ -1,4 +1,153 @@
 (() => {
   'use strict';
-  // UI + logic will be injected in stage 3
+
+  const app = document.getElementById('water-cost-app');
+  if (!app) return;
+
+  const tomanFmt = v => new Intl.NumberFormat('fa-IR').format(Math.round(v));
+  const pctFmt = new Intl.NumberFormat('fa-IR', { maximumFractionDigits: 1 });
+
+  const c_production = document.getElementById('c_production');
+  const c_production_val = document.getElementById('c_production_val');
+  const c_maintenance = document.getElementById('c_maintenance');
+  const c_maintenance_val = document.getElementById('c_maintenance_val');
+  const p_loss = document.getElementById('p_loss');
+  const p_loss_val = document.getElementById('p_loss_val');
+  const c_energy = document.getElementById('c_energy');
+  const c_energy_val = document.getElementById('c_energy_val');
+  const p_power_outage = document.getElementById('p_power_outage');
+  const p_power_outage_val = document.getElementById('p_power_outage_val');
+
+  const realCostEl = document.getElementById('real_cost');
+  const finalPriceEl = document.getElementById('final_price');
+  const breakdownTable = document.getElementById('breakdown_table');
+  const costChartEl = document.getElementById('costChart');
+  const sensitivityTable = document.getElementById('sensitivity_table');
+  const summaryEl = document.getElementById('summary');
+
+  realCostEl.setAttribute('aria-live', 'polite');
+  finalPriceEl.setAttribute('aria-live', 'polite');
+
+  const hasChart = !!window.Chart;
+  if (hasChart) {
+    Chart.defaults.font.family = "'Vazirmatn', sans-serif";
+  }
+  let chart;
+
+  function updateDisplays() {
+    c_production_val.textContent = tomanFmt(c_production.value);
+    c_maintenance_val.textContent = tomanFmt(c_maintenance.value);
+    c_energy_val.textContent = tomanFmt(c_energy.value);
+    p_loss_val.textContent = p_loss.value;
+    p_power_outage_val.textContent = p_power_outage.value;
+  }
+
+  function calcCosts(vals) {
+    const base = vals.c_production + vals.c_maintenance + vals.c_energy;
+    const withLoss = base / (1 - vals.p_loss / 100);
+    const final = withLoss * (1 + vals.p_power_outage / 100);
+    return { real: withLoss, final };
+  }
+
+  function renderBreakdown(realCost, data) {
+    let html = '<thead><tr><th class="p-2">آیتم</th><th class="p-2">هزینه (تومان)</th><th class="p-2">درصد</th></tr></thead><tbody>';
+    data.forEach(item => {
+      const percentage = (item.value / realCost) * 100;
+      html += `<tr><td class="p-2">${item.label}</td><td class="p-2">${tomanFmt(item.value)}</td><td class="p-2">${pctFmt.format(percentage)}%</td></tr>`;
+    });
+    html += '</tbody>';
+    breakdownTable.innerHTML = html;
+  }
+
+  function renderChart(data) {
+    if (!hasChart) return;
+    const labels = data.map(i => i.label);
+    const values = data.map(i => i.value);
+    const colors = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6'];
+    if (!chart) {
+      chart = new Chart(costChartEl.getContext('2d'), {
+        type: 'pie',
+        data: { labels, datasets: [{ data: values, backgroundColor: colors }] },
+        options: { plugins: { legend: { position: 'bottom' } } }
+      });
+    } else {
+      chart.data.labels = labels;
+      chart.data.datasets[0].data = values;
+      chart.update();
+    }
+  }
+
+  function renderSensitivity(baseVals, baseFinal) {
+    const scenarios = [
+      { key: 'c_production', label: 'هزینه تولید', isPercent: false },
+      { key: 'c_maintenance', label: 'هزینه نگهداری', isPercent: false },
+      { key: 'c_energy', label: 'هزینه انرژی', isPercent: false },
+      { key: 'p_loss', label: 'تلفات شبکه', isPercent: true },
+      { key: 'p_power_outage', label: 'قطعی برق', isPercent: true }
+    ];
+    let html = '<thead><tr><th class="p-2">سناریو</th><th class="p-2">قیمت نهایی</th><th class="p-2">تغییر</th></tr></thead><tbody>';
+    scenarios.forEach(sc => {
+      const newVals = { ...baseVals };
+      newVals[sc.key] = baseVals[sc.key] * 1.1;
+      const { final } = calcCosts(newVals);
+      const change = final - baseFinal;
+      const percentageChange = (change / baseFinal) * 100;
+      const sign = change >= 0 ? '+' : '-';
+      const colorClass = change >= 0 ? 'text-red-600' : 'text-green-600';
+      html += `<tr><td class="p-2">+۱۰٪ ${sc.label}</td><td class="p-2">${tomanFmt(final)}</td><td class="p-2 font-semibold ${colorClass}">${sign} ${pctFmt.format(Math.abs(percentageChange))}% (${tomanFmt(Math.abs(change))} تومان)</td></tr>`;
+    });
+    html += '</tbody>';
+    sensitivityTable.innerHTML = html;
+  }
+
+  function renderSummary(realCost, finalPrice) {
+    summaryEl.textContent = `هزینه واقعی هر مترمکعب ${tomanFmt(realCost)} تومان و قیمت نهایی پیشنهادی ${tomanFmt(finalPrice)} تومان است.`;
+  }
+
+  function calculate() {
+    const vals = {
+      c_production: c_production.valueAsNumber,
+      c_maintenance: c_maintenance.valueAsNumber,
+      p_loss: p_loss.valueAsNumber,
+      c_energy: c_energy.valueAsNumber,
+      p_power_outage: p_power_outage.valueAsNumber
+    };
+    const { real, final } = calcCosts(vals);
+    realCostEl.textContent = tomanFmt(real);
+    finalPriceEl.textContent = tomanFmt(final);
+
+    const breakdownData = [
+      { label: 'هزینه تولید', value: vals.c_production },
+      { label: 'هزینه نگهداری', value: vals.c_maintenance },
+      { label: 'هزینه انرژی', value: vals.c_energy },
+      { label: 'تلفات شبکه', value: real - (vals.c_production + vals.c_maintenance + vals.c_energy) },
+      { label: 'قطعی برق', value: final - real }
+    ];
+
+    renderBreakdown(real, breakdownData);
+    renderChart(breakdownData);
+    renderSensitivity(vals, final);
+    renderSummary(real, final);
+  }
+
+  function debounce(fn, delay) {
+    let timer;
+    return (...args) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => fn(...args), delay);
+    };
+  }
+
+  const recalcDebounced = debounce(calculate, 200);
+  [c_production, c_maintenance, p_loss, c_energy, p_power_outage].forEach(inp => {
+    inp.addEventListener('input', () => {
+      updateDisplays();
+      recalcDebounced();
+    });
+  });
+
+  updateDisplays();
+  calculate();
+
+  window.WaterCost = { recalc: () => calculate() };
 })();

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -7,6 +7,25 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;700&display=swap" rel="stylesheet">
+    <style>
+      .input-group {
+        background: #fff;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+      }
+      .output-card {
+        background: #fff;
+        padding: 1rem;
+        border-radius: 0.5rem;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+        text-align: center;
+      }
+      .chart-container {
+        position: relative;
+        height: 300px;
+      }
+    </style>
   </head>
   <body class="bg-slate-50 text-slate-800 p-4 sm:p-6 md:p-8">
     <main class="max-w-7xl mx-auto" id="main">
@@ -14,7 +33,59 @@
         <h1 class="text-3xl md:text-4xl font-bold text-blue-600 mb-2">ماشین‌حساب پیشرفته قیمت تمام‌شده آب</h1>
         <p class="text-lg text-slate-600">تأثیر هر متغیر را بر هزینه واقعی و قیمت نهایی آب شرب تحلیل کنید.</p>
       </header>
-      <div id="water-cost-app"></div> <!-- UI goes here -->
+      <div id="water-cost-app">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+          <div class="input-group">
+            <label for="c_production" class="block mb-1">هزینه تولید هر مترمکعب (تومان)</label>
+            <input type="range" id="c_production" min="0" max="50000" step="500" value="10000" class="w-full">
+            <div class="text-sm text-slate-600"><span id="c_production_val">10,000</span> تومان</div>
+          </div>
+          <div class="input-group">
+            <label for="c_maintenance" class="block mb-1">هزینه نگهداری و تعمیرات (تومان)</label>
+            <input type="range" id="c_maintenance" min="0" max="20000" step="500" value="5000" class="w-full">
+            <div class="text-sm text-slate-600"><span id="c_maintenance_val">5,000</span> تومان</div>
+          </div>
+          <div class="input-group">
+            <label for="p_loss" class="block mb-1">درصد تلفات شبکه</label>
+            <input type="range" id="p_loss" min="0" max="50" step="1" value="20" class="w-full">
+            <div class="text-sm text-slate-600"><span id="p_loss_val">20</span>%</div>
+          </div>
+          <div class="input-group">
+            <label for="c_energy" class="block mb-1">هزینه انرژی (تومان)</label>
+            <input type="range" id="c_energy" min="0" max="30000" step="500" value="7000" class="w-full">
+            <div class="text-sm text-slate-600"><span id="c_energy_val">7,000</span> تومان</div>
+          </div>
+          <div class="input-group md:col-span-2">
+            <label for="p_power_outage" class="block mb-1">درصد تأثیر قطعی برق</label>
+            <input type="range" id="p_power_outage" min="0" max="20" step="1" value="5" class="w-full">
+            <div class="text-sm text-slate-600"><span id="p_power_outage_val">5</span>%</div>
+          </div>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
+          <div class="output-card">
+            <h2 class="font-semibold mb-2">هزینه واقعی هر مترمکعب</h2>
+            <p id="real_cost" class="text-2xl font-bold">۰</p>
+          </div>
+          <div class="output-card">
+            <h2 class="font-semibold mb-2">قیمت نهایی پیشنهادی</h2>
+            <p id="final_price" class="text-2xl font-bold text-blue-600">۰</p>
+          </div>
+        </div>
+
+        <div class="mb-8">
+          <h3 class="font-semibold mb-2">سهم هر بخش از هزینه</h3>
+          <table id="breakdown_table" class="min-w-full text-sm"></table>
+        </div>
+        <div class="chart-container mb-8">
+          <canvas id="costChart"></canvas>
+        </div>
+        <div class="mb-8">
+          <h3 class="font-semibold mb-2">تحلیل حساسیت</h3>
+          <table id="sensitivity_table" class="min-w-full text-sm"></table>
+        </div>
+        <p id="summary" class="text-sm text-slate-600"></p>
+      </div>
     </main>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.3/chart.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script defer src="../assets/water-cost.js"></script>


### PR DESCRIPTION
## Summary
- embed full calculator interface in docs/water/cost-calculator.html with styled inputs, outputs, tables and chart container
- migrate logic into docs/assets/water-cost.js, add fa-IR number formatting and percent formatter, debounce input events, guard Chart.js and expose recalc hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a15f347b9c83288c393c598a7af264