### PR TITLE
Remove quick water entry from home page

### DIFF
--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -111,3 +111,12 @@ main .hero, main .brand, main .hero-logo, main .banner {
   margin: 0;
   padding: 0;
 }
+
+/* Collapse leftover spacing after removing CTA */
+.cta-water, .quick-water, .home-cta, .cta-wave {
+  display: none;
+}
+main .cta, main .hero-cta {
+  margin: 0;
+  padding: 0;
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,17 +63,7 @@
         </div>
       </div>
     </section>
-    <div class="text-center">
-      <a href="/water/hub" class="mx-auto mt-6 md:mt-8 inline-flex items-center gap-2 rounded-full px-6 py-3 md:px-8 md:py-4 text-base md:text-lg font-semibold text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود سریع به آب</a>
-    </div>
   </main>
-  <style>
-    @keyframes float {0%{transform:translateY(0)}50%{transform:translateY(-4px)}100%{transform:translateY(0)}}
-    .wave{animation:float 8s ease-in-out infinite}
-  </style>
-  <svg class="wave pointer-events-none w-full h-24 text-sky-100" viewBox="0 0 1440 320" aria-hidden="true">
-    <path fill="currentColor" d="M0,224L48,192C96,160,192,96,288,69.3C384,43,480,53,576,74.7C672,96,768,128,864,133.3C960,139,1056,117,1152,128C1248,139,1344,181,1392,202.7L1440,224L1440,0L0,0Z" />
-  </svg>
   <script defer src="index.js?v=1"></script>
   <script defer src="assets/numfmt.js?v=1"></script>
   <script defer src="/assets/footer.js"></script>

--- a/docs/index.js
+++ b/docs/index.js
@@ -59,18 +59,7 @@
     if (debug) console.log('Curtain bound to', el);
   }
   document.querySelectorAll('[data-sector]').forEach(bind);
-  const sector = localStorage.getItem('sector');
-  if (sector) {
-    const names = { water: 'آب', electricity: 'برق', gas: 'گاز و فرآورده‌های نفتی' };
-    const quick = document.getElementById('quick-entry');
-    if (quick) {
-      quick.href = sector + '/';
-      quick.textContent = 'ورود سریع به ' + (names[sector] || sector);
-      quick.setAttribute('data-sector', sector);
-      quick.classList.remove('hidden');
-      bind(quick);
-    }
-  }
+  // quick-entry button removed
 })();
 (function () {
   const params = new URLSearchParams(location.search);


### PR DESCRIPTION
## Summary
- remove "ورود سریع به آب" CTA and decorative wave from landing page
- drop quick-entry logic from home script
- add CSS rules to collapse potential leftover CTA spacing

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a29ad4b1f4832881d5348c8bcfca12