### PR TITLE
feat: add smart tips fallback and scoped styling

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -95,3 +95,13 @@ h1, h2, h3, .result-number {
 
 .simulate-result .result-number.main { line-height: 1; }
 .simulate-result .result-number.delta { line-height: 1; }
+
+/* ----- Smart Tips (scoped) ----- */
+.tips-card { background:#fff; border:1px solid #e5e7eb; border-radius:1rem; padding:1rem 1.25rem; box-shadow: inset 0 1px 0 rgba(0,0,0,.02); }
+.tips-prose { direction: rtl; text-align:right; line-height:2; }
+.tips-prose p { margin:.5rem 0; }
+.tips-item { margin-top:1rem; }
+.tips-title { font-weight:800; color:#1e40af; /* blue-800 */ font-size:1.125rem; /* text-lg */ margin-bottom:.25rem; }
+.tips-body { color:#334155; /* slate-700 */ }
+.tips-list { list-style:disc; list-style-position: outside; padding-right:1.25rem; margin:.5rem 0 .5rem 0; }
+.tips-hr { border:0; height:1px; background:#e5e7eb; margin:1rem 0; }


### PR DESCRIPTION
## Summary
- add smart tips helpers with local fallback and JSON-based AI update
- replace handleGenerateTips and hook button to new flow
- scope tip card typography and colors with dedicated CSS classes

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run flag:test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a29700a35c83288440e8467fbe1435