### PR TITLE
Hide previous simulator text while loading new AI result

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -50,9 +50,10 @@ async function handleSimulation() {
   const consumptionReduction = consumptionSlider.value;
   const futureRainfall = rainfallSlider.value;
 
-  simulationResultContainer.classList.remove('hidden');
-  simulationLoader.classList.remove('hidden');
+  // Hide any previous result and show loading state immediately
   simulationResultDiv.innerHTML = '';
+  simulationResultContainer.classList.add('hidden');
+  simulationLoader.classList.remove('hidden');
   simulateBtn.disabled = true;
   simulateBtn.classList.add('opacity-50');
 
@@ -115,6 +116,8 @@ Return ONLY valid JSON (no markdown) with this exact shape:
       </p>
       <p class="text-slate-700 text-lg">${result.explanation}</p>
     `;
+    // Reveal the updated result after loading finishes
+    simulationResultContainer.classList.remove('hidden');
   } catch (error) {
     console.error('Gemini API Error (Simulator):', error);
     showErrorModal('پاسخ هوش مصنوعی قابل استفاده نبود. لطفاً دوباره تلاش کنید.');

--- a/docs/assets/water-insights.js
+++ b/docs/assets/water-insights.js
@@ -182,8 +182,12 @@ All numbers must be numeric (no units attached in JSON).
     if (!btn || !rain || !cut || !out) return;
 
     btn.addEventListener('click', async () => {
+      const thinking = document.getElementById('simulate-thinking');
       try {
-        setLoading(btn, true); out.textContent = '⏳';
+        setLoading(btn, true);
+        if (thinking) thinking.classList.remove('hidden');
+        out.textContent = '';
+        out.classList.add('hidden');
         const rainVal = rain.value || rain.getAttribute('value') || '0';
         const cutVal  = cut.value  || cut.getAttribute('value')  || '0';
         const prompt =
@@ -214,8 +218,16 @@ All numbers must be numeric (no units attached in JSON).
         note.className = 'mt-1';
         note.textContent = data.note_fa || '';
         out.replaceChildren(ul, impact, note);
-      } catch(e){ out.textContent = '⚠️ خطا در شبیه‌سازی.'; console.warn(e.message); }
-      finally { setLoading(btn, false); }
+        out.classList.remove('hidden');
+      } catch(e){
+        out.textContent = '⚠️ خطا در شبیه‌سازی.';
+        out.classList.remove('hidden');
+        console.warn(e.message);
+      }
+      finally {
+        if (thinking) thinking.classList.add('hidden');
+        setLoading(btn, false);
+      }
     });
   })();
 


### PR DESCRIPTION
## Summary
- Ensure the water simulator hides prior output and only shows a loading state until the AI response arrives.
- Reveal the updated simulation result once the response is processed.
- Apply the same loading and hiding behavior to legacy `wireSimulator` logic.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a2ee38300483288cc90f5e78f78efa