### PR TITLE
style: restyle electricity page

### DIFF
--- a/docs/assets/electricity-theme.css
+++ b/docs/assets/electricity-theme.css
@@ -1,0 +1,26 @@
+:root{
+  --bg:#0B1220; --bg2:#0F172A; --muted:#94A3B8;
+  --primary:#22D3EE; --accent:#FACC15; --success:#34D399; --danger:#F87171;
+  --radius:16px; --pad:20px; --maxw:1100px;
+}
+[dir="rtl"] body{background:radial-gradient(1200px 600px at 50% -10%, #16254a 0%, var(--bg) 50%, #060a14 100%); color:#fff; font-family:'Vazirmatn', sans-serif;}
+.container{max-width:var(--maxw); margin-inline:auto; padding:32px 16px;}
+.page-title{font-weight:800; font-size:clamp(22px,3.4vw,36px); text-align:center; margin:20px 0 28px;}
+.grid{display:grid; grid-template-columns:repeat(3,minmax(0,1fr)); gap:16px;}
+@media (max-width:900px){ .grid{grid-template-columns:1fr;} }
+
+.card{background:var(--bg2); border:1px solid rgba(255,255,255,.08); border-radius:var(--radius);
+      padding:var(--pad); box-shadow:0 14px 30px rgba(0,0,0,.35);}
+.card h3{margin:0 0 8px; font-weight:800;}
+.card p{margin:0; color:var(--muted); font-size:.95rem;}
+
+.actions{display:flex; flex-wrap:wrap; gap:12px; justify-content:center; margin-top:18px;}
+.btn{display:inline-flex; align-items:center; justify-content:center; gap:.5rem;
+     padding:.8rem 1.1rem; border-radius:12px; font-weight:800; text-decoration:none; transition:.18s transform,.18s box-shadow;}
+.btn-primary{background:linear-gradient(90deg,var(--primary),var(--accent)); color:#0B1220; box-shadow:0 8px 22px rgba(34,211,238,.25);}
+.btn-primary:hover{transform:translateY(-1px); box-shadow:0 12px 28px rgba(34,211,238,.32);}
+.btn-ghost{background:transparent; color:#fff; border:1px solid rgba(255,255,255,.18);}
+.btn-ghost:hover{border-color:var(--primary); color:#c3f5ff;}
+.btn:focus{outline:2px solid var(--accent); outline-offset:2px;}
+
+.footer-note{margin-top:36px; color:var(--muted); text-align:center; font-size:.9rem;}

--- a/docs/assets/fonts.css
+++ b/docs/assets/fonts.css
@@ -1,7 +1,5 @@
-@font-face {
-  font-family: 'Vazirmatn';
-  src: url('../fonts/vazirmatn/Vazirmatn[wght].woff2') format('woff2-variations');
-  font-weight: 100 900;
-  font-style: normal;
-  font-display: swap;
+@font-face{
+  font-family:'Vazirmatn';
+  src:url('../fonts/vazirmatn/Vazirmatn[wght].woff2') format('woff2');
+  font-weight:100 900; font-style:normal; font-display:swap;
 }

--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -13,31 +13,46 @@
   <title>برق - wesh360</title>
   <meta name="section" content="electricity" />
   <link rel="stylesheet" href="../assets/fonts.css">
-  <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/styles.css">
-  <link rel="stylesheet" href="../assets/electricity.css">
+  <link rel="stylesheet" href="../assets/electricity-theme.css">
   <link rel="stylesheet" href="/assets/footer.css">
 </head>
-<body class="min-h-screen bg-gradient-to-b from-indigo-950 via-blue-900 to-slate-900 py-16">
+<body>
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-  <main id="main" class="max-w-5xl mx-auto px-4">
-    <h1 class="text-white text-3xl md:text-4xl font-extrabold text-center mb-10">صفحه برق</h1>
-    <!-- Buttons row -->
-    <div class="grid grid-cols-1 md:grid-cols-3 gap-4 mt-6" dir="rtl">
-      <a href="./peak.html" class="inline-flex items-center justify-center h-12 rounded-xl px-6 font-semibold text-white border border-amber-400/40 bg-white/5 hover:bg-white/10 hover:border-amber-400/70 transition shadow-lg backdrop-blur focus:outline-none focus:ring-2 focus:ring-amber-400/60">
-        داشبورد مدیریت مصرف
-      </a>
-      <a href="./power-tariff.html" class="inline-flex items-center justify-center h-12 rounded-xl px-6 font-semibold text-white border border-amber-400/40 bg-white/5 hover:bg-white/10 hover:border-amber-400/70 transition shadow-lg backdrop-blur focus:outline-none focus:ring-2 focus:ring-amber-400/60">
-        داشبورد تحلیل شاخص برق
-      </a>
-      <a href="./quality.html" class="inline-flex items-center justify-center h-12 rounded-xl px-6 font-semibold text-white border border-amber-400/40 bg-white/5 hover:bg-white/10 hover:border-amber-400/70 transition shadow-lg backdrop-blur focus:outline-none focus:ring-2 focus:ring-amber-400/60">
-        داشبورد کیفیت توزیع برق
-      </a>
+  <main id="main" class="container">
+    <h1 class="page-title">⚡ صفحه برق</h1>
+
+    <section class="grid" aria-label="Electricity dashboards">
+      <article class="card">
+        <h3>داشبورد کیفیت توزیع برق</h3>
+        <p>شاخص‌های قابلیت اطمینان، خاموشی، و پروفایل کیفیت</p>
+        <div class="actions">
+          <a class="btn btn-primary" href="./quality.html" aria-label="رفتن به داشبورد کیفیت توزیع برق">ورود به داشبورد</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h3>داشبورد تحلیل شاخص برق</h3>
+        <p>روندها، همبستگی‌ها و تحلیل شاخص‌ها</p>
+        <div class="actions">
+          <a class="btn btn-primary" href="./power-tariff.html" aria-label="رفتن به داشبورد تحلیل شاخص برق">ورود به داشبورد</a>
+        </div>
+      </article>
+
+      <article class="card">
+        <h3>داشبورد مدیریت مصرف</h3>
+        <p>پیک روزانه/ساعتی، هشدار پیک و مدیریت بار</p>
+        <div class="actions">
+          <a class="btn btn-primary" href="./peak.html" aria-label="رفتن به داشبورد مدیریت مصرف">ورود به داشبورد</a>
+        </div>
+      </article>
+    </section>
+
+    <div class="actions" style="margin-top:26px">
+      <a class="btn btn-ghost" href="../index.html" aria-label="بازگشت به صفحه اصلی">بازگشت به صفحه اصلی</a>
     </div>
-    <!-- Back to home -->
-    <a href="../" class="mt-8 w-full md:w-auto mx-auto block text-center rounded-xl border border-white/20 bg-white/5 hover:bg-white/10 text-white h-12 px-6">
-      بازگشت به صفحه اصلی
-    </a>
+
+    <!-- فوتر موجود سایت شما همان‌طور که هست بماند -->
   </main>
   <script defer src="index.js"></script>
   <script defer src="../assets/numfmt.js"></script>


### PR DESCRIPTION
## Summary
- add electricity dark theme stylesheet and reference local Vazirmatn font
- rebuild electricity landing page with three responsive cards and ghost home link

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a2c8ae3a948328b4d24fe7f4de058e