### PR TITLE
Handle backend errors and surface alerts on the frontend

### DIFF
--- a/docs/agrivoltaics/app.js
+++ b/docs/agrivoltaics/app.js
@@ -86,7 +86,8 @@ async function saveScenario(state, setShareLink) {
     })
   });
   if (!res.ok) {
-    alert("ذخیره نشد؛ بعداً دوباره امتحان کن.");
+    const err = await res.json().catch(() => ({}));
+    alert(err.message || "ذخیره نشد؛ بعداً دوباره امتحان کن.");
     return;
   }
   const {
@@ -99,7 +100,8 @@ async function loadScenarioById(id, setState) {
   if (!id) return;
   const res = await fetch(`/api/get-scenario?id=${encodeURIComponent(id)}`);
   if (!res.ok) {
-    alert("خواندن نشد؛ بعداً دوباره امتحان کن.");
+    const err = await res.json().catch(() => ({}));
+    alert(err.message || "خواندن نشد؛ بعداً دوباره امتحان کن.");
     return;
   }
   const saved = await res.json();

--- a/docs/agrivoltaics/app.jsx
+++ b/docs/agrivoltaics/app.jsx
@@ -51,7 +51,11 @@
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ state })
         });
-        if (!res.ok) { alert("ذخیره نشد؛ بعداً دوباره امتحان کن."); return; }
+        if (!res.ok) {
+          const err = await res.json().catch(()=>({}));
+          alert(err.message || "ذخیره نشد؛ بعداً دوباره امتحان کن.");
+          return;
+        }
         const { id } = await res.json();
         const share = `${location.origin}${location.pathname}?id=${encodeURIComponent(id)}`;
         setShareLink(share);
@@ -60,7 +64,11 @@
       async function loadScenarioById(id, setState){
         if (!id) return;
         const res = await fetch(`/api/get-scenario?id=${encodeURIComponent(id)}`);
-        if (!res.ok) { alert("خواندن نشد؛ بعداً دوباره امتحان کن."); return; }
+        if (!res.ok) {
+          const err = await res.json().catch(()=>({}));
+          alert(err.message || "خواندن نشد؛ بعداً دوباره امتحان کن.");
+          return;
+        }
         const saved = await res.json();
         if (saved) setState(saved);
       }

--- a/netlify/functions/get-scenario.js
+++ b/netlify/functions/get-scenario.js
@@ -29,6 +29,11 @@ exports.handler = async (event) => {
     const json = await store.get(`scenario:${id}`);
     return { statusCode: 200, headers, body: json || "null" };
   } catch (e) {
-    return { statusCode: 500, headers, body: JSON.stringify({ error: "SERVER_ERROR" }) };
+    console.error(e);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: "internal", message: e.message }),
+    };
   }
 };

--- a/netlify/functions/save-scenario.js
+++ b/netlify/functions/save-scenario.js
@@ -31,6 +31,11 @@ exports.handler = async (event) => {
     await store.setJSON(`scenario:${id}`, body.state || {});
     return { statusCode: 200, headers, body: JSON.stringify({ ok: true, id }) };
   } catch (e) {
-    return { statusCode: 500, headers, body: JSON.stringify({ error: "SERVER_ERROR" }) };
+    console.error(e);
+    return {
+      statusCode: 500,
+      headers,
+      body: JSON.stringify({ error: "internal", message: e.message }),
+    };
   }
 };


### PR DESCRIPTION
## Summary
- log and return detailed 500 responses from scenario save/get functions
- alert users in the agrivoltaics app when server requests fail

## Testing
- `npm test`
- `npm run build:agri`


------
https://chatgpt.com/codex/tasks/task_e_68a4247bf7c083288d5bae9b2e0ad363