### PR TITLE
feat(water): UX validation, debounced inputs, ARIA live regions

### DIFF
--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -62,6 +62,10 @@
           </div>
         </div>
 
+        <div class="text-center mb-8">
+          <button id="btn_defaults" type="button" class="px-4 py-2 bg-slate-200 rounded hover:bg-slate-300">مقادیر پیش‌فرض</button>
+        </div>
+
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
           <div class="output-card">
             <h2 class="font-semibold mb-2">هزینه واقعی هر مترمکعب</h2>


### PR DESCRIPTION
## Summary
- add "مقادیر پیش‌فرض" reset button and hook it into calculator
- validate input ranges with inline hints and clamp values
- reuse charts, cancel timers on unload, and announce results via ARIA live regions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a162b76f2c8328b72ede58db31cd91