### PR TITLE
feat: add parallax landing hero and dashboard cards

### DIFF
--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -1,0 +1,39 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const back = document.querySelector('.layer-back');
+  const front = document.querySelector('.layer-front');
+  if (back) {
+    window.addEventListener('scroll', () => {
+      const y = window.pageYOffset;
+      back.style.transform = `translateY(${y * 0.2}px)`;
+      if (front) {
+        front.style.transform = `translateY(${y * 0.4}px)`;
+      }
+    });
+  }
+
+  const cta = document.querySelector('.cta-button');
+  if (cta) {
+    cta.addEventListener('click', (e) => {
+      e.preventDefault();
+      const target = document.querySelector(cta.getAttribute('href'));
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth' });
+      }
+    });
+  }
+
+  const cards = document.querySelectorAll('.card');
+  if ('IntersectionObserver' in window) {
+    const observer = new IntersectionObserver((entries, obs) => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible');
+          obs.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.1 });
+    cards.forEach(card => observer.observe(card));
+  } else {
+    cards.forEach(card => card.classList.add('visible'));
+  }
+});

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -181,3 +181,122 @@ main .cta, main .hero-cta {
   border: 1px solid #E5E7EB;
   border-radius: .5rem;
 }
+
+/* ===== Parallax Hero ===== */
+.parallax-section {
+  position: relative;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.parallax-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 150%;
+  background-size: cover;
+  background-position: center;
+  will-change: transform;
+}
+
+.layer-back {
+  background-image: url('../page/landing/hiro2.webp');
+}
+
+.layer-front {
+  background-image: url('../page/landing/hiro1.webp');
+  filter: brightness(1.1) saturate(1.2);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,0.3);
+}
+
+.parallax-section .content {
+  position: relative;
+  z-index: 10;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: #fff;
+  text-shadow: 0 2px 4px rgba(0,0,0,0.6);
+  padding: 0 1rem;
+}
+
+.parallax-section .content h1 {
+  font-size: 2rem;
+  margin-bottom: 1rem;
+}
+
+.parallax-section .content h2 {
+  font-size: 1.125rem;
+  margin-bottom: 1.5rem;
+  font-weight: 400;
+}
+
+.cta-button {
+  background-color: #FFD600;
+  color: #0D47A1;
+  padding: 0.75rem 1.5rem;
+  border-radius: 8px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background-color .3s ease;
+}
+.cta-button:hover {
+  background-color: #ffca28;
+}
+
+/* ===== Dashboard Cards ===== */
+.cards-section {
+  display: flex;
+  justify-content: center;
+  gap: 1.5rem;
+  padding: 3rem 1rem;
+  flex-wrap: wrap;
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  text-decoration: none;
+  border-radius: 16px;
+  padding: 2rem 1.5rem;
+  box-shadow: 0 4px 10px rgba(0,0,0,0.15);
+  opacity: 0;
+  transform: translateY(40px);
+  transition: opacity .8s ease-out, transform .8s ease-out;
+  font-size: 1.125rem;
+}
+
+.card .icon {
+  font-size: 2.5rem;
+  margin-bottom: .5rem;
+}
+
+.card.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.card.water { background-color: #0097A7; color: #fff; }
+.card.electricity { background-color: #FFA000; color: #000; }
+.card.gas { background-color: #388E3C; color: #fff; }
+
+@media (max-width: 768px) {
+  .layer-front { display: none; }
+  .parallax-section .content h1 { font-size: 1.5rem; }
+  .parallax-section .content h2 { font-size: 1rem; }
+  .cards-section { flex-direction: column; align-items: center; }
+  .card { width: 100%; max-width: 320px; }
+}
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,58 +46,30 @@
         </button>
       </div>
     </header>
-    <section id="landing-hero" class="hero">
-      <div class="detail-toggle" onclick="
-    const h=document.getElementById('landing-hero');
-    h.classList.toggle('art-detail');
-    this.innerText = h.classList.contains('art-detail') ? 'نمایش معمولی' : 'نمایش جزئیات تصویر';
-  ">نمایش جزئیات تصویر</div>
-
-      <div class="content-panel">
-        <h1 class="text-2xl md:text-4xl font-extrabold">پلتفرم داده و مدیریت انرژی و آب خراسان رضوی</h1>
-        <p class="mt-3 md:mt-4 md:text-lg">داده‌های هوشمند برای مدیریت پایدار منابع</p>
-      </div>
-
-      <div class="hero-cards" aria-label="quick dashboards">
-          <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">
-            <svg class="w-12 h-12 text-sky-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C8 6.5 5 10.5 5 14a7 7 0 1 0 14 0c0-3.5-3-7.5-7-12z"/></svg>
-            <h2 class="text-lg font-semibold text-slate-900 mb-2">آب</h2>
-            <p class="text-slate-600 text-sm flex-grow">پایش و مدیریت منابع آبی استان.</p>
-            <a href="/water/hub" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
-          </article>
-          <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">
-            <svg class="w-12 h-12 text-yellow-500 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13 2L3 14h7v8l10-12h-7z"/></svg>
-            <h2 class="text-lg font-semibold text-slate-900 mb-2">برق</h2>
-            <p class="text-slate-600 text-sm flex-grow">رصد مصرف و تولید برق.</p>
-            <a href="electricity/" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
-          </article>
-          <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">
-            <svg class="w-12 h-12 text-amber-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C10 5 7 8.9 7 13a5 5 0 0 0 10 0c0-4.1-3-8-5-11z"/></svg>
-            <h2 class="text-lg font-semibold text-slate-900 mb-2">گاز و فرآورده‌ها</h2>
-            <p class="text-slate-600 text-sm flex-grow">اطلاعات شبکه گاز و فرآورده‌های نفتی.</p>
-            <a href="./gas/" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
-          </article>
+    <section id="landing-hero" class="parallax-section">
+      <div class="parallax-layer layer-back" aria-hidden="true"></div>
+      <div class="parallax-layer layer-front" aria-hidden="true"></div>
+      <div class="overlay" aria-hidden="true"></div>
+      <div class="content">
+        <h1>مدیریت هوشمند آب، برق و گاز در خراسان رضوی</h1>
+        <h2>داشبوردهای تعاملی برای آگاهی، بهینه‌سازی و تصمیم‌گیری بهتر</h2>
+        <a href="#dashboards" class="cta-button">🚀 مشاهده داشبوردها</a>
       </div>
     </section>
-  <main id="main" class="flex-grow space-y-14">
-    <section class="max-w-6xl mx-auto px-4 mt-10">
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
-          <svg class="w-8 h-8 text-sky-500" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <circle cx="18" cy="18" r="16" stroke="#e2e8f0" stroke-width="4" />
-            <circle cx="18" cy="18" r="16" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-dasharray="100" stroke-dashoffset="62" />
-          </svg>
-          <span class="text-sm md:text-base text-slate-700">پرشدگی مخازن ۳۸٪</span>
-        </div>
-        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
-          <svg class="w-8 h-8 text-yellow-500" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13 2L3 14h7v8l10-12h-7z"/></svg>
-          <span class="text-sm md:text-base text-slate-700">پیک امروز برق ۴,۸۰۰ MW</span>
-        </div>
-        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
-          <svg class="w-8 h-8 text-slate-400" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 1a11 11 0 1 0 0 22 11 11 0 0 0 0-22zm1 11V6h-2v8h7v-2h-5z"/></svg>
-          <span class="text-sm md:text-base text-slate-700">آخرین به‌روزرسانی: ۲۵ مرداد ۱۴۰۴</span>
-        </div>
-      </div>
+  <main id="main" class="flex-grow">
+    <section id="dashboards" class="cards-section">
+      <a href="/water/hub" class="card water" aria-label="ورود به داشبورد آب">
+        <span class="icon" aria-hidden="true">💧</span>
+        <h3>آب</h3>
+      </a>
+      <a href="/electricity/" class="card electricity" aria-label="ورود به داشبورد برق">
+        <span class="icon" aria-hidden="true">⚡</span>
+        <h3>برق</h3>
+      </a>
+      <a href="/gas/" class="card gas" aria-label="ورود به داشبورد گاز">
+        <span class="icon" aria-hidden="true">🔥</span>
+        <h3>گاز</h3>
+      </a>
     </section>
   </main>
   <!-- Policy Sheet -->
@@ -262,6 +234,7 @@
   addEventListener('resize', setHF);
 })();
 </script>
+  <script defer src="assets/main.js"></script>
   <script defer src="index.js?v=1"></script>
   <script defer src="assets/numfmt.js?v=1"></script>
 </body>


### PR DESCRIPTION
## Summary
- add layered parallax hero with clear message and CTA
- introduce responsive dashboard cards for water, electricity, and gas
- implement scroll-based parallax, smooth scroll, and card fade-in animations

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a545c1e1ec83289e75f55ef78fa17a