### PR TITLE
chore: unify footer with Iran flag

### DIFF
--- a/docs/assets/footer-guard.js
+++ b/docs/assets/footer-guard.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const allFooters = Array.from(document.querySelectorAll('footer.site-footer, footer, .footer, #footer'));
+  // Keep the #global-footer; remove others
+  allFooters.forEach(el => {
+    if (el.id !== 'global-footer') {
+      // If it's not the canonical footer and contains the same copyright text, remove it
+      const text = (el.textContent || '').trim();
+      if (text.includes('کلیه حقوق') || el.matches('.site-footer')) el.remove();
+    }
+  });
+});

--- a/docs/assets/footer.css
+++ b/docs/assets/footer.css
@@ -1,18 +1,11 @@
-/* footer flag sizing */
-.footer-flag {
-  height: 28px;          /* اندازه‌ی استاندارد دسکتاپ */
-  width: auto;           /* جلوگیری از کشیدگی */
-  max-width: none;       /* نادیده گرفتن قواعد پیش‌فرض img {max-width:100%} */
-  object-fit: contain;
-  vertical-align: middle;
+.site-footer {
+  margin-top: 2rem;
+  padding: 1rem 0;
+  border-top: 1px solid rgba(0,0,0,.08);
+  background: transparent;
+  font-size: .9rem;
 }
-@media (max-width: 768px) {
-  .footer-flag { height: 22px; }  /* موبایل */
-}
-.footer-note {
-  display: inline-flex;
-  align-items: center;
-  gap: .5rem;
-  justify-content: center;
-  text-align: center;
-}
+.site-footer .container { max-width: 1100px; margin: 0 auto; padding: 0 1rem; }
+.footer-copy { display: inline-flex; align-items: center; gap: .5rem; }
+.iran-flag { inline-size: 22px; block-size: auto; vertical-align: middle; }
+html[dir="rtl"] .footer-copy { flex-direction: row-reverse; } /* پرچم قبل از متن در RTL */

--- a/docs/assets/footer.js
+++ b/docs/assets/footer.js
@@ -1,9 +1,12 @@
 (function() {
   function loadFooter() {
+    if (document.querySelector('#global-footer')) return;
     fetch('/assets/footer.html')
       .then(function(res) { return res.text(); })
       .then(function(html) {
-        document.body.insertAdjacentHTML('beforeend', html);
+        if (!document.querySelector('#global-footer')) {
+          document.body.insertAdjacentHTML('beforeend', html);
+        }
       })
       .catch(function(err) {
         console.error('Failed to load footer', err);

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
   <title>wesh360</title>
   <link rel="stylesheet" href="assets/tailwind.css" />
   <link rel="stylesheet" href="assets/styles.css" />
-  <link rel="stylesheet" href="/assets/footer-ui.css">
+  <link rel="stylesheet" href="./assets/footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <script defer src="/assets/unified-badge.js"></script>
 
@@ -239,13 +239,19 @@
   <script defer src="index.js?v=1"></script>
   <script defer src="assets/numfmt.js?v=1"></script>
   <script defer src="/assets/footer.js"></script>
-
   <script defer src="./assets/badge-updated.js"></script>
-<div dir="rtl">
-  کلیه حقوق مادی و معنوی این سایت متعلق به خانه هم‌افزایی انرژی و آب استان خراسان رضوی است.<br>طراحی و تولید: خانه هم‌افزایی انرژی و آب خراسان رضوی
-</div>
-<footer dir="rtl">
-  کلیه حقوق مادی و معنوی این سایت متعلق به خانه هم‌افزایی انرژی و آب استان خراسان رضوی است.<br>طراحی و تولید: خانه هم‌افزایی انرژی و آب خراسان رضوی
-</footer>
+
+  <footer id="global-footer" class="site-footer">
+    <div class="container">
+      <span class="footer-copy">
+        <img src="./assets/IRAN-FLAG.png"
+             alt="پرچم ایران"
+             class="iran-flag"
+             width="22" height="14" loading="lazy" />
+        کلیه حقوق مادی و معنوی این سایت متعلق به خانه هم‌افزایی انرژی و آب خراسان رضوی است.
+      </span>
+    </div>
+  </footer>
+  <script src="./assets/footer-guard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- deduplicate homepage footer and show Iran flag before text
- guard dynamic footer injection to avoid duplicates
- add CSS and JS helpers for consistent footer display

## Testing
- `npm test`
- `npm run flag:test` *(fails: پرچم در DOM پیدا نشد.)*
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a43bf114808328a946f2f8816ff05c