### PR TITLE
feat(water): elevate KPI price cards and emphasize with accent backgrounds and large numerals

### DIFF
--- a/docs/assets/water-cost.js
+++ b/docs/assets/water-cost.js
@@ -24,6 +24,8 @@
 
   const realCostEl = document.getElementById('real_cost');
   const finalPriceEl = document.getElementById('final_price');
+  document.getElementById('real_cost')?.setAttribute('aria-live', 'polite');
+  document.getElementById('final_price')?.setAttribute('aria-live', 'polite');
   const breakdownTable = document.getElementById('breakdown_table');
   const costChartEl = document.getElementById('costChart');
   const sensitivityTable = document.getElementById('sensitivity_table');
@@ -38,8 +40,6 @@
     inp.insertAdjacentElement('afterend', hint);
   });
 
-  realCostEl.setAttribute('aria-live', 'polite');
-  finalPriceEl.setAttribute('aria-live', 'polite');
 
   const hasChart = !!window.Chart;
   if (hasChart) {

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -67,32 +67,45 @@
           <button id="btn_defaults" type="button" class="px-4 py-2 bg-slate-200 rounded hover:bg-slate-300">مقادیر پیش‌فرض</button>
         </div>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-8">
-          <div class="output-card">
-            <h2 class="font-semibold mb-2">هزینه واقعی هر مترمکعب</h2>
-            <p id="real_cost" class="text-2xl font-bold">۰</p>
+        <section id="outputs" class="space-y-8">
+          <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div class="rounded-xl p-5 bg-rose-50 border border-rose-100 shadow-sm">
+              <h3 class="text-base md:text-lg font-semibold text-rose-800">قیمت تمام‌شده واقعی</h3>
+              <p id="real_cost" class="mt-1 text-4xl md:text-5xl font-extrabold text-rose-600 tabular-nums">0</p>
+              <p class="text-sm text-slate-500 mt-1">تومان بر مترمکعب</p>
+            </div>
+            <div class="rounded-xl p-5 bg-emerald-50 border border-emerald-100 shadow-sm">
+              <h3 class="text-base md:text-lg font-semibold text-emerald-800">قیمت نهایی برای مصرف‌کننده</h3>
+              <p id="final_price" class="mt-1 text-4xl md:text-5xl font-extrabold text-emerald-600 tabular-nums">0</p>
+              <p class="text-sm text-slate-500 mt-1">تومان بر مترمکعب</p>
+            </div>
           </div>
-          <div class="output-card">
-            <h2 class="font-semibold mb-2">قیمت نهایی پیشنهادی</h2>
-            <p id="final_price" class="text-2xl font-bold text-blue-600">۰</p>
-          </div>
-        </div>
 
-        <div class="mb-8">
-          <h3 class="font-semibold mb-2">سهم هر بخش از هزینه</h3>
-          <table id="breakdown_table" class="min-w-full text-sm"></table>
-        </div>
-        <div class="chart-container mb-8">
-          <canvas id="costChart"></canvas>
-        </div>
-        <div class="mb-8">
-          <h3 class="font-semibold mb-2">تحلیل حساسیت</h3>
-          <table id="sensitivity_table" class="min-w-full text-sm"></table>
-          <div class="chart-container mt-4">
-            <canvas id="sensitivityChart"></canvas>
+          <div>
+            <h3 class="font-semibold mb-2">جدول سهم هر متغیر</h3>
+            <table id="breakdown_table" class="min-w-full text-sm"></table>
           </div>
-        </div>
-        <p id="summary" class="text-sm text-slate-600"></p>
+
+          <div>
+            <h3 class="font-semibold mb-2">نمودار دونات سهم عوامل</h3>
+            <div class="chart-container">
+              <canvas id="costChart"></canvas>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="font-semibold mb-2">تحلیل حساسیت</h3>
+            <table id="sensitivity_table" class="min-w-full text-sm"></table>
+            <div class="chart-container mt-4">
+              <canvas id="sensitivityChart"></canvas>
+            </div>
+          </div>
+
+          <div>
+            <h3 class="font-semibold mb-2">جمع‌بندی تحلیلی</h3>
+            <p id="summary" class="text-sm text-slate-600"></p>
+          </div>
+        </section>
       </div>
     </main>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.3/chart.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>


### PR DESCRIPTION
## Summary
- Promote real-cost and final-price cards to lead the outputs section with bold accent styling
- Organize remaining outputs sequentially: variable share table, donut chart, sensitivity analysis, and analytical summary
- Mark real and final price elements with `aria-live` for polite screen-reader updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a16b8e859c83289e529417645b4c89