### PR TITLE
chore(water): add navigation between hub and dashboards

### DIFF
--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -30,6 +30,7 @@
   </head>
   <body class="bg-slate-50 text-slate-800 p-4 sm:p-6 md:p-8">
     <main class="max-w-7xl mx-auto" id="main">
+      <a href="./hub.html" class="text-blue-600 hover:underline">بازگشت به انتخاب داشبورد</a>
       <header class="text-center mb-10">
         <h1 class="text-3xl md:text-4xl font-bold text-blue-600 mb-2">ماشین‌حساب پیشرفته قیمت تمام‌شده آب</h1>
         <p class="text-lg text-slate-600">تأثیر هر متغیر را بر هزینه واقعی و قیمت نهایی آب شرب تحلیل کنید.</p>

--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html lang="fa" dir="rtl">
 <head>
-    <base href="..">
     <meta charset="UTF-8">
     <meta http-equiv="Content-Language" content="fa-IR">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -13,18 +12,18 @@
     <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
     <title>داشبورد وضعیت آب مشهد (مجهز به Gemini)</title>
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%231f7aff'/%3E%3Cpath d='M20 36c8 4 16-4 24 0' stroke='white' stroke-width='4' fill='none'/%3E%3C/svg%3E" />
-    <link rel="stylesheet" href="assets/tailwind.css">
+    <link rel="stylesheet" href="../assets/tailwind.css">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="assets/styles.css">
-    <link rel="stylesheet" href="water/water.css">
+    <link rel="stylesheet" href="../assets/styles.css">
+    <link rel="stylesheet" href="./water.css">
 </head>
 <body class="p-4 sm:p-6 md:p-8">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
     <header class="w-full flex justify-center mt-4">
       <picture>
-        <source srcset="header2.avif" type="image/avif">
-        <source srcset="header2.webp" type="image/webp">
-        <img src="header2.jpg" alt="هدر سایت" class="max-w-full h-auto rounded-lg shadow-md" width="1584" height="396" loading="lazy">
+        <source srcset="../header2.avif" type="image/avif">
+        <source srcset="../header2.webp" type="image/webp">
+        <img src="../header2.jpg" alt="هدر سایت" class="max-w-full h-auto rounded-lg shadow-md" width="1584" height="396" loading="lazy">
       </picture>
     </header>
     <main id="main" class="max-w-7xl mx-auto">

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -26,12 +26,13 @@
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
     <header class="w-full flex justify-center mt-4">
       <picture>
-        <source srcset="header2.avif" type="image/avif">
-        <source srcset="header2.webp" type="image/webp">
-        <img src="header2.jpg" alt="هدر سایت" class="max-w-full h-auto rounded-lg shadow-md" width="1584" height="396" loading="lazy">
+        <source srcset="../header2.avif" type="image/avif">
+        <source srcset="../header2.webp" type="image/webp">
+        <img src="../header2.jpg" alt="هدر سایت" class="max-w-full h-auto rounded-lg shadow-md" width="1584" height="396" loading="lazy">
       </picture>
     </header>
     <main id="main" class="max-w-7xl mx-auto">
+        <a href="./hub.html" class="text-blue-600 hover:underline">بازگشت به انتخاب داشبورد</a>
         <header class="text-center mb-12">
             <h1 class="text-4xl md:text-5xl font-extrabold main-title">وضعیت بحرانی آب در مشهد</h1>
             <p class="text-slate-600 text-lg mt-4">آخرین بروزرسانی: شنبه 25مرداد ۱۴۰۴</p>


### PR DESCRIPTION
## Summary
- link water landing page to hub and correct asset paths
- add back links from insights and cost calculator dashboards to hub

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16b05ad288328aba9deac189e3069