### PR TITLE
refactor landing hero parallax

### DIFF
--- a/docs/assets/fonts.css
+++ b/docs/assets/fonts.css
@@ -5,4 +5,4 @@
   font-style: normal;
   font-display: swap;
 }
-html, body { font-family: 'Vazirmatn', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+html, body{ font-family: 'Vazirmatn', system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }

--- a/docs/assets/parallax.js
+++ b/docs/assets/parallax.js
@@ -1,33 +1,32 @@
 (function(){
   const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const hero = document.querySelector('.parallax-section');
-  const bgUrl = hero ? hero.getAttribute('data-bg') : null;
   const layers = Array.from(document.querySelectorAll('.parallax-layer'));
-  if (bgUrl){ layers.forEach(l => l.style.backgroundImage = `url('${bgUrl}')`); }
+  const cards  = Array.from(document.querySelectorAll('.card'));
+  const vh = Math.max(1, window.innerHeight);
 
-  if (!reduceMotion && 'requestAnimationFrame' in window){
-    let ticking = false;
-    const onScroll = () => {
-      if (!ticking){
-        requestAnimationFrame(() => {
-          const y = window.scrollY || window.pageYOffset;
-          layers.forEach(layer => {
-            const speed = parseFloat(layer.getAttribute('data-speed') || '0');
-            layer.style.transform = `translate3d(0, ${y * speed}px, 0)`;
-          });
-          ticking = false;
-        });
-        ticking = true;
+  function tick(){
+    const y = window.scrollY || 0;
+    // اورلی پویا: ابتدای صفحه تیره‌تر، با اسکرول کمی روشن‌تر
+    const p = Math.min(1, y / (vh * 0.7));
+    document.documentElement.style.setProperty('--overlay', (0.35 - p * 0.2).toFixed(2));
+
+    // پارالاکس با اختلاف سرعت
+    if (!reduceMotion){
+      for (const el of layers){
+        const s = parseFloat(el.getAttribute('data-speed') || '0');
+        el.style.transform = `translate3d(0, ${y * s}px, 0)`;
       }
-    };
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
+    }
+    requestAnimationFrame(tick);
   }
+  requestAnimationFrame(tick);
 
-  const cards = Array.from(document.querySelectorAll('.card'));
+  // ظاهر شدن کارت‌ها
   if ('IntersectionObserver' in window){
     const io = new IntersectionObserver((entries)=>{
-      entries.forEach(e => { if (e.isIntersecting){ e.target.classList.add('visible'); io.unobserve(e.target); } });
+      entries.forEach(e => {
+        if (e.isIntersecting){ e.target.classList.add('visible'); io.unobserve(e.target); }
+      });
     }, { rootMargin: '-10% 0px' });
     cards.forEach(c => io.observe(c));
   } else {

--- a/docs/index.html
+++ b/docs/index.html
@@ -10,16 +10,9 @@
   <meta name="twitter:image" content="header2.webp" />
   <meta name="section" content="site" />
   <title>wesh360</title>
-  <link rel="stylesheet" href="./assets/tailwind.css" />
-  <link rel="stylesheet" href="./assets/global-footer.css">
-  <link rel="stylesheet" href="./assets/footer.css">
-  <link rel="preload" as="image" href="./page/landing/hiro2.webp" fetchpriority="high">
   <link rel="stylesheet" href="./assets/fonts.css">
-  <link rel="stylesheet" href="./assets/unified-badge.css">
   <link rel="stylesheet" href="./page/landing/landing.css">
   <link rel="icon" type="image/x-icon" href="./page/landing/favicon.ico">
-  <script defer src="./assets/unified-badge.js"></script>
-  <script defer src="./assets/global-footer.js"></script>
 </head>
   <body class="min-h-screen flex flex-col">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
@@ -46,10 +39,10 @@
         </button>
       </div>
     </header>
-    <section class="parallax-section" aria-label="hero" data-bg="./page/landing/hiro2.webp">
-      <div class="parallax-layer layer-back" data-speed="-0.15" aria-hidden="true"></div>
-      <div class="parallax-layer layer-front" data-speed="-0.35" aria-hidden="true"></div>
-      <div class="parallax-overlay" aria-hidden="true"></div>
+    <section class="parallax-section" aria-label="hero">
+      <div class="parallax-layer layer-back"  data-speed="-0.10"></div>
+      <div class="parallax-layer layer-front" data-speed="-0.35"></div>
+      <div class="parallax-overlay"></div>
       <div class="hero-content">
         <h1>مدیریت هوشمند آب، برق و گاز در خراسان رضوی</h1>
         <p>داشبوردهای تعاملی برای آگاهی، بهینه‌سازی و تصمیم‌گیری بهتر</p>
@@ -217,24 +210,6 @@
       </a>
     </div>
   </div>
-  <script>
-(function(){
-  const root = document.documentElement;
-  const header = document.querySelector('header, .site-header, nav[role="navigation"]');
-  const footer = document.querySelector('footer, .site-footer');
-  function setHF(){
-    const hh = header ? header.getBoundingClientRect().height : 0;
-    const fh = footer ? footer.getBoundingClientRect().height : 0;
-    root.style.setProperty('--header-h', hh + 'px');
-    root.style.setProperty('--footer-h', fh + 'px');
-  }
-  setHF();
-  addEventListener('load', setHF);
-  addEventListener('resize', setHF);
-})();
-</script>
-  <script defer src="./assets/parallax.js"></script>
-  <script defer src="index.js?v=1"></script>
-  <script defer src="assets/numfmt.js?v=1"></script>
+  <script src="./assets/parallax.js" defer></script>
 </body>
 </html>

--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -1,22 +1,88 @@
-.parallax-section{ position:relative; min-height:100vh; overflow:hidden; isolation:isolate; }
-.parallax-layer{ position:absolute; inset:-10% 0 0 0; background-size:cover; background-position:center; will-change:transform; transform:translate3d(0,0,0); }
-.layer-front{ filter:contrast(1.05) saturate(1.05) blur(.2px); opacity:.55; }
-.parallax-overlay{ position:absolute; inset:0; background:linear-gradient(to bottom, rgba(0,0,0,.35), rgba(0,0,0,.25) 40%, rgba(0,0,0,.15)); pointer-events:none; }
-.hero-content{ position:relative; z-index:2; display:grid; place-items:center; text-align:center; color:#fff; padding:14vh 1rem 8vh; }
-.hero-content h1{ font-size:clamp(22px,4vw,42px); line-height:1.25; text-shadow:0 2px 6px rgba(0,0,0,.35); }
-.hero-content p{ margin-top:.75rem; font-size:clamp(14px,2.1vw,18px); opacity:.95; }
-
-.cards-section{ display:grid; grid-template-columns:repeat(3, minmax(210px,1fr)); gap:1.25rem; max-width:980px; margin:-60px auto 48px; padding:0 16px; }
-.card{ background:rgba(255,255,255,.9); border-radius:16px; box-shadow:0 10px 30px rgba(0,0,0,.12); backdrop-filter:blur(2px); padding:18px 20px; text-align:center; transform:translateY(32px); opacity:0; transition:transform .8s ease, opacity .8s ease; }
-.card.visible{ transform:translateY(0); opacity:1; }
-
-@media (max-width:992px){ .cards-section{ grid-template-columns:1fr 1fr; } }
-@media (max-width:640px){
-  .cards-section{ grid-template-columns:1fr; margin-top:-30px; }
-  .hero-content{ padding:12vh 1rem 6vh; }
-  .layer-front{ display:none; }
+:root{
+  --vg: url('./hiro2.webp');   /* تصویر هیرو فقط از این مسیر */
+  --overlay: .35;              /* تیرگی اولیه اورلی */
 }
+
+/* Hero Parallax */
+.parallax-section{
+  position: relative;
+  min-height: 100svh; /* svh برای iOS جدید پایدارتر از vh است */
+  overflow: hidden;
+  isolation: isolate;
+}
+.parallax-layer{
+  position: absolute; inset: -10% 0 0 0;
+  background-image: var(--vg);
+  background-size: cover;
+  background-position: center;
+  will-change: transform;
+  transform: translate3d(0,0,0);
+}
+.layer-front{
+  filter: contrast(1.05) saturate(1.05) blur(.2px);
+  opacity: .55;
+}
+.parallax-overlay{
+  position: absolute; inset: 0;
+  background: linear-gradient(
+    to bottom,
+    rgba(0,0,0,var(--overlay)),
+    rgba(0,0,0, calc(var(--overlay) - .1)) 40%,
+    rgba(0,0,0, .12)
+  );
+  pointer-events: none;
+}
+.hero-content{
+  position: relative; z-index: 2;
+  display: grid; place-items: center;
+  text-align: center; color: #fff;
+  padding: 14svh 1rem 8svh;
+}
+.hero-content h1{
+  font-size: clamp(22px, 4vw, 42px);
+  line-height: 1.25;
+  text-shadow: 0 2px 6px rgba(0,0,0,.32);
+}
+.hero-content p{
+  margin-top: .9rem;
+  font-size: clamp(14px, 2.1vw, 18px);
+  opacity: .95;
+}
+
+/* Cards زیر هیرو (همپوشانی برای سیگنال اسکرول) */
+.cards-section{
+  display: grid;
+  grid-template-columns: repeat(3, minmax(210px,1fr));
+  gap: 1.25rem;
+  max-width: 980px;
+  margin: -64px auto 48px;   /* همپوشانی با هیرو */
+  padding: 0 16px;
+  content-visibility: auto; contain-intrinsic-size: 800px;
+}
+.card{
+  background: rgba(255,255,255,.9);
+  border-radius: 16px;
+  box-shadow: 0 8px 24px rgba(0,0,0,.16);
+  backdrop-filter: blur(2px);
+  padding: 18px 20px; text-align: center;
+  transform: translateY(32px); opacity: 0;
+  transition: transform .8s ease, opacity .8s ease;
+}
+.card.visible{ transform: translateY(0); opacity: 1; }
+
+/* ریسپانسیو و موبایل */
+@media (max-width: 992px){
+  .cards-section{ grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 640px){
+  .cards-section{ grid-template-columns: 1fr; margin: -32px auto 40px; }
+  .hero-content{ padding: 12svh 1rem 6svh; }
+  .parallax-layer{ background-position: 40% center; } /* فوکوس بهتر تابلو در موبایل */
+  .layer-front{ display: none; } /* موبایل: سبک‌تر */
+}
+
+/* کاهش حرکت برای دسترس‌پذیری */
 @media (prefers-reduced-motion: reduce){
-  .parallax-layer{ transform:none !important; }
-  .card{ transition:none; transform:none; opacity:1; }
+  .parallax-layer{ transform: none !important; }
+  .card{ transition: none; transform: none; opacity: 1; }
 }


### PR DESCRIPTION
## Summary
- clean head to load only fonts and landing styles and correct favicon
- rebuild hero markup for two-layer parallax with overlay and no CTA
- implement CSS variables and JS parallax to avoid duplicate image requests and respect reduced motion

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a55ace6e6883289ac1b1df97b4edfd