### PR TITLE
feat(water-select): modern 2-card layout with gradient bg, icons, mini-KPIs and animated wave

### DIFF
--- a/docs/water/hub.backup.html
+++ b/docs/water/hub.backup.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>انتخاب داشبورد آب</title>
+  <link rel="stylesheet" href="../assets/tailwind.css">
+  <link rel="stylesheet" href="../assets/styles.css">
+  <!-- Vazirmatn -->
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;700&display=swap" rel="stylesheet">
+</head>
+<body class="bg-slate-50 text-slate-800 min-h-screen">
+  <main class="container mx-auto p-6 md:p-10" id="main">
+    <h1 class="text-3xl font-extrabold text-slate-700 mb-6 text-center">یک داشبورد انتخاب کنید</h1>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+      <!-- Card 1: Insights -->
+      <a href="./insights.html" class="block bg-white rounded-2xl shadow-sm p-6 hover:shadow-md transition">
+        <h2 class="text-xl font-bold text-slate-800 mb-2">داشبورد وضعیت و تحلیل آب</h2>
+        <p class="text-slate-600 mb-4">نمای کلی وضعیت، نمودارها و تحلیل روند مصرف/تأمین.</p>
+        <span class="inline-flex items-center gap-2 text-blue-600 font-semibold">باز کردن
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path d="M12.293 3.293a1 1 0 011.414 0L18 7.586a2 2 0 010 2.828l-6.293 6.293a1 1 0 01-1.414-1.414L14.586 11H4a1 1 0 110-2h10.586l-4.293-4.293a1 1 0 010-1.414z"/></svg>
+        </span>
+      </a>
+      <!-- Card 2: Cost Calculator -->
+      <a href="./cost-calculator.html" class="block bg-white rounded-2xl shadow-sm p-6 hover:shadow-md transition">
+        <h2 class="text-xl font-bold text-slate-800 mb-2">ماشین‌حساب قیمت تمام‌شده آب</h2>
+        <p class="text-slate-600 mb-4">محاسبه قیمت واقعی، سهم عوامل و تحلیل حساسیت.</p>
+        <span class="inline-flex items-center gap-2 text-blue-600 font-semibold">باز کردن
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path d="M12.293 3.293a1 1 0 011.414 0L18 7.586a2 2 0 010 2.828l-6.293 6.293a1 1 0 01-1.414-1.414L14.586 11H4a1 1 0 110-2h10.586l-4.293-4.293a1 1 0 010-1.414z"/></svg>
+        </span>
+      </a>
+    </div>
+    <div class="text-center mt-8">
+      <a href="../" class="text-slate-500 hover:text-slate-700 underline">بازگشت به صفحه اصلی</a>
+    </div>
+  </main>
+  <script defer src="../assets/water-init.js"></script>
+</body>
+</html>

--- a/docs/water/hub.html
+++ b/docs/water/hub.html
@@ -4,38 +4,69 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>انتخاب داشبورد آب</title>
-  <link rel="stylesheet" href="../assets/tailwind.css">
+  <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="../assets/styles.css">
   <!-- Vazirmatn -->
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Vazirmatn:wght@300;400;500;700&display=swap" rel="stylesheet">
+  <style>
+    @keyframes float { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-6px)} }
+  </style>
 </head>
-<body class="bg-slate-50 text-slate-800 min-h-screen">
-  <main class="container mx-auto p-6 md:p-10" id="main">
-    <h1 class="text-3xl font-extrabold text-slate-700 mb-6 text-center">یک داشبورد انتخاب کنید</h1>
-    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 max-w-4xl mx-auto">
+<body class="bg-gradient-to-b from-slate-50 via-sky-50/60 to-white text-slate-800 min-h-screen relative overflow-hidden text-sm md:text-base">
+  <main class="max-w-6xl mx-auto px-4 py-10 md:py-14">
+    <h1 class="text-2xl md:text-3xl font-bold text-slate-800 text-center">یک داشبورد انتخاب کنید</h1>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mt-10">
       <!-- Card 1: Insights -->
-      <a href="./insights.html" class="block bg-white rounded-2xl shadow-sm p-6 hover:shadow-md transition">
-        <h2 class="text-xl font-bold text-slate-800 mb-2">داشبورد وضعیت و تحلیل آب</h2>
-        <p class="text-slate-600 mb-4">نمای کلی وضعیت، نمودارها و تحلیل روند مصرف/تأمین.</p>
-        <span class="inline-flex items-center gap-2 text-blue-600 font-semibold">باز کردن
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path d="M12.293 3.293a1 1 0 011.414 0L18 7.586a2 2 0 010 2.828l-6.293 6.293a1 1 0 01-1.414-1.414L14.586 11H4a1 1 0 110-2h10.586l-4.293-4.293a1 1 0 010-1.414z"/></svg>
-        </span>
-      </a>
+      <article class="relative rounded-2xl p-6 md:p-8 bg-white/80 backdrop-blur shadow-lg hover:shadow-xl border border-slate-100 transition-all duration-300 hover:-translate-y-1">
+        <div class="flex items-start gap-4">
+          <span class="shrink-0 grid place-items-center w-12 h-12 rounded-xl bg-gradient-to-br from-sky-500 to-cyan-500 text-white">
+            <svg class="w-7 h-7" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 2.25C9 6 6.75 8.6 6.75 11.25a5.25 5.25 0 1010.5 0c0-2.65-2.25-5.25-4.5-9" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </span>
+          <div>
+            <h2 class="text-lg md:text-xl font-semibold text-slate-900">داشبورد وضعیت و تحلیل آب</h2>
+            <p class="mt-2 text-slate-600 leading-7">نمای کلی وضعیت، نمودارها و تحلیل روند مصرف/تأمین.</p>
+            <div class="mt-4 flex items-center gap-3">
+              <svg class="w-14 h-14" viewBox="0 0 36 36" aria-label="نرخ پرشدگی نمونه">
+                <circle cx="18" cy="18" r="16" fill="none" stroke="#E5E7EB" stroke-width="4"></circle>
+                <circle cx="18" cy="18" r="16" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" class="text-sky-500" stroke-dasharray="100" stroke-dashoffset="28"></circle>
+                <text x="18" y="20" text-anchor="middle" class="text-[10px] fill-slate-700">72%</text>
+              </svg>
+              <span class="text-xs text-slate-500">پرشدگی مخازن (نمونه)</span>
+            </div>
+            <a href="./insights.html" aria-label="شروع داشبورد وضعیت و تحلیل آب" class="inline-flex items-center gap-2 mt-5 rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-500 to-cyan-500 shadow-lg hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-sky-400/50">
+              شروع کن
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </a>
+          </div>
+        </div>
+      </article>
       <!-- Card 2: Cost Calculator -->
-      <a href="./cost-calculator.html" class="block bg-white rounded-2xl shadow-sm p-6 hover:shadow-md transition">
-        <h2 class="text-xl font-bold text-slate-800 mb-2">ماشین‌حساب قیمت تمام‌شده آب</h2>
-        <p class="text-slate-600 mb-4">محاسبه قیمت واقعی، سهم عوامل و تحلیل حساسیت.</p>
-        <span class="inline-flex items-center gap-2 text-blue-600 font-semibold">باز کردن
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor"><path d="M12.293 3.293a1 1 0 011.414 0L18 7.586a2 2 0 010 2.828l-6.293 6.293a1 1 0 01-1.414-1.414L14.586 11H4a1 1 0 110-2h10.586l-4.293-4.293a1 1 0 010-1.414z"/></svg>
-        </span>
-      </a>
+      <article class="relative rounded-2xl p-6 md:p-8 bg-white/80 backdrop-blur shadow-lg hover:shadow-xl border border-slate-100 transition-all duration-300 hover:-translate-y-1">
+        <div class="flex items-start gap-4">
+          <span class="shrink-0 grid place-items-center w-12 h-12 rounded-xl bg-gradient-to-br from-violet-500 to-fuchsia-500 text-white">
+            <svg class="w-7 h-7" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M4 7h16M4 11h16M4 15h16M4 19h16" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M8 3v4M16 3v4M8 11v8M16 11v8" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
+          </span>
+          <div>
+            <h2 class="text-lg md:text-xl font-semibold text-slate-900">ماشین‌حساب قیمت تمام‌شده آب</h2>
+            <p class="mt-2 text-slate-600 leading-7">محاسبه قیمت واقعی، سهم عوامل و تحلیل حساسیت.</p>
+            <div class="mt-4">
+              <span class="text-xs rounded-full px-2 py-1 bg-slate-100 text-slate-700">میانگین نمونه: ۲,۵۰۰ تومان/م³</span>
+            </div>
+            <a href="./cost-calculator.html" aria-label="شروع ماشین‌حساب قیمت تمام‌شده آب" class="inline-flex items-center gap-2 mt-5 rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-violet-500 to-fuchsia-500 shadow-lg hover:shadow-xl transition-all focus:outline-none focus:ring-2 focus:ring-violet-400/50">
+              شروع کن
+              <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+            </a>
+          </div>
+        </div>
+      </article>
     </div>
-    <div class="text-center mt-8">
-      <a href="../" class="text-slate-500 hover:text-slate-700 underline">بازگشت به صفحه اصلی</a>
+    <div class="text-center mt-12">
+      <a href="../" class="text-slate-500 hover:text-slate-700 underline underline-offset-4">بازگشت به صفحه اصلی</a>
     </div>
   </main>
+  <svg class="absolute bottom-0 left-0 w-full opacity-30 text-sky-200 pointer-events-none animate-[float_12s_ease-in-out_infinite]" viewBox="0 0 1440 320" aria-hidden="true"><path fill="currentColor" d="M0 224L48 218.7C96 213 192 203 288 176C384 149 480 107 576 117.3C672 128 768 192 864 213.3C960 235 1056 213 1152 208C1248 203 1344 213 1392 218.7L1440 224V320H1392C1344 320 1248 320 1152 320C1056 320 960 320 864 320C768 320 672 320 576 320C480 320 384 320 288 320C192 320 96 320 48 320H0Z"></path></svg>
   <script defer src="../assets/water-init.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- modernize water dashboard selection page with Tailwind CDN, gradient background and animated wave
- add two responsive cards with SVG icons, mini KPIs and rounded CTA buttons

### Screenshots
| before | after |
| -- | -- |
| _TODO: add before screenshot_ | _TODO: add after screenshot_ |

### Checklist
- [x] Tailwind CDN added and gradient page background
- [x] Two-card responsive grid with icons and hover transitions
- [x] Water insights card includes circular progress KPI
- [x] Cost calculator card shows sample badge KPI
- [x] Animated wave footer and home navigation link


------
https://chatgpt.com/codex/tasks/task_e_68a1ded8e3ac83288f2b4331f408c2f1