### PR TITLE
Add fuel-carbon gas dashboard navigation

### DIFF
--- a/docs/gas/fuel-carbon.html
+++ b/docs/gas/fuel-carbon.html
@@ -40,9 +40,16 @@
     .mazut-danger { border: 2px solid #ef4444; }  /* red-500 */
   </style>
 </head>
-<body class="bg-slate-50 text-slate-800">
-  <div class="container mx-auto p-4 md:p-8">
-    <!-- Header -->
+  <body class="bg-slate-50 text-slate-800">
+    <nav class="container mx-auto p-4 md:p-8 mb-4 text-sm text-slate-500">
+      <a href="../index.html" class="hover:text-slate-700">خانه</a>
+      <span class="mx-2">/</span>
+      <a href="./index.html" class="hover:text-slate-700">گاز</a>
+      <span class="mx-2">/</span>
+      <span class="text-slate-700">سوخت و کربن برق</span>
+    </nav>
+    <div class="container mx-auto p-4 md:p-8">
+      <!-- Header -->
     <header class="text-center mb-8">
       <h1 class="text-3xl md:text-4xl font-bold text-slate-900">برق استان از چه سوختی می‌آید؟</h1>
       <p class="text-lg text-slate-600 mt-2">درصد هر سوخت را ببینید و شدت کربن برق استان را با کشور مقایسه کنید.</p>

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -19,6 +19,17 @@
     <h1 class="text-3xl font-extrabold text-slate-700">صفحه گاز و فرآورده‌های نفتی</h1>
     <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
     <a href="./energy.html" class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 font-extrabold">ورود به داشبورد</a>
+    <div class="max-w-md mx-auto">
+      <a href="./fuel-carbon.html" class="block rounded-xl p-4 border border-slate-200 hover:shadow-sm hover:-translate-y-0.5 transition">
+        <div class="flex items-center justify-between">
+          <div>
+            <h3 class="font-bold text-slate-800">سوخت و کربن برق (داشبورد ۲)</h3>
+            <p class="text-sm text-slate-500 mt-1">سهم سوخت‌ها، شدت کربن، روند ۲۴ماهه، شبیه‌ساز اگر/آنگاه</p>
+          </div>
+          <span class="text-slate-400">&larr;</span>
+        </div>
+      </a>
+    </div>
     <a href="../" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>
   </main>
   <script defer src="index.js"></script>


### PR DESCRIPTION
## Summary
- add link to fuel-carbon dashboard on gas index page
- include breadcrumb navigation on fuel-carbon page

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run flag:test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a1ef4272388328abaa0f3e4407a263