### PR TITLE
feat(water): add hub page with two dashboard cards

### DIFF
--- a/docs/water/hub.html
+++ b/docs/water/hub.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>انتخاب داشبورد آب</title>
+  <link rel="stylesheet" href="../assets/tailwind.css">
+  <link rel="stylesheet" href="../assets/styles.css">
+  <!-- Vazirmatn -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-slate-50 text-slate-800 min-h-screen">
+  <main class="container mx-auto p-6 md:p-10" id="main">
+    <h1 class="text-3xl font-extrabold text-slate-700 mb-6 text-center">یک داشبورد انتخاب کنید</h1>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+      <!-- Card 1: Insights -->
+      <a href="./insights.html" class="block bg-white rounded-2xl shadow-sm p-6 hover:shadow-md transition">
+        <h2 class="text-xl font-bold text-slate-800 mb-2">داشبورد وضعیت و تحلیل آب</h2>
+        <p class="text-slate-600 mb-4">نمای کلی وضعیت، نمودارها و تحلیل روند مصرف/تأمین.</p>
+        <span class="inline-flex items-center gap-2 text-blue-600 font-semibold">باز کردن
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path d="M12.293 3.293a1 1 0 011.414 0L18 7.586a2 2 0 010 2.828l-6.293 6.293a1 1 0 01-1.414-1.414L14.586 11H4a1 1 0 110-2h10.586l-4.293-4.293a1 1 0 010-1.414z"/></svg>
+        </span>
+      </a>
+      <!-- Card 2: Cost Calculator -->
+      <a href="./cost-calculator.html" class="block bg-white rounded-2xl shadow-sm p-6 hover:shadow-md transition">
+        <h2 class="text-xl font-bold text-slate-800 mb-2">ماشین‌حساب قیمت تمام‌شده آب</h2>
+        <p class="text-slate-600 mb-4">محاسبه قیمت واقعی، سهم عوامل و تحلیل حساسیت.</p>
+        <span class="inline-flex items-center gap-2 text-blue-600 font-semibold">باز کردن
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path d="M12.293 3.293a1 1 0 011.414 0L18 7.586a2 2 0 010 2.828l-6.293 6.293a1 1 0 01-1.414-1.414L14.586 11H4a1 1 0 110-2h10.586l-4.293-4.293a1 1 0 010-1.414z"/></svg>
+        </span>
+      </a>
+    </div>
+    <div class="text-center mt-8">
+      <a href="../" class="text-slate-500 hover:text-slate-700 underline">بازگشت به صفحه اصلی</a>
+    </div>
+  </main>
+  <script>localStorage.setItem('sector','water');</script> <!-- small + safe -->
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `docs/water/hub.html` as a new Water Hub landing page
- link to insights and cost calculator dashboards with accessible cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a165e9d00c832887d842b241e216f5