### PR TITLE
Enhance hero parallax depth

### DIFF
--- a/docs/assets/parallax.js
+++ b/docs/assets/parallax.js
@@ -1,29 +1,69 @@
 (function(){
-  const reduceMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const finePtr = window.matchMedia && window.matchMedia('(pointer: fine)').matches; // دسکتاپ/ماوس
   const hero = document.querySelector('.parallax-section');
   const bgUrl = hero ? hero.getAttribute('data-bg') : null;
   const layers = Array.from(document.querySelectorAll('.parallax-layer'));
+  if (!layers.length) return;
   if (bgUrl){ layers.forEach(l => l.style.backgroundImage = `url('${bgUrl}')`); }
 
-  if (!reduceMotion && 'requestAnimationFrame' in window){
-    let ticking = false;
-    const onScroll = () => {
-      if (!ticking){
-        requestAnimationFrame(() => {
-          const y = window.scrollY || window.pageYOffset;
-          layers.forEach(layer => {
-            const speed = parseFloat(layer.getAttribute('data-speed') || '0');
-            layer.style.transform = `translate3d(0, ${y * speed}px, 0)`;
-          });
-          ticking = false;
-        });
-        ticking = true;
-      }
-    };
-    onScroll();
-    window.addEventListener('scroll', onScroll, { passive: true });
+  const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+  const ampMul = isMobile ? 0.55 : 1.0;  // موبایل عمق کمتر
+
+  // اسکرول نرم با LERP (low-pass filter) و کلمپ برای جلوگیری از over-shoot
+  let targetY = 0, currentY = 0;
+  const lerp = (a,b,t)=>a+(b-a)*t;
+  const clamp = (v,min,max)=>Math.max(min, Math.min(max,v));
+
+  // تیلت خفیف با ماوس (اختیاری فقط دسکتاپ) برای حس عمق افقی
+  let tiltX = 0, tiltTargetX = 0;
+  if (finePtr){
+    window.addEventListener('mousemove', (e)=>{
+      const w = window.innerWidth || 1;
+      const n = (e.clientX / w - 0.5);           // -0.5..+0.5
+      tiltTargetX = clamp(n * 10, -10, 10);      // حداکثر 10px جابه‌جایی افقی
+    }, {passive:true});
   }
 
+  const vh = Math.max(1, window.innerHeight);
+  function frame(){
+    targetY = window.scrollY || 0;
+    // لِرپ برای روانی
+    currentY = lerp(currentY, targetY, 0.08);
+
+    // اورلی تطبیقی (اگر CSS از --overlay استفاده می‌کند)
+    const p = Math.min(1, currentY / (vh * 0.7));
+    document.documentElement.style.setProperty('--overlay', (0.35 - p * 0.2).toFixed(2));
+
+    // لِرپ تیلت
+    if (finePtr){ tiltX = lerp(tiltX, tiltTargetX, 0.1); }
+
+    // اعمال پارالاکس بر اساس data-speed هر لایه (تقویت شده با ampMul)
+    for (const el of layers){
+      const base = parseFloat(el.getAttribute('data-speed') || '0'); // مثل -0.46 یا -0.14
+      // دامنه حرکت را نسبت به ارتفاع ویوپورت کمی نرمال کنیم تا در نمایشگرهای کوتاه/بلند متعادل باشد
+      const norm = currentY * base * ampMul * (vh / 900);
+      // محدودیت حرکت برای جلوگیری از بیرون‌زدن لبه‌ها
+      const limited = clamp(norm, -vh * 0.8, vh * 0.8);
+      // اسکیل جزئی همراه با عمق برای لایه جلو (خیلی ظریف)
+      const depthScale = base < -0.30 ? 1.02 : 1.0;
+      el.style.setProperty('--pz', depthScale.toFixed(3));
+      // ترکیب حرکت عمودی + تیلت افقی خفیف
+      const dx = finePtr ? (tiltX * (base < -0.30 ? 1.0 : 0.6)) : 0;
+      el.style.transform = `translate3d(${dx}px, ${limited}px, 0) scale(var(--pz,1.10))`;
+    }
+
+    requestAnimationFrame(frame);
+  }
+
+  if (!reduce) requestAnimationFrame(frame);
+  else {
+    // اگر کاهش حرکت فعال است، هیچ ترنسفورمی اعمال نکن
+    layers.forEach(el => el.style.transform = 'none');
+  }
+})();
+
+(function(){
   const cards = Array.from(document.querySelectorAll('.card'));
   if ('IntersectionObserver' in window){
     const io = new IntersectionObserver((entries)=>{
@@ -34,3 +74,4 @@
     cards.forEach(c => c.classList.add('visible'));
   }
 })();
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -47,8 +47,8 @@
       </div>
     </header>
     <section class="parallax-section" aria-label="hero" data-bg="./page/landing/hiro2.webp">
-      <div class="parallax-layer layer-back" data-speed="-0.15" aria-hidden="true"></div>
-      <div class="parallax-layer layer-front" data-speed="-0.35" aria-hidden="true"></div>
+      <div class="parallax-layer layer-back" data-speed="-0.14" aria-hidden="true"></div>
+      <div class="parallax-layer layer-front" data-speed="-0.46" aria-hidden="true"></div>
       <div class="parallax-overlay" aria-hidden="true"></div>
       <div class="hero-content">
         <h1>مدیریت هوشمند آب، برق و گاز در خراسان رضوی</h1>

--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -1,5 +1,5 @@
-.parallax-section{ position:relative; min-height:100vh; overflow:hidden; isolation:isolate; }
-.parallax-layer{ position:absolute; inset:-10% 0 0 0; background-size:cover; background-position:center; will-change:transform; transform:translate3d(0,0,0); }
+.parallax-section{ position:relative; min-height:100svh; overflow:hidden; isolation:isolate; perspective:1200px; }
+.parallax-layer{ position:absolute; inset:-12% 0 0 0; background-size:cover; background-position:center; will-change:transform; transform:translate3d(0,0,0) scale(var(--pz,1.10)); transform-origin:center center; }
 .layer-front{ filter:contrast(1.05) saturate(1.05) blur(.2px); opacity:.55; }
 .parallax-overlay{ position:absolute; inset:0; background:linear-gradient(to bottom, rgba(0,0,0,.35), rgba(0,0,0,.25) 40%, rgba(0,0,0,.15)); pointer-events:none; }
 .hero-content{ position:relative; z-index:2; display:grid; place-items:center; text-align:center; color:#fff; padding:14vh 1rem 8vh; }
@@ -12,6 +12,8 @@
 
 @media (max-width:992px){ .cards-section{ grid-template-columns:1fr 1fr; } }
 @media (max-width:640px){
+  .parallax-section{ perspective:900px; }
+  .parallax-layer{ inset:-8% 0 0 0; transform:translate3d(0,0,0) scale(1.06); }
   .cards-section{ grid-template-columns:1fr; margin-top:-30px; }
   .hero-content{ padding:12vh 1rem 6vh; }
   .layer-front{ display:none; }


### PR DESCRIPTION
## Summary
- Intensify hero parallax by increasing layer speed differentials
- Add perspective and safe-scale to parallax layers for deeper motion without edge reveal
- Replace parallax engine with smooth lerp/clamp system plus optional mouse tilt while keeping card reveal logic

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run flag:test` *(fails: Failed to launch the browser process: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a55edda4a08328b54db56df3ab2445