### PR TITLE
chore: prioritize agrivoltaics spa redirects

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,11 +10,6 @@
   node_bundler = "esbuild"
 
 [[redirects]]
-  from = "/api/*"
-  to = "/.netlify/functions/:splat"
-  status = 200
-
-[[redirects]]
   from = "/agrivoltaics"
   to = "/agrivoltaics/"
   status = 301
@@ -22,6 +17,11 @@
 [[redirects]]
   from = "/agrivoltaics/*"
   to = "/agrivoltaics/index.html"
+  status = 200
+
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/:splat"
   status = 200
 
 [[headers]]


### PR DESCRIPTION
## Summary
- move agrivoltaics SPA redirects above other rules so they precede catch-all handlers

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a4258b49688328b37be76c65ecef3d