### PR TITLE
fix: route gas card to landing

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,3 +1,3 @@
 /water   /water/hub   301
 /water/  /water/hub   301
-/gas /gas/energy.html 301
+/gas/energy    /gas/   301

--- a/docs/dev-notes/Plan_fuel_carbon.md
+++ b/docs/dev-notes/Plan_fuel_carbon.md
@@ -29,3 +29,7 @@ If Content Security Policy headers are enabled, whitelist:
 ## Fix log
 - Dashboard only showed static text because required scripts were blocked by CSP and browser caching.
 - Added local `vendor` copies of Chart.js and its date-fns adapter, updated script paths with `?v=1` cache-busting, and inserted a hidden JS boot status span.
+
+## Routing Fix
+- Updated landing page card to link to `/gas/` instead of the old `/gas/energy.html`.
+- Added Netlify redirect: `/gas/energy    /gas/   301` to forward legacy requests.

--- a/docs/index.html
+++ b/docs/index.html
@@ -41,7 +41,7 @@
           <svg class="w-12 h-12 text-amber-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C10 5 7 8.9 7 13a5 5 0 0 0 10 0c0-4.1-3-8-5-11z"/></svg>
           <h2 class="text-lg font-semibold text-slate-900 mb-2">گاز و فرآورده‌ها</h2>
           <p class="text-slate-600 text-sm flex-grow">اطلاعات شبکه گاز و فرآورده‌های نفتی.</p>
-          <a href="gas/energy.html" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
+          <a href="./gas/" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
         </article>
       </div>
     </section>
@@ -75,7 +75,7 @@
   <svg class="wave pointer-events-none w-full h-24 text-sky-100" viewBox="0 0 1440 320" aria-hidden="true">
     <path fill="currentColor" d="M0,224L48,192C96,160,192,96,288,69.3C384,43,480,53,576,74.7C672,96,768,128,864,133.3C960,139,1056,117,1152,128C1248,139,1344,181,1392,202.7L1440,224L1440,0L0,0Z" />
   </svg>
-  <script defer src="index.js"></script>
-  <script defer src="assets/numfmt.js"></script>
+  <script defer src="index.js?v=1"></script>
+  <script defer src="assets/numfmt.js?v=1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- route gas home card to `/gas/`
- add netlify redirect from legacy `/gas/energy`
- document routing fix

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a1f66d18748328be0250f6c3812681