### PR TITLE
Refactor gas docs layout with themed styling

### DIFF
--- a/docs/assets/gas.css
+++ b/docs/assets/gas.css
@@ -1,0 +1,12 @@
+:root {
+  --gas-green: #16a34a; /* green-600 */
+  --gas-blue: #0284c7;  /* sky-600 */
+  --oil-black: #0f172a; /* slate-900 */
+  --oil-gray: #4b5563;  /* gray-600 */
+  --oil-orange: #ea580c; /* orange-600 */
+}
+
+body {
+  background: linear-gradient(to bottom, #f0fdf4, #e2e8f0);
+  font-family: 'Vazirmatn', sans-serif;
+}

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -1,37 +1,35 @@
 <!DOCTYPE html>
 <html lang="fa" dir="rtl">
 <head>
-    <meta charset="UTF-8">
-    <meta http-equiv="Content-Language" content="fa-IR">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta property="og:image" content="https://wesh360.ir/page/landing/logo2.jfif">
-    <meta property="og:image:secure_url" content="https://wesh360.ir/page/landing/logo2.jfif">
-    <meta property="og:image:type" content="image/jpeg">
-    <meta property="og:image:alt" content="wesh360 – تصویر شاخص صفحه">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
-    <title>گاز - wesh360</title>
-      <link rel="stylesheet" href="../assets/tailwind.css">
-      <link rel="stylesheet" href="../assets/styles.css"></head>
-<body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Language" content="fa-IR">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta property="og:image" content="https://wesh360.ir/page/landing/logo2.jfif">
+  <meta property="og:image:secure_url" content="https://wesh360.ir/page/landing/logo2.jfif">
+  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:alt" content="wesh360 – تصویر شاخص صفحه">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
+  <title>گاز - wesh360</title>
+  <link rel="stylesheet" href="../assets/tailwind.css">
+  <link rel="stylesheet" href="../assets/styles.css">
+  <link rel="stylesheet" href="../assets/gas.css">
+</head>
+<body class="min-h-screen flex flex-col">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-  <main id="main" class="text-center space-y-6">
-    <h1 class="text-3xl font-extrabold text-slate-700">صفحه گاز و فرآورده‌های نفتی</h1>
-    <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
-    <a href="./energy.html" class="inline-block px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 font-extrabold">ورود به داشبورد</a>
-    <div class="max-w-md mx-auto">
-      <a href="./fuel-carbon.html" class="block rounded-xl p-4 border border-slate-200 hover:shadow-sm hover:-translate-y-0.5 transition">
-        <div class="flex items-center justify-between">
-          <div>
-            <h3 class="font-bold text-slate-800">سوخت و کربن برق (داشبورد ۲)</h3>
-            <p class="text-sm text-slate-500 mt-1">سهم سوخت‌ها، شدت کربن، روند ۲۴ماهه، شبیه‌ساز اگر/آنگاه</p>
-          </div>
-          <span class="text-slate-400">&larr;</span>
-        </div>
-      </a>
+  <main id="main" class="flex-grow flex flex-col items-center justify-center text-center space-y-8 p-6">
+    <div class="space-y-2">
+      <h1 class="text-3xl font-extrabold text-slate-800">صفحه گاز و فرآورده‌های نفتی</h1>
+      <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
     </div>
-    <a href="../" class="text-blue-600 hover:underline">بازگشت به صفحه اصلی</a>
+    <div class="flex flex-col sm:flex-row gap-4">
+      <a href="./energy.html" class="px-6 py-3 rounded-lg shadow-md bg-gradient-to-r from-green-600 to-blue-600 text-white font-bold hover:from-green-700 hover:to-blue-700 transition">داشبورد انرژی</a>
+      <a href="./fuel-carbon.html" class="px-6 py-3 rounded-lg shadow-md bg-gradient-to-r from-gray-700 to-black text-orange-400 font-bold hover:text-orange-300 hover:from-gray-800 hover:to-black transition">سوخت و کربن برق</a>
+    </div>
   </main>
+  <footer class="py-6 flex justify-center">
+    <a href="../" class="px-6 py-3 rounded-lg shadow-md bg-slate-700 text-white font-bold hover:bg-slate-800 transition">بازگشت به صفحه اصلی</a>
+  </footer>
   <script defer src="index.js"></script>
   <script defer src="../assets/numfmt.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- revamp gas section landing with horizontal dashboard buttons and bottom back link
- add gas.css with gas/oil themed colors and gradient background using Vazirmatn font

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run flag:test` *(fails: error while loading shared libraries: libcups.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f9835864832897a34806e03c2038