### PR TITLE
feat: add parallax landing hero and dashboard cards

### DIFF
--- a/docs/assets/main.js
+++ b/docs/assets/main.js
@@ -1,0 +1,50 @@
+(function(){
+  const supportsRAF = 'requestAnimationFrame' in window;
+  const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+
+  const layers = Array.from(document.querySelectorAll('.parallax-layer'));
+  const cards = Array.from(document.querySelectorAll('.card'));
+
+  // Fallback تصویر: اگر لایه‌ها تصویر پس‌زمینه ندارند یا van-gogh.webp موجود نبود، از header2.webp استفاده کن
+  layers.forEach(l => {
+    const style = getComputedStyle(l);
+    if (!style.backgroundImage || style.backgroundImage === 'none'){
+      l.style.backgroundImage = "url('../header2.webp')"; // TODO: replace with van-gogh.webp when available
+    }
+  });
+
+  // Parallax
+  if (supportsRAF && !reduceMotion){
+    let ticking = false;
+    const onScroll = () => {
+      if (!ticking){
+        requestAnimationFrame(() => {
+          const y = window.scrollY || window.pageYOffset;
+          layers.forEach(layer => {
+            const speed = parseFloat(layer.getAttribute('data-speed') || '0');
+            layer.style.transform = `translate3d(0, ${y * speed}px, 0)`;
+          });
+          ticking = false;
+        });
+        ticking = true;
+      }
+    };
+    if (!isMobile){ onScroll(); window.addEventListener('scroll', onScroll, {passive:true}); }
+  }
+
+  // Cards reveal
+  if ('IntersectionObserver' in window){
+    const io = new IntersectionObserver((entries) => {
+      entries.forEach(e => {
+        if (e.isIntersecting){
+          e.target.classList.add('visible');
+          io.unobserve(e.target);
+        }
+      });
+    }, {rootMargin:'-10% 0px'});
+    cards.forEach(c => io.observe(c));
+  } else {
+    cards.forEach(c => c.classList.add('visible'));
+  }
+})();

--- a/docs/assets/styles.css
+++ b/docs/assets/styles.css
@@ -181,3 +181,76 @@ main .cta, main .hero-cta {
   border: 1px solid #E5E7EB;
   border-radius: .5rem;
 }
+
+/* Hero Parallax */
+.parallax-section{
+  position: relative;
+  min-height: 100vh;
+  overflow: hidden;
+  isolation: isolate;
+}
+.parallax-layer{
+  position: absolute; inset: -10% 0 0 0;
+  background-size: cover; background-position: center;
+  will-change: transform;
+  transform: translate3d(0,0,0);
+}
+.layer-back{
+  background-image: url('../header2.webp'); /* TODO: replace with van-gogh.webp */
+}
+.layer-front{
+  background-image: url('../header2.webp'); /* TODO: replace with van-gogh.webp */
+  filter: contrast(1.05) saturate(1.05) blur(0.2px);
+  opacity: .55;
+}
+.parallax-overlay{
+  position: absolute; inset: 0;
+  background: linear-gradient(to bottom, rgba(0,0,0,.35), rgba(0,0,0,.25) 40%, rgba(0,0,0,.15));
+  pointer-events: none;
+}
+.hero-content{
+  position: relative; z-index: 2;
+  display: grid; place-items: center;
+  text-align: center; color: #fff;
+  padding: 14vh 1rem 8vh;
+}
+.hero-content h1{ font-size: clamp(22px, 4vw, 42px); line-height: 1.25; text-shadow: 0 2px 6px rgba(0,0,0,.35); }
+.hero-content p{ margin-top: .75rem; font-size: clamp(14px, 2.1vw, 18px); opacity: .95; }
+
+/* Cards */
+.cards-section{
+  display: grid; grid-template-columns: repeat(3, minmax(210px, 1fr));
+  gap: 1.25rem; max-width: 980px; margin: -60px auto 48px; padding: 0 16px;
+}
+.card{
+  background: rgba(255,255,255,.9);
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(0,0,0,.12);
+  backdrop-filter: blur(2px);
+  padding: 18px 20px; text-align: center;
+  transform: translateY(32px); opacity: 0; transition: transform .8s ease, opacity .8s ease;
+}
+.card .icon{ font-size:2.5rem; display:block; margin-bottom:.5rem; }
+.card.visible{ transform: translateY(0); opacity: 1; }
+
+/* رنگ‌های نمونه همسو با ونگوک – در صورت داشتن کلاس‌های اختصاصی کارت‌ها، اعمال کن */
+.card.water{ background: #007c91; color:#fff; }
+.card.electricity{ background: #f6a800; color:#1a1a1a; }
+.card.gas{ background: #2e7d32; color:#fff; }
+
+/* ریسپانسیو */
+@media (max-width: 992px){
+  .cards-section{ grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 640px){
+  .cards-section{ grid-template-columns: 1fr; margin-top: -30px; }
+  .hero-content{ padding: 12vh 1rem 6vh; }
+  .layer-front{ display: none; }
+}
+
+/* کاهش حرکت برای دسترس‌پذیری */
+@media (prefers-reduced-motion: reduce){
+  .parallax-layer{ transform: none !important; }
+  .card{ transition: none; transform: none; opacity: 1; }
+}
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,58 +46,29 @@
         </button>
       </div>
     </header>
-    <section id="landing-hero" class="hero">
-      <div class="detail-toggle" onclick="
-    const h=document.getElementById('landing-hero');
-    h.classList.toggle('art-detail');
-    this.innerText = h.classList.contains('art-detail') ? 'نمایش معمولی' : 'نمایش جزئیات تصویر';
-  ">نمایش جزئیات تصویر</div>
-
-      <div class="content-panel">
-        <h1 class="text-2xl md:text-4xl font-extrabold">پلتفرم داده و مدیریت انرژی و آب خراسان رضوی</h1>
-        <p class="mt-3 md:mt-4 md:text-lg">داده‌های هوشمند برای مدیریت پایدار منابع</p>
-      </div>
-
-      <div class="hero-cards" aria-label="quick dashboards">
-          <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">
-            <svg class="w-12 h-12 text-sky-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C8 6.5 5 10.5 5 14a7 7 0 1 0 14 0c0-3.5-3-7.5-7-12z"/></svg>
-            <h2 class="text-lg font-semibold text-slate-900 mb-2">آب</h2>
-            <p class="text-slate-600 text-sm flex-grow">پایش و مدیریت منابع آبی استان.</p>
-            <a href="/water/hub" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
-          </article>
-          <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">
-            <svg class="w-12 h-12 text-yellow-500 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13 2L3 14h7v8l10-12h-7z"/></svg>
-            <h2 class="text-lg font-semibold text-slate-900 mb-2">برق</h2>
-            <p class="text-slate-600 text-sm flex-grow">رصد مصرف و تولید برق.</p>
-            <a href="electricity/" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
-          </article>
-          <article class="rounded-2xl bg-white/80 backdrop-blur border border-slate-100 shadow-sm hover:shadow-xl hover:-translate-y-1 transition-all duration-300 p-6 md:p-7 flex flex-col dash-card">
-            <svg class="w-12 h-12 text-amber-600 mb-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 2C10 5 7 8.9 7 13a5 5 0 0 0 10 0c0-4.1-3-8-5-11z"/></svg>
-            <h2 class="text-lg font-semibold text-slate-900 mb-2">گاز و فرآورده‌ها</h2>
-            <p class="text-slate-600 text-sm flex-grow">اطلاعات شبکه گاز و فرآورده‌های نفتی.</p>
-            <a href="./gas/" class="mt-4 inline-block rounded-full px-4 py-2 text-sm font-medium text-white bg-gradient-to-r from-sky-600 to-cyan-500 shadow hover:shadow-md focus:outline-none focus:ring-2 focus:ring-sky-400/50">ورود</a>
-          </article>
+    <section class="parallax-section" aria-label="hero">
+      <div class="parallax-layer layer-back" data-speed="-0.15" aria-hidden="true"></div>
+      <div class="parallax-layer layer-front" data-speed="-0.35" aria-hidden="true"></div>
+      <div class="parallax-overlay" aria-hidden="true"></div>
+      <div class="hero-content">
+        <h1>مدیریت هوشمند آب، برق و گاز در خراسان رضوی</h1>
+        <p>داشبوردهای تعاملی برای آگاهی، بهینه‌سازی و تصمیم‌گیری بهتر</p>
       </div>
     </section>
-  <main id="main" class="flex-grow space-y-14">
-    <section class="max-w-6xl mx-auto px-4 mt-10">
-      <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
-          <svg class="w-8 h-8 text-sky-500" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-            <circle cx="18" cy="18" r="16" stroke="#e2e8f0" stroke-width="4" />
-            <circle cx="18" cy="18" r="16" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-dasharray="100" stroke-dashoffset="62" />
-          </svg>
-          <span class="text-sm md:text-base text-slate-700">پرشدگی مخازن ۳۸٪</span>
-        </div>
-        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
-          <svg class="w-8 h-8 text-yellow-500" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M13 2L3 14h7v8l10-12h-7z"/></svg>
-          <span class="text-sm md:text-base text-slate-700">پیک امروز برق ۴,۸۰۰ MW</span>
-        </div>
-        <div class="bg-slate-50 border border-slate-100 rounded-xl p-3 md:p-4 flex items-center gap-3">
-          <svg class="w-8 h-8 text-slate-400" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 1a11 11 0 1 0 0 22 11 11 0 0 0 0-22zm1 11V6h-2v8h7v-2h-5z"/></svg>
-          <span class="text-sm md:text-base text-slate-700">آخرین به‌روزرسانی: ۲۵ مرداد ۱۴۰۴</span>
-        </div>
-      </div>
+  <main id="main" class="flex-grow">
+    <section id="entry-cards" class="cards-section" aria-label="navigation cards">
+      <a href="/water/hub" class="card water" aria-label="ورود به داشبورد آب">
+        <span class="icon" aria-hidden="true">💧</span>
+        <h3>آب</h3>
+      </a>
+      <a href="/electricity/" class="card electricity" aria-label="ورود به داشبورد برق">
+        <span class="icon" aria-hidden="true">⚡</span>
+        <h3>برق</h3>
+      </a>
+      <a href="/gas/" class="card gas" aria-label="ورود به داشبورد گاز">
+        <span class="icon" aria-hidden="true">🔥</span>
+        <h3>گاز</h3>
+      </a>
     </section>
   </main>
   <!-- Policy Sheet -->
@@ -262,6 +233,7 @@
   addEventListener('resize', setHF);
 })();
 </script>
+  <script defer src="assets/main.js"></script>
   <script defer src="index.js?v=1"></script>
   <script defer src="assets/numfmt.js?v=1"></script>
 </body>


### PR DESCRIPTION
## Summary
- refine hero with layered parallax and clear messaging without CTA
- show water, electricity, and gas entry cards that fade in after the hero
- drive parallax scrolling and card reveal via requestAnimationFrame and IntersectionObserver

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a545c1e1ec83289e75f55ef78fa17a