### PR TITLE
chore(electricity): add back link and ARIA labels to peak dashboard

### DIFF
--- a/docs/electricity/peak.html
+++ b/docs/electricity/peak.html
@@ -21,6 +21,7 @@
 </head>
 <body class="bg-slate-50 text-slate-800">
   <main id="main" class="container mx-auto p-4 space-y-8">
+    <a href="./" class="text-sm text-blue-600 hover:underline">بازگشت به صفحه برق</a>
     <h1 class="text-2xl mb-4">داشبورد پیک مصرف برق</h1>
     <section id="peak-load-dashboard" class="space-y-8">
       <!-- KPI Cards -->
@@ -47,12 +48,12 @@
 
       <!-- Realtime Chart -->
       <div class="chart-container bg-white rounded p-4">
-        <canvas id="realtime-chart"></canvas>
+        <canvas id="realtime-chart" aria-label="نمودار بار لحظه‌ای"></canvas>
       </div>
 
       <!-- Hourly Peak Chart -->
       <div class="chart-container bg-white rounded p-4">
-        <canvas id="hourly-peak-chart"></canvas>
+        <canvas id="hourly-peak-chart" aria-label="نمودار پیک ساعتی"></canvas>
       </div>
 
       <!-- Daily Peak Table -->
@@ -70,7 +71,7 @@
 
       <!-- Forecast Chart -->
       <div class="chart-container bg-white rounded p-4">
-        <canvas id="forecast-chart"></canvas>
+        <canvas id="forecast-chart" aria-label="نمودار پیش‌بینی"></canvas>
       </div>
     </section>
   </main>


### PR DESCRIPTION
## Summary
- add link to return to electricity page
- label charts for realtime, hourly peak, and forecast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16225018c8328bb3597ea36a65f26