### PR TITLE
feat(landing): modern hero/grid/KPIs/CTA using existing header2.webp & logo2.webp (zero-binary)

### DIFF
--- a/docs/index.backup.html
+++ b/docs/index.backup.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Language" content="fa-IR" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta property="og:image" content="https://wesh360.ir/page/landing/logo2.jfif" />
+  <meta property="og:image:secure_url" content="https://wesh360.ir/page/landing/logo2.jfif" />
+  <meta property="og:image:type" content="image/jpeg" />
+  <meta property="og:image:alt" content="wesh360 – تصویر شاخص صفحه" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif" />
+  <title>wesh360</title>
+    <link rel="stylesheet" href="assets/tailwind.css" />
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="stylesheet" href="page/landing/landing.css" /></head>
+<body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <picture>
+    <source srcset="page/landing/logo2.avif" type="image/avif">
+    <source srcset="page/landing/logo2.webp" type="image/webp">
+    <img src="page/landing/logo2.jfif" alt="لوگوی سایت" class="landing-logo max-w-full h-auto object-contain block" loading="lazy">
+  </picture>
+  <main id="main" class="w-full text-center space-y-12">
+    <h1 class="welcome-text">به wesh360 خوش آمدید</h1>
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-3xl mx-auto">
+        <a href="/water/hub" data-sector="water" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
+          <span class="text-5xl mb-4">💧</span>
+          آب
+        </a>
+        <a href="electricity/" data-sector="electricity" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
+          <span class="text-5xl mb-4">⚡</span>
+          برق
+        </a>
+        <a href="gas/energy.html" data-sector="gas" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
+          <span class="text-5xl mb-4">🛢</span>
+          گاز و فرآورده‌های نفتی
+        </a>
+      </div>
+      <a id="quick-entry" href="#" class="hidden landing-option bg-blue-600 text-white rounded-xl py-4 px-8 inline-block font-bold"></a>
+  </main>
+  <div id="curtain" class="curtain hidden"><div class="curtain-half left"></div><div class="curtain-half right"></div></div>
+  <script defer src="index.js"></script>
+  <script defer src="assets/numfmt.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,42 +4,77 @@
   <meta charset="UTF-8" />
   <meta http-equiv="Content-Language" content="fa-IR" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <meta property="og:image" content="https://wesh360.ir/page/landing/logo2.jfif" />
-  <meta property="og:image:secure_url" content="https://wesh360.ir/page/landing/logo2.jfif" />
-  <meta property="og:image:type" content="image/jpeg" />
+  <meta property="og:image" content="header2.webp" />
   <meta property="og:image:alt" content="wesh360 – تصویر شاخص صفحه" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif" />
+  <meta name="twitter:image" content="header2.webp" />
   <title>wesh360</title>
-    <link rel="stylesheet" href="assets/tailwind.css" />
-    <link rel="stylesheet" href="assets/styles.css" />
-    <link rel="stylesheet" href="page/landing/landing.css" /></head>
-<body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
+  <link rel="stylesheet" href="assets/tailwind.css" />
+  <link rel="stylesheet" href="assets/styles.css" />
+</head>
+<body class="min-h-screen flex flex-col bg-gradient-to-b from-slate-50 via-sky-50/70 to-white">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-  <picture>
-    <source srcset="page/landing/logo2.avif" type="image/avif">
-    <source srcset="page/landing/logo2.webp" type="image/webp">
-    <img src="page/landing/logo2.jfif" alt="لوگوی سایت" class="landing-logo max-w-full h-auto object-contain block" loading="lazy">
-  </picture>
-  <main id="main" class="w-full text-center space-y-12">
-    <h1 class="welcome-text">به wesh360 خوش آمدید</h1>
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-3xl mx-auto">
-        <a href="/water/hub" data-sector="water" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
-          <span class="text-5xl mb-4">💧</span>
-          آب
-        </a>
-        <a href="electricity/" data-sector="electricity" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
-          <span class="text-5xl mb-4">⚡</span>
-          برق
-        </a>
-        <a href="gas/energy.html" data-sector="gas" class="landing-option bg-white rounded-xl p-8 flex flex-col items-center text-lg font-bold text-slate-700">
-          <span class="text-5xl mb-4">🛢</span>
-          گاز و فرآورده‌های نفتی
-        </a>
+  <header class="p-4 flex justify-center">
+    <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
+  </header>
+  <main id="main" class="flex-grow space-y-14">
+    <section class="text-center max-w-6xl mx-auto px-4 py-10 md:py-14">
+      <img src="header2.webp" alt="هدر wesh360" decoding="async" loading="lazy" class="w-full h-auto max-h-[320px] object-contain mx-auto" />
+      <h1 class="mt-6 text-2xl md:text-4xl font-extrabold text-slate-900">پلتفرم داده و مدیریت انرژی و آب خراسان رضوی</h1>
+      <p class="mt-3 md:mt-4 text-slate-600 md:text-lg">داده‌های هوشمند برای مدیریت پایدار منابع</p>
+    </section>
+    <section class="max-w-6xl mx-auto px-4">
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-7">
+        <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col">
+          <svg class="w-12 h-12 text-sky-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C8 6.5 5 10.5 5 14a7 7 0 1 0 14 0c0-3.5-3-7.5-7-12z"/></svg>
+          <h2 class="text-lg font-semibold text-slate-900 mb-2">آب</h2>
+          <p class="text-slate-600 text-sm flex-grow">پایش و مدیریت منابع آبی استان.</p>
+          <a href="/water/hub" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
+        </article>
+        <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col">
+          <svg class="w-12 h-12 text-yellow-500 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13 2L3 14h7v8l10-12h-7z"/></svg>
+          <h2 class="text-lg font-semibold text-slate-900 mb-2">برق</h2>
+          <p class="text-slate-600 text-sm flex-grow">رصد مصرف و تولید برق.</p>
+          <a href="electricity/" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
+        </article>
+        <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col">
+          <svg class="w-12 h-12 text-amber-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C10 5 7 8.9 7 13a5 5 0 0 0 10 0c0-4.1-3-8-5-11z"/></svg>
+          <h2 class="text-lg font-semibold text-slate-900 mb-2">گاز و فرآورده‌ها</h2>
+          <p class="text-slate-600 text-sm flex-grow">اطلاعات شبکه گاز و فرآورده‌های نفتی.</p>
+          <a href="gas/energy.html" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
+        </article>
       </div>
-      <a id="quick-entry" href="#" class="hidden landing-option bg-blue-600 text-white rounded-xl py-4 px-8 inline-block font-bold"></a>
+    </section>
+    <section class="max-w-6xl mx-auto px-4 mt-10">
+      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
+          <svg class="w-8 h-8 text-sky-500" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <circle cx="18" cy="18" r="16" stroke="#e2e8f0" stroke-width="4" />
+            <circle cx="18" cy="18" r="16" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-dasharray="100" stroke-dashoffset="62" />
+          </svg>
+          <span class="text-sm md:text-base text-slate-700">پرشدگی مخازن ۳۸٪</span>
+        </div>
+        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
+          <svg class="w-8 h-8 text-yellow-500" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13 2L3 14h7v8l10-12h-7z"/></svg>
+          <span class="text-sm md:text-base text-slate-700">پیک امروز برق ۴,۸۰۰ MW</span>
+        </div>
+        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
+          <svg class="w-8 h-8 text-slate-400" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 1a11 11 0 1 0 0 22 11 11 0 0 0 0-22zm1 11V6h-2v8h7v-2h-5z"/></svg>
+          <span class="text-sm md:text-base text-slate-700">آخرین به‌روزرسانی: ۲۵ مرداد ۱۴۰۴</span>
+        </div>
+      </div>
+    </section>
+    <div class="text-center">
+      <a href="/water/hub" class="mx-auto mt-6 md:mt-8 inline-flex items-center gap-2 rounded-full px-6 py-3 md:px-8 md:py-4 text-base md:text-lg font-semibold text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود سریع به آب</a>
+    </div>
   </main>
-  <div id="curtain" class="curtain hidden"><div class="curtain-half left"></div><div class="curtain-half right"></div></div>
+  <style>
+    @keyframes float {0%{transform:translateY(0)}50%{transform:translateY(-4px)}100%{transform:translateY(0)}}
+    .wave{animation:float 8s ease-in-out infinite}
+  </style>
+  <svg class="wave pointer-events-none w-full h-24 text-sky-100" viewBox="0 0 1440 320" aria-hidden="true">
+    <path fill="currentColor" d="M0,224L48,192C96,160,192,96,288,69.3C384,43,480,53,576,74.7C672,96,768,128,864,133.3C960,139,1056,117,1152,128C1248,139,1344,181,1392,202.7L1440,224L1440,0L0,0Z" />
+  </svg>
   <script defer src="index.js"></script>
   <script defer src="assets/numfmt.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- redesign landing with gradient hero using existing `header2.webp`
- add logo, grid cards with inline SVG icons, KPI bar, central CTA and animated wave
- keep zero-binary policy; backup old page as `index.backup.html`

## Testing
- `npm test`
- `npm run check:no-binary`

## Assets موردنیاز
- none

------
https://chatgpt.com/codex/tasks/task_e_68a1e7527a108328b0264dcdb98999ad