### PR TITLE
feat: add landing hero section

### DIFF
--- a/docs/assets/landing.css
+++ b/docs/assets/landing.css
@@ -1,0 +1,56 @@
+/* --- Landing Hero Background --- */
+:root {
+  --hero-blur: 12px;       /* adjust if needed */
+  --hero-darken: 0.55;     /* bottom gradient strength */
+  --hero-topfade: 0.25;    /* top gradient strength */
+}
+
+/* Full-viewport hero container */
+.hero {
+  position: relative;
+  min-height: 100vh;      /* full screen */
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #fff;
+  isolation: isolate;      /* ensure stacking context */
+  overflow: hidden;
+}
+
+/* Blurred background image layer */
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: url("page/landing/hiro1.webp") center / cover no-repeat fixed;
+  filter: blur(var(--hero-blur));
+  transform: scale(1.05);   /* avoid blur edge cropping */
+  z-index: -2;
+}
+
+/* Dark overlay for contrast (gradient) */
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, var(--hero-darken)),
+    rgba(0, 0, 0, var(--hero-topfade))
+  );
+  z-index: -1;
+}
+
+/* Optional: responsive spacing for any hero text/buttons */
+.hero .hero-content {
+  padding: clamp(16px, 4vw, 48px);
+  backdrop-filter: none;      /* keep text crisp; no glass effect */
+}
+
+/* Ensure body has no unexpected margins around hero */
+body {
+  margin: 0;
+}
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -13,12 +13,13 @@
   <link rel="stylesheet" href="assets/tailwind.css" />
   <link rel="stylesheet" href="assets/styles.css" />
   <link rel="stylesheet" href="./assets/footer.css">
+  <link rel="stylesheet" href="assets/landing.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <script defer src="/assets/unified-badge.js"></script>
 
   <script defer src="/assets/footer-fix.js"></script>
 </head>
-  <body class="min-h-screen flex flex-col bg-gradient-to-b from-slate-50 via-sky-50/70 to-white">
+  <body class="min-h-screen flex flex-col">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
     <header class="relative p-4 flex justify-center items-center">
       <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
@@ -43,11 +44,13 @@
         </button>
       </div>
     </header>
-  <main id="main" class="flex-grow space-y-14">
-    <section class="text-center max-w-6xl mx-auto px-4 py-10 md:py-14">
-      <h1 class="text-2xl md:text-4xl font-extrabold text-slate-900">پلتفرم داده و مدیریت انرژی و آب خراسان رضوی</h1>
-      <p class="mt-3 md:mt-4 text-slate-600 md:text-lg">داده‌های هوشمند برای مدیریت پایدار منابع</p>
+    <section id="landing-hero" class="hero">
+      <div class="hero-content max-w-6xl mx-auto">
+        <h1 class="text-2xl md:text-4xl font-extrabold">پلتفرم داده و مدیریت انرژی و آب خراسان رضوی</h1>
+        <p class="mt-3 md:mt-4 md:text-lg">داده‌های هوشمند برای مدیریت پایدار منابع</p>
+      </div>
     </section>
+  <main id="main" class="flex-grow space-y-14">
     <section class="max-w-6xl mx-auto px-4">
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 md:gap-7">
         <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">


### PR DESCRIPTION
## Summary
- add landing hero CSS with blurred image and gradient overlay
- insert hero section on landing page and link stylesheet
- remove existing body background so hero fills viewport

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a443c90dfc8328bbda55df938717e2