### PR TITLE
Remove water insights cost calculator CTA

### DIFF
--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -210,9 +210,6 @@
                 </div>
             </div>
         </section>
-        <div class="text-center mt-8">
-            <a href="./cost-calculator.html" class="inline-block px-4 py-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 focus:outline-none">باز کردن ماشین‌حساب قیمت تمام‌شده آب</a>
-        </div>
         <p class="text-center mt-12 text-slate-500 text-sm">منبع داده‌ها: گزارش رسمی شرکت آب منطقه‌ای خراسان رضوی (سال ۱۴۰۴)</p>
     </main>
     <div id="error-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4"><div class="bg-white p-6 rounded-lg shadow-lg max-w-sm mx-auto text-center"><div class="text-red-500 mb-4"><span class="text-5xl" aria-hidden="true">❗</span></div><h3 class="text-lg font-bold text-red-600 mb-2">خطا در ارتباط با سرور</h3><p id="error-message" class="text-slate-700">متاسفانه مشکلی در دریافت اطلاعات پیش آمد. لطفا دوباره تلاش کنید.</p><button id="close-modal-btn" type="button" class="mt-6 bg-red-500 text-white px-6 py-2 rounded-lg hover:bg-red-600 transition">بستن</button></div></div>


### PR DESCRIPTION
## Summary
- remove "open cost calculator" call-to-action from water insights page
- tidy footer layout after button removal; no JS references remain

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a295b52b588328bd744da0266def84