### PR TITLE
chore(power): polish tariff dashboard — lazy load pdf deps, fix IDs, add headers proposal

### DIFF
--- a/dash/assets/js/power-tariff.js
+++ b/dash/assets/js/power-tariff.js
@@ -114,9 +114,10 @@ function analyzeConsumption() {
 
 async function loadPdfLibs() {
   try {
-    const html2canvas = (await import('https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js')).default;
-    const jsPDF = (await import('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js')).jsPDF;
-    return { html2canvas, jsPDF };
+    const hMod = await import('https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js');
+    const jMod = await import('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js');
+    if (!hMod?.default || !jMod?.jsPDF) throw new Error('dynamic import failed');
+    return { html2canvas: hMod.default, jsPDF: jMod.jsPDF };
   } catch (e) {
     return new Promise(resolve => {
       const h = document.createElement('script');
@@ -135,7 +136,7 @@ async function loadPdfLibs() {
 async function downloadBillAsPDF() {
   const libs = await loadPdfLibs();
   const element = document.getElementById('etf-bill-to-print');
-  const canvas = await libs.html2canvas(element);
+  const canvas = await libs.html2canvas(element, { useCORS: true, scale: 2 });
   const img = canvas.toDataURL('image/png');
   const pdf = new libs.jsPDF('p', 'mm', 'a4');
   const width = pdf.internal.pageSize.getWidth();

--- a/dash/pages/power/power-tariff.html
+++ b/dash/pages/power/power-tariff.html
@@ -18,6 +18,11 @@
         <p class="mt-3 text-lg text-slate-600 max-w-2xl mx-auto">مصرف خود را تحلیل کن، قبض ماه بعدت را شبیه‌سازی کن و راهکارهای بهینه را پیدا کن.</p>
     </header>
 
+    <!-- Placeholder for removed power tariff screenshots -->
+    <div class="aspect-[16/9] w-full rounded-xl bg-gradient-to-br from-slate-800 to-slate-700 flex items-center justify-center text-slate-300 text-sm select-none mb-10">
+      پیش‌نمایش داشبورد تعرفه برق (تصویر حذف شد)
+    </div>
+
     <!-- Tabs Navigation -->
     <div class="mb-10 p-1.5 bg-slate-200 rounded-full flex max-w-md mx-auto">
         <button class="etf-tab-btn etf-active flex-1 py-2 px-4 rounded-full transition-all duration-300 text-slate-600" data-tab="tariffs">تعرفه‌ها</button>

--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -18,6 +18,9 @@
   <main id="main" class="text-center space-y-6">
     <h1 class="text-3xl font-extrabold text-slate-700">صفحه برق</h1>
     <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
+    <div class="aspect-[16/9] w-full rounded-xl bg-gradient-to-br from-slate-800 to-slate-700 flex items-center justify-center text-slate-300 text-sm select-none my-4">
+      پیش‌نمایش صفحه برق (تصویر حذف شد)
+    </div>
     <a href="./peak.html" class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">مشاهده داشبورد مدیریت مصرف برق</a>
     <a href="/dash/pages/power/power-tariff.html" class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700">تحلیل و شبیه‌سازی قبض (تعرفه‌ها)</a>
     <a href="../" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,20 @@
   to = "/.netlify/functions/:splat"
   status = 200
 
+[[headers]]
+for = "/docs/fonts/vazirmatn/*"
+  [headers.values]
+  Access-Control-Allow-Origin = "*"
+  Cache-Control = "public, max-age=31536000, immutable"
+
+[[headers]]
+for = "/assets/images/*"
+  [headers.values]
+  Cache-Control = "public, max-age=31536000, immutable"
+  Access-Control-Allow-Origin = "*"
+
+[[headers]]
+for = "/*.woff2"
+  [headers.values]
+  Cache-Control = "public, max-age=31536000, immutable"
+

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build:css": "tailwindcss -i docs/assets/tailwind.input.css -o docs/assets/tailwind.css --minify",
     "test": "echo \"No tests\"",
-    "flag:test": "node scripts/check-flag.js"
+    "flag:test": "node scripts/check-flag.js",
+    "check:no-binary": "node tools/check-no-binary.js"
   },
   "keywords": [],
   "author": "",

--- a/tools/check-no-binary.js
+++ b/tools/check-no-binary.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const exts = ['png','jpg','jpeg','webp','gif','svg','woff','woff2','ttf','otf','pdf','zip'];
+let diff;
+try {
+  diff = execSync('git diff --cached --name-only --diff-filter=A', {encoding: 'utf8'});
+} catch (e) {
+  diff = '';
+}
+const files = diff.split('\n').filter(Boolean);
+const matches = files.filter(f => exts.some(ext => f.toLowerCase().endsWith('.' + ext)));
+if (matches.length) {
+  console.error('Warning: newly added binary files detected:\n' + matches.join('\n'));
+  process.exitCode = 1;
+} else {
+  console.log('No newly-added binary files detected.');
+}


### PR DESCRIPTION
## Summary
- lazy load html2canvas and jsPDF only on demand with runtime fallback
- add Netlify headers for local fonts/woff2 caching
- replace power dashboard PNG screenshots with lightweight gradient placeholders and remove binary assets
- introduce `check:no-binary` script to warn on committed binary blobs

## Testing
- `rg -l "power-tariff.png"` (no matches)
- `rg -l "power-tariff-mobile.png"` (no matches)
- `rg -l "electricity_index.png"` (no matches)
- `npm run check:no-binary`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1ddf263d483288146982203a909f5