### PR TITLE
feat(water): optional sensitivity chart when Chart.js is available

### DIFF
--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -88,6 +88,9 @@
         <div class="mb-8">
           <h3 class="font-semibold mb-2">تحلیل حساسیت</h3>
           <table id="sensitivity_table" class="min-w-full text-sm"></table>
+          <div class="chart-container mt-4">
+            <canvas id="sensitivityChart"></canvas>
+          </div>
         </div>
         <p id="summary" class="text-sm text-slate-600"></p>
       </div>


### PR DESCRIPTION
## Summary
- add sensitivity chart canvas to the water cost calculator page
- render sorted +10% scenario impacts in a horizontal bar chart when Chart.js is loaded

## Testing
- `npm test`
- `npm run flag:test`


------
https://chatgpt.com/codex/tasks/task_e_68a164bfb5bc83288f65bf8078e55589