### PR TITLE
fix: load local Chart.js for water cost calculator

### DIFF
--- a/docs/assets/cost-calculator.js
+++ b/docs/assets/cost-calculator.js
@@ -48,10 +48,11 @@
   });
 
 
-  const hasChart = !!window.Chart;
-  if (hasChart) {
-    Chart.defaults.font.family = "'Vazirmatn', sans-serif";
+  if (!window.Chart) {
+    console.error('Chart.js not loaded');
+    return;
   }
+  Chart.defaults.font.family = "'Vazirmatn', sans-serif";
   let chart;
   let sensitivityChart;
 
@@ -76,7 +77,6 @@
   }
 
   function renderChart(data) {
-    if (!hasChart) return;
     const labels = data.map(i => i.label);
     const values = data.map(i => i.value);
     const colors = ['#3b82f6', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6'];
@@ -147,7 +147,7 @@
     });
     sensitivityList.innerHTML = html;
 
-    if (hasChart && sensitivityChartEl) {
+    if (sensitivityChartEl) {
       const labels = results.map(r => `+۱۰٪ ${r.label}`);
       const data = results.map(r => r.percentageChange);
       if (!sensitivityChart) {

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -139,9 +139,9 @@
         </section>
       </div>
     </main>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.3/chart.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="../assets/libs/chart.umd.min.js"></script>
     <script defer src="../assets/numfmt.js"></script>
     <script defer src="../assets/water-init.js"></script>
-    <script defer src="../assets/water-cost.js"></script>
+    <script defer src="../assets/cost-calculator.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load Chart.js from local assets to comply with CSP
- rename and update cost calculator script to require Chart.js before running

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a18c99fc4c8328b6215b320284559a