### PR TITLE
Show loading state before simulation results

### DIFF
--- a/docs/assets/app.js
+++ b/docs/assets/app.js
@@ -49,12 +49,11 @@ const footprintResultDiv = document.getElementById('water-result');
 async function handleSimulation() {
   const consumptionReduction = consumptionSlider.value;
   const futureRainfall = rainfallSlider.value;
-
-  simulationResultContainer.classList.remove('hidden');
+  // Show a loading state and clear any previous result
+  setLoading(simulateBtn, true);
   simulationLoader.classList.remove('hidden');
-  simulationResultDiv.innerHTML = '';
-  simulateBtn.disabled = true;
-  simulateBtn.classList.add('opacity-50');
+  simulationResultDiv.textContent = '⏳';
+  simulationResultContainer.classList.remove('hidden');
 
   const prompt = `
 You are a water crisis analyst for the city of Mashhad. Your task is to simulate the effect of citizen actions and rainfall on the city's "Day Zero" (the day water runs out).
@@ -121,8 +120,7 @@ Return ONLY valid JSON (no markdown) with this exact shape:
     simulationResultContainer.classList.add('hidden');
   } finally {
     simulationLoader.classList.add('hidden');
-    simulateBtn.disabled = false;
-    simulateBtn.classList.remove('opacity-50');
+    setLoading(simulateBtn, false);
   }
 }
 


### PR DESCRIPTION
## Summary
- Clear previous simulator text and show an hourglass placeholder while the AI response loads.
- Re-enable the simulate button and hide spinner after completion.

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run flag:test` *(fails: پرچم در DOM پیدا نشد.)*

------
https://chatgpt.com/codex/tasks/task_e_68a2ee38300483288cc90f5e78f78efa