### PR TITLE
Direct water link to /water/hub + remove intermediate page

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,0 +1,2 @@
+/water   /water/hub   301
+/water/  /water/hub   301

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,7 +24,7 @@
   <main id="main" class="w-full text-center space-y-12">
     <h1 class="welcome-text">به wesh360 خوش آمدید</h1>
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-3xl mx-auto">
-        <a href="water/" data-sector="water" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
+        <a href="/water/hub" data-sector="water" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
           <span class="text-5xl mb-4">💧</span>
           آب
         </a>

--- a/docs/water/index.html
+++ b/docs/water/index.html
@@ -1,48 +1,0 @@
-<!DOCTYPE html>
-<html lang="fa" dir="rtl">
-<head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Language" content="fa-IR">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta property="og:image" content="https://wesh360.ir/page/landing/logo2.jfif">
-    <meta property="og:image:secure_url" content="https://wesh360.ir/page/landing/logo2.jfif">
-    <meta property="og:image:type" content="image/jpeg">
-    <meta property="og:image:alt" content="wesh360 – تصویر شاخص صفحه">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
-    <title>داشبورد وضعیت آب مشهد (مجهز به Gemini)</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%231f7aff'/%3E%3Cpath d='M20 36c8 4 16-4 24 0' stroke='white' stroke-width='4' fill='none'/%3E%3C/svg%3E" />
-    <link rel="stylesheet" href="../assets/tailwind.css">
-    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="../assets/styles.css">
-    <link rel="stylesheet" href="./water.css">
-</head>
-<body class="p-4 sm:p-6 md:p-8">
-    <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-    <header class="w-full flex justify-center mt-4">
-      <picture>
-        <source srcset="../header2.avif" type="image/avif">
-        <source srcset="../header2.webp" type="image/webp">
-        <img src="../header2.jpg" alt="هدر سایت" class="max-w-full h-auto rounded-lg shadow-md" width="1584" height="396" loading="lazy">
-      </picture>
-    </header>
-    <main id="main" class="max-w-7xl mx-auto">
-        <header class="text-center mb-12">
-            <h1 class="text-4xl md:text-5xl font-extrabold main-title">وضعیت بحرانی آب در مشهد</h1>
-            <p class="text-slate-600 text-lg mt-4">آخرین بروزرسانی: شنبه 25مرداد ۱۴۰۴</p>
-        </header>
-        <div class="text-center my-12">
-            <a href="./hub.html" class="inline-block px-6 py-3 rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus:outline-none">انتخاب داشبورد</a>
-        </div>
-        <footer class="text-center mt-12 text-slate-500 text-sm">
-            <p>کلیه حقوق مادی و معنوی این داشبورد متعلق به «خانه هم‌افزایی انرژی و آب استان خراسان رضوی» است. <span class="emoji-flag" role="img" aria-label="پرچم ایران">🇮🇷</span></p>
-            <p>طراحی و تولید: خانه هم‌افزایی انرژی و آب خراسان رضوی</p>
-            <p>منبع داده‌ها: گزارش رسمی شرکت آب منطقه‌ای خراسان رضوی (سال ۱۴۰۴)</p>
-        </footer>
-    </main>
-    <script defer src="../assets/water-init.js"></script>
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/twemoji.min.js" integrity="sha512-3v3L9b5m9q2s0i6gQ0yq+8vJm3a6oI1mG2r3l0X3zv3Y6uFJq1Wc1q9kGmXlM3Yj6fxp2U7N7yqZtCz9D6Qy4A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <script defer src="/assets/emoji-flag.js"></script>
-    <script defer src="/assets/numfmt.js"></script>
-</body>
-</html>

--- a/scripts/check-flag.js
+++ b/scripts/check-flag.js
@@ -6,7 +6,7 @@ const path = require('path');
   const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'], ignoreHTTPSErrors: true });
   const page = await browser.newPage();
 
-  await page.goto('https://wesh360.ir/water/', { waitUntil: 'networkidle2' });
+  await page.goto('https://wesh360.ir/water/hub', { waitUntil: 'networkidle2' });
 
   // Scroll to bottom to trigger lazy content
   await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));


### PR DESCRIPTION
## Summary
- Link landing "آب" directly to water hub.
- Add Netlify redirects from `/water` and `/water/` to `/water/hub`.
- Remove intermediate page and update flag checker script.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a171e98ee88328be325d36b9d72f61