### PR TITLE
fix: prevent hero overlap with header and footer

### DIFF
--- a/docs/assets/landing.css
+++ b/docs/assets/landing.css
@@ -293,3 +293,114 @@ header{
 }
 
 /* ====== END Van Gogh Hero & Cards ====== */
+
+/* ===== Hero details + header/footer safe area ===== */
+:root{
+  /* مسیر تصویر؛ اگر لازم است همین‌جا تغییرش بده */
+  --hero-url: url("/page/landing/hiro2.webp");
+
+  /* نمایش پیش‌فرض (خوانایی + جزئیات مناسب) */
+  --hero-darken: 0.38;
+  --hero-topfade: 0.18;
+  --hero-focus-x: 50%;
+  --hero-focus-y: 58%;
+  --hero-clarity: contrast(1.06) saturate(1.12) brightness(1.02);
+
+  /* فقط پنل‌ها بلور داشته باشند */
+  --panel-blur: 4px;
+
+  /* فاصله کارت‌ها از پایین هیرو */
+  --cards-bottom: clamp(16px, 7vh, 96px);
+
+  /* ارتفاع‌های داینامیک هدر/فوتر – توسط JS مقداردهی می‌شوند */
+  --header-h: 0px;
+  --footer-h: 0px;
+}
+
+/* هیرو هرگز زیر هدر/فوتر پنهان نشود */
+.hero{
+  position: relative;
+  min-height: calc(100vh - var(--header-h) - var(--footer-h));
+  padding-top: calc(var(--header-h) + 12px);
+  padding-bottom: calc(var(--footer-h) + 12px);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  justify-content: center;
+  color: #fff;
+  isolation: isolate;
+  overflow: hidden;
+  margin: 0;
+  padding-inline: clamp(12px, 3vw, 48px);
+}
+
+/* پس‌زمینه‌ی هیرو – بدون بلور روی خود تصویر */
+.hero::before{
+  content: "";
+  position: absolute; inset: 0; z-index: -2;
+  background: var(--hero-url) var(--hero-focus-x) var(--hero-focus-y)/cover no-repeat;
+  background-attachment: fixed;      /* پارالاکس لطیف دسکتاپ */
+  filter: var(--hero-clarity);        /* تقویت بافت قلم‌موها */
+  transform: translateZ(0);
+}
+
+/* گرادیان برای کنتراست متن */
+.hero::after{
+  content: "";
+  position: absolute; inset: 0; z-index: -1;
+  background:
+    radial-gradient(1200px 700px at 65% 45%, rgba(0,0,0,0.10), transparent 60%),
+    linear-gradient(to top, rgba(0,0,0,var(--hero-darken)), rgba(0,0,0,var(--hero-topfade)));
+}
+
+/* پنل تیتر/زیرتیتر */
+.hero .content-panel{
+  max-width: min(56ch, 60vw);
+  background: rgba(0,0,0,0.20);
+  -webkit-backdrop-filter: blur(var(--panel-blur));
+  backdrop-filter: blur(var(--panel-blur));
+  border-radius: 18px;
+  padding: clamp(12px, 2.4vw, 28px);
+  box-shadow: 0 12px 30px rgba(0,0,0,.25);
+}
+
+/* کارت‌ها روی هیرو */
+.hero-cards{
+  position: absolute;
+  left: 50%;
+  bottom: calc(var(--cards-bottom) + var(--footer-h)); /* بالاتر از فوتر بایستد */
+  transform: translateX(-50%);
+  z-index: 1;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(220px,1fr));
+  gap: clamp(12px, 2.4vw, 24px);
+  width: min(1200px, 94vw);
+}
+.hero-cards > *{
+  width: clamp(220px, 22vw, 320px) !important;
+  height: clamp(280px, 40vh, 520px) !important;
+  margin: 0 !important;
+  border-radius: 18px;
+  box-shadow: 0 12px 36px rgba(0,0,0,.18);
+  transition: transform .2s ease;
+}
+.hero-cards > *:hover{ transform: translateY(-6px); }
+
+/* حالت «نمایش جزئیات» برای عاشقان هنر */
+.hero.art-detail::after{
+  background:
+    radial-gradient(1400px 800px at 60% 45%, rgba(0,0,0,0.06), transparent 65%),
+    linear-gradient(to top, rgba(0,0,0,0.18), rgba(0,0,0,0.06));
+}
+.hero.art-detail::before{
+  filter: contrast(1.10) saturate(1.18) brightness(1.03);
+}
+
+/* موبایل: پارالاکس خاموش و گرادیان کمی قوی‌تر */
+@media (max-width:1024px){ .hero::before{ background-attachment: scroll; } }
+@media (max-width:768px), (max-height:720px){
+  :root{ --hero-darken: 0.50; --hero-topfade: 0.24; }
+  .hero{ align-items: center; }
+  .hero .content-panel{ max-width: 92vw; }
+  .hero-cards{ grid-template-columns: 1fr; width: 92vw; bottom: calc(18px + var(--footer-h)); gap: 10px; }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,10 +47,17 @@
       </div>
     </header>
     <section id="landing-hero" class="hero">
-      <div class="hero-content max-w-6xl mx-auto">
+      <div class="detail-toggle" onclick="
+    const h=document.getElementById('landing-hero');
+    h.classList.toggle('art-detail');
+    this.innerText = h.classList.contains('art-detail') ? 'نمایش معمولی' : 'نمایش جزئیات تصویر';
+  ">نمایش جزئیات تصویر</div>
+
+      <div class="content-panel">
         <h1 class="text-2xl md:text-4xl font-extrabold">پلتفرم داده و مدیریت انرژی و آب خراسان رضوی</h1>
         <p class="mt-3 md:mt-4 md:text-lg">داده‌های هوشمند برای مدیریت پایدار منابع</p>
       </div>
+
       <div class="hero-cards" aria-label="quick dashboards">
           <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">
             <svg class="w-12 h-12 text-sky-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C8 6.5 5 10.5 5 14a7 7 0 1 0 14 0c0-3.5-3-7.5-7-12z"/></svg>
@@ -239,6 +246,22 @@
       </a>
     </div>
   </div>
+  <script>
+(function(){
+  const root = document.documentElement;
+  const header = document.querySelector('header, .site-header, nav[role="navigation"]');
+  const footer = document.querySelector('footer, .site-footer');
+  function setHF(){
+    const hh = header ? header.getBoundingClientRect().height : 0;
+    const fh = footer ? footer.getBoundingClientRect().height : 0;
+    root.style.setProperty('--header-h', hh + 'px');
+    root.style.setProperty('--footer-h', fh + 'px');
+  }
+  setHF();
+  addEventListener('load', setHF);
+  addEventListener('resize', setHF);
+})();
+</script>
   <script defer src="index.js?v=1"></script>
   <script defer src="assets/numfmt.js?v=1"></script>
 </body>


### PR DESCRIPTION
## Summary
- enhance landing hero with clarity filter and dynamic safe area respecting header and footer
- keep content panel glassy and ensure hero cards stay above footer
- add detail toggle and script to update header/footer offsets on resize

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a4a6df06848328a53b432407bf0a28