### PR TITLE
feat: enable responsive desktop layout for water insights

### DIFF
--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -31,13 +31,13 @@
         <img src="../header2.jpg" alt="هدر سایت" class="max-w-full h-auto rounded-lg shadow-md" width="1584" height="396" loading="lazy">
       </picture>
     </header>
-    <main id="main" class="max-w-7xl mx-auto">
+    <main id="main" class="dashboard">
         <a href="./hub.html" class="text-blue-600 hover:underline">بازگشت به انتخاب داشبورد</a>
         <header class="text-center mb-12">
             <h1 class="text-4xl md:text-5xl font-extrabold main-title">وضعیت بحرانی آب در مشهد</h1>
             <p class="text-slate-600 text-lg mt-4">آخرین بروزرسانی: شنبه 25مرداد ۱۴۰۴</p>
         </header>
-        <section class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-12">
+        <section class="cards mb-12">
             <div class="card days-left-card md:col-span-2 flex flex-col justify-center items-center text-center p-8" data-fa-digits>
                 <span class="text-5xl mb-4 opacity-75" aria-hidden="true">⏳</span>
                 <h2 class="text-2xl font-bold mb-2">روزهای باقی‌مانده تا روز صفر آبی</h2>
@@ -56,7 +56,7 @@
         </section>
         <section class="mb-12">
             <h2 class="text-3xl font-bold text-slate-800 text-center mb-8">پایش لحظه‌ای سدها</h2>
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div class="cards">
                 <div class="card text-center" data-fa-digits>
                     <h3 class="text-2xl font-bold text-slate-700 mb-4">سد دوستی</h3>
                     <div class="waffle mb-4" id="waffle-doosti"></div>
@@ -168,7 +168,7 @@
             </div>
         </section>
         <section class="mb-12">
-            <div class="card-row">
+            <div class="cards">
                 <div class="card stats-card" data-fa-digits>
                     <h2 class="text-2xl font-bold text-slate-800 text-center mb-6">آب ما کجا مصرف می‌شود؟</h2>
                     <div class="space-y-5">

--- a/docs/water/water.css
+++ b/docs/water/water.css
@@ -3,11 +3,16 @@ body { background-color: #f0f4f8; }
 
 .main-title { font-weight: 800; color: #1e3a8a; }
 
-.card-row {
-  display: flex;
+.dashboard {
+  max-width: 1200px;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: 1.5rem;
-  flex-wrap: wrap;
-  justify-content: center;
 }
 
 .card {
@@ -15,10 +20,7 @@ body { background-color: #f0f4f8; }
   border-radius: 18px;
   box-shadow: 0 8px 20px rgba(0, 0, 0, 0.05);
   padding: 1.5rem;
-  flex: 1;
-  min-width: 0;
-  width: 320px;
-  max-width: 100%;
+  width: 100%;
 }
 
 .footprint-card {
@@ -146,13 +148,13 @@ input[type=range]::-moz-range-thumb {
 
 /* ===== Mobile overrides ===== */
 @media (max-width: 768px) {
-  .card-row {
-    flex-direction: column;
-    align-items: center;
+  .cards {
+    grid-template-columns: 1fr;
+    max-width: 100%;
   }
 
   .card {
-    width: 90%;
+    width: 100%;
   }
 
   .site-logo {


### PR DESCRIPTION
## Summary
- switch water insights page to desktop-first layout using `.dashboard` and `.cards`
- allow multi-column cards with CSS grid and mobile-only stacking
- clean up fixed-width card styles for better scaling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a182e1817c832881ddcff9ee43dabf