### PR TITLE
feat: add gas & oil dashboard page (energy.html + energy.js)

### DIFF
--- a/docs/gas/energy.html
+++ b/docs/gas/energy.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Language" content="fa-IR" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta property="og:image" content="https://wesh360.ir/page/landing/logo2.jfif" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <title>داشبورد گاز و فرآورده‌های نفتی - wesh360</title>
+
+  <!-- استایل‌های محلی پروژه -->
+  <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="../assets/styles.css" />
+</head>
+<body class="min-h-screen bg-slate-900 text-slate-200 antialiased">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+
+  <div class="container mx-auto p-4 sm:p-6 lg:p-8">
+    <header class="mb-8">
+      <div class="flex flex-col md:flex-row justify-between items-center gap-4">
+        <div>
+          <h1 class="text-3xl font-extrabold text-white">داشبورد مدیریت انرژی</h1>
+          <p class="text-lg text-cyan-400 mt-1">استان خراسان رضوی (نمای عمومی)</p>
+        </div>
+        <a href="../" class="text-sm text-cyan-300 hover:underline">بازگشت به گاز</a>
+      </div>
+
+      <!-- فیلترها -->
+      <div class="mt-6 p-4 bg-slate-800/50 rounded-xl border border-slate-700 flex flex-wrap items-center justify-center gap-4">
+        <select id="timeFilter" class="filter-select bg-slate-700 text-white border-slate-600 rounded-lg px-3 py-2">
+          <option value="daily">روزانه</option>
+          <option value="weekly">هفتگی</option>
+          <option value="monthly" selected>ماهانه</option>
+          <option value="seasonal">فصلی</option>
+        </select>
+        <select id="cityFilter" class="filter-select bg-slate-700 text-white border-slate-600 rounded-lg px-3 py-2"></select>
+        <select id="productFilter" class="filter-select bg-slate-700 text-white border-slate-600 rounded-lg px-3 py-2">
+          <option value="all">همه فرآورده‌ها</option>
+          <option value="gasoline">بنزین</option>
+          <option value="diesel">گازوئیل</option>
+          <option value="lpg">گاز مایع</option>
+        </select>
+      </div>
+    </header>
+
+    <main id="main" class="space-y-8">
+      <!-- KPI ها -->
+      <section id="kpi-section">
+        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+          <div class="bg-slate-800 p-4 rounded-lg border border-slate-700 text-center">
+            <h3 class="text-sm text-slate-400">تراز گاز دیروز (MCM)</h3>
+            <p id="kpi-gas-balance" class="text-2xl font-extrabold text-green-400 mt-2">+۱.۵</p>
+          </div>
+          <div class="bg-slate-800 p-4 rounded-lg border border-slate-700 text-center">
+            <h3 class="text-sm text-slate-400">مصرف کل گاز دیروز (MCM)</h3>
+            <p id="kpi-gas-consumption" class="text-2xl font-extrabold text-cyan-400 mt-2">۲۲.۵</p>
+          </div>
+          <div class="bg-slate-800 p-4 rounded-lg border border-slate-700 text-center">
+            <h3 class="text-sm text-slate-400">پیک مصرف گاز (MCM/h)</h3>
+            <p id="kpi-gas-peak" class="text-2xl font-extrabold text-white mt-2">۱.۲ <span class="text-xs text-slate-500">@ ۲۰:۰۰</span></p>
+          </div>
+          <div class="bg-slate-800 p-4 rounded-lg border border-slate-700 text-center">
+            <h3 class="text-sm text-slate-400">ذخیره بنزین (Days of Cover)</h3>
+            <p id="kpi-gasoline-doc" class="text-2xl font-extrabold text-amber-400 mt-2">۱۵</p>
+          </div>
+          <div class="bg-slate-800 p-4 rounded-lg border border-slate-700 text-center">
+            <h3 class="text-sm text-slate-400">ذخیره گازوئیل (Days of Cover)</h3>
+            <p id="kpi-diesel-doc" class="text-2xl font-extrabold text-amber-400 mt-2">۲۱</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- وضعیت عمومی + نکته روز -->
+      <section id="public-info-section">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div class="bg-slate-800 p-5 rounded-lg border border-slate-700">
+            <h2 class="text-lg font-bold mb-4">وضعیت شبکه انرژی امروز</h2>
+            <div class="flex items-center justify-between">
+              <div class="flex items-center gap-3">
+                <span id="light-green" class="inline-block w-5 h-5 rounded-full bg-slate-600"></span>
+                <span id="light-yellow" class="inline-block w-5 h-5 rounded-full bg-slate-600"></span>
+                <span id="light-red" class="inline-block w-5 h-5 rounded-full bg-slate-600"></span>
+              </div>
+              <p id="network-status-text" class="text-base font-medium"></p>
+            </div>
+          </div>
+          <div class="bg-slate-800 p-5 rounded-lg border border-slate-700">
+            <h2 class="text-lg font-bold mb-4">نکته روز برای صرفه‌جویی</h2>
+            <p id="saving-tip-text" class="text-slate-300 leading-relaxed"></p>
+          </div>
+        </div>
+      </section>
+
+      <!-- محاسبه‌گر مصرف -->
+      <section id="consumption-calculator-section" class="bg-slate-800 p-6 rounded-lg border border-slate-700">
+        <h2 class="text-xl font-bold mb-4 text-center text-cyan-400">مصرف گاز خانگی خود را بسنجید</h2>
+        <div class="flex flex-col md:flex-row items-center justify-center gap-4">
+          <input type="number" id="user-consumption-input" placeholder="مصرف گاز ماهانه (متر مکعب)" class="bg-slate-700 text-white border-slate-600 rounded-lg px-4 py-2 text-center w-full md:w-64 focus:ring-2 focus:ring-cyan-500 focus:outline-none">
+          <button id="calculate-btn" class="bg-cyan-600 hover:bg-cyan-500 text-white font-bold py-2 px-6 rounded-lg transition-colors w-full md:w-auto">محاسبه کن</button>
+        </div>
+        <div id="calculator-result" class="mt-5 text-center min-h-[50px]"></div>
+      </section>
+
+      <!-- نمودارها -->
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div class="bg-slate-800 p-4 rounded-xl border border-slate-700">
+          <div class="flex justify-between items-center mb-4">
+            <h2 class="text-lg font-bold">نمودار آبشاری تراز گاز (MCM)</h2>
+            <div id="gas-balance-badge" class="widget-badge text-xs"></div>
+          </div>
+          <div class="h-80"><canvas id="gasBalanceWaterfallChart"></canvas></div>
+        </div>
+        <div class="bg-slate-800 p-4 rounded-xl border border-slate-700">
+          <div class="flex justify-between items-center mb-4">
+            <h2 class="text-lg font-bold">سهم بخش‌ها از مصرف گاز</h2>
+            <div id="gas-share-badge" class="widget-badge text-xs"></div>
+          </div>
+          <div class="h-80"><canvas id="gasConsumptionShareChart"></canvas></div>
+        </div>
+        <div class="bg-slate-800 p-4 rounded-xl border border-slate-700">
+          <div class="flex justify-between items-center mb-4">
+            <h2 class="text-lg font-bold">تأمین فرآورده‌ها (هزار لیتر)</h2>
+            <div id="product-supply-badge" class="widget-badge text-xs"></div>
+          </div>
+          <div class="h-80"><canvas id="productSupplyChart"></canvas></div>
+        </div>
+        <div class="bg-slate-800 p-4 rounded-xl border border-slate-700">
+          <div class="flex justify-between items-center mb-4">
+            <h2 class="text-lg font-bold">روند مصرف ۲۴ ماه گذشته</h2>
+            <div id="long-trend-badge" class="widget-badge text-xs"></div>
+          </div>
+          <div class="h-80"><canvas id="longTermTrendChart"></canvas></div>
+        </div>
+      </div>
+    </main>
+
+    <footer class="text-center mt-12 py-4 border-t border-slate-700">
+      <p class="text-slate-500 text-sm">&copy; ۱۴۰۳ - سامانه هوشمند مدیریت انرژی استان خراسان رضوی</p>
+    </footer>
+  </div>
+
+  <!-- کتابخانه‌ها و اسکریپت‌ها (محلی) -->
+  <script defer src="../assets/libs/chart.umd.min.js"></script>
+  <script defer src="/assets/numfmt.js"></script>
+  <script defer src="./energy.js"></script>
+</body>
+</html>

--- a/docs/gas/energy.js
+++ b/docs/gas/energy.js
@@ -1,0 +1,6 @@
+'use strict';
+
+// Placeholder script for energy dashboard
+localStorage.setItem('sector', 'gas');
+
+console.log('energy dashboard initialized');

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -18,6 +18,7 @@
   <main id="main" class="text-center space-y-6">
     <h1 class="text-3xl font-extrabold text-slate-700">صفحه گاز و فرآورده‌های نفتی</h1>
     <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
+    <a href="./energy.html" class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">مشاهده داشبورد مدیریت انرژی</a>
     <a href="../" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>
   </main>
   <script defer src="index.js"></script>


### PR DESCRIPTION
## Summary
- add gas & oil dashboard page using local Tailwind CSS and scripts
- stub energy.js to initialize gas sector
- link gas index page to new dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a1d44c370c832893edaff12df47cb4