### PR TITLE
fix: standardize footer flag size

### DIFF
--- a/docs/assets/footer.css
+++ b/docs/assets/footer.css
@@ -1,0 +1,18 @@
+/* footer flag sizing */
+.footer-flag {
+  height: 28px;          /* اندازه‌ی استاندارد دسکتاپ */
+  width: auto;           /* جلوگیری از کشیدگی */
+  max-width: none;       /* نادیده گرفتن قواعد پیش‌فرض img {max-width:100%} */
+  object-fit: contain;
+  vertical-align: middle;
+}
+@media (max-width: 768px) {
+  .footer-flag { height: 22px; }  /* موبایل */
+}
+.footer-note {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  justify-content: center;
+  text-align: center;
+}

--- a/docs/assets/footer.html
+++ b/docs/assets/footer.html
@@ -1,5 +1,6 @@
 <footer class="site-footer" dir="rtl" style="position:fixed;bottom:0;left:0;right:0;width:100%;background:#fff;z-index:1000;">
-  <img src="/assets/IRAN-FLAG.png" alt="Iran flag" class="iran-flag" aria-hidden="true">
-  کلیه حقوق مادی و معنوی این سایت متعلق به خانه هم‌افزایی انرژی و آب استان خراسان رضوی است.<br>
-  طراحی و تولید: خانه هم‌افزایی انرژی و آب خراسان رضوی
+  <div class="footer-note">
+    <span>کلیه حقوق مادی و معنوی این سایت متعلق به خانه هم‌افزایی انرژی و آب استان خراسان رضوی است.<br>طراحی و تولید: خانه هم‌افزایی انرژی و آب خراسان رضوی</span>
+    <img src="/assets/IRAN-FLAG.png" alt="پرچم ایران" class="footer-flag" loading="lazy" decoding="async">
+  </div>
 </footer>

--- a/docs/electricity/index.backup.html
+++ b/docs/electricity/index.backup.html
@@ -12,7 +12,9 @@
     <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif">
     <title>برق - wesh360</title>
       <link rel="stylesheet" href="../assets/tailwind.css">
-      <link rel="stylesheet" href="../assets/styles.css"></head>
+      <link rel="stylesheet" href="../assets/styles.css">
+  <link rel="stylesheet" href="/assets/footer.css">
+</head>
 <body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <main id="main" class="text-center space-y-6">

--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -15,6 +15,7 @@
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/styles.css">
   <link rel="stylesheet" href="../assets/electricity.css">
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="min-h-screen bg-gradient-to-b from-blue-900 to-blue-500 flex items-center justify-center p-4 sm:p-6">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>

--- a/docs/electricity/peak.backup.html
+++ b/docs/electricity/peak.backup.html
@@ -16,6 +16,7 @@
     @keyframes alertPulse { 0%,100% { opacity:1; } 50% { opacity:0.4; } }
     .chart-container { position: relative; height: 300px; }
   </style>
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="bg-slate-50 text-slate-800">
   <main id="main" class="container mx-auto p-4 space-y-8">

--- a/docs/electricity/peak.html
+++ b/docs/electricity/peak.html
@@ -22,6 +22,7 @@
         ::-webkit-scrollbar-thumb:hover { background: #64748b; }
         .chart-container { position: relative; height: 350px; width: 100%; }
     </style>
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="bg-slate-100 text-slate-800">
     <div class="container mx-auto p-4 md:p-6 lg:p-8">

--- a/docs/electricity/power-tariff.html
+++ b/docs/electricity/power-tariff.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../assets/styles.css">
   <link rel="stylesheet" href="../assets/power-tariff.css">
   <script defer src="../assets/power-tariff.js"></script>
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="bg-slate-100 text-slate-800">
 <div id="etf-root" class="container mx-auto p-4 md:p-8">

--- a/docs/electricity/quality.html
+++ b/docs/electricity/quality.html
@@ -26,6 +26,7 @@
             -webkit-text-fill-color: transparent;
         }
     </style>
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="bg-gray-900 text-gray-200">
 

--- a/docs/gas/energy.html
+++ b/docs/gas/energy.html
@@ -11,6 +11,7 @@
   <!-- استایل‌های محلی پروژه -->
   <link rel="stylesheet" href="../assets/tailwind.css" />
   <link rel="stylesheet" href="../assets/styles.css" />
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="min-h-screen bg-slate-900 text-slate-200 antialiased">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>

--- a/docs/gas/fuel-carbon.html
+++ b/docs/gas/fuel-carbon.html
@@ -36,6 +36,7 @@
     .mazut-warning { border: 2px solid #f97316; } /* orange-500 */
     .mazut-danger { border: 2px solid #ef4444; }  /* red-500 */
   </style>
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
   <body class="bg-slate-50 text-slate-800">
     <span id="fc-js-status" class="hidden">X</span>

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/styles.css">
   <link rel="stylesheet" href="../assets/gas.css">
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="min-h-screen flex flex-col">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>

--- a/docs/index.backup.html
+++ b/docs/index.backup.html
@@ -13,7 +13,9 @@
   <title>wesh360</title>
     <link rel="stylesheet" href="assets/tailwind.css" />
     <link rel="stylesheet" href="assets/styles.css" />
-    <link rel="stylesheet" href="page/landing/landing.css" /></head>
+    <link rel="stylesheet" href="page/landing/landing.css" />
+  <link rel="stylesheet" href="/assets/footer.css">
+</head>
 <body class="min-h-screen bg-gray-100 flex items-center justify-center p-6">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <picture>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@
   <title>wesh360</title>
   <link rel="stylesheet" href="assets/tailwind.css" />
   <link rel="stylesheet" href="assets/styles.css" />
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
   <body class="min-h-screen flex flex-col bg-gradient-to-b from-slate-50 via-sky-50/70 to-white">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -12,7 +12,8 @@
         height: 300px;
       }
     </style>
-  </head>
+    <link rel="stylesheet" href="/assets/footer.css">
+</head>
   <body class="bg-slate-50 text-slate-800 p-4 sm:p-6 md:p-8 tabular-nums">
     <main class="max-w-7xl mx-auto" id="main">
       <a href="./hub.html" class="text-blue-600 hover:underline">بازگشت به انتخاب داشبورد</a>

--- a/docs/water/hub.backup.html
+++ b/docs/water/hub.backup.html
@@ -6,6 +6,7 @@
   <title>انتخاب داشبورد آب</title>
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/styles.css">
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="bg-slate-50 text-slate-800 min-h-screen">
   <main class="container mx-auto p-6 md:p-10" id="main">

--- a/docs/water/hub.html
+++ b/docs/water/hub.html
@@ -9,6 +9,7 @@
   <style>
     @keyframes float { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-6px)} }
   </style>
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="bg-gradient-to-b from-slate-50 via-sky-50/60 to-white text-slate-800 min-h-screen relative overflow-hidden text-sm md:text-base">
   <main class="max-w-6xl mx-auto px-4 py-10 md:py-14">

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -18,6 +18,7 @@
       <link rel="stylesheet" href="water.css">
   <!-- Vazirmatn -->
     
+  <link rel="stylesheet" href="/assets/footer.css">
 </head>
 <body class="p-4 sm:p-6 md:p-8">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>


### PR DESCRIPTION
## Summary
- add `footer.css` for consistent footer flag dimensions
- load the new stylesheet and footer snippet across all docs pages
- normalize footer markup and flag image attributes

## Testing
- `npm test`
- `npm run flag:test` *(fails: flag not found in DOM)*
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a2ab6c017083289a65d55b3122a411