### PR TITLE
Enhance header transparency and hero spacing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -23,8 +23,8 @@
 </head>
   <body class="min-h-screen flex flex-col">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-    <header class="relative p-4 flex justify-center items-center">
-      <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
+    <header class="site-header relative flex justify-center items-center px-4">
+      <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
       <div class="absolute top-4 right-4 flex items-center gap-2">
         <button id="policyBtn" type="button" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-haspopup="dialog" aria-controls="policySheet" title="سیاست امنیت و حکمرانی داده">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
@@ -50,7 +50,7 @@
       <div class="parallax-layer layer-back" data-speed="-0.14" aria-hidden="true"></div>
       <div class="parallax-layer layer-front" data-speed="-0.46" aria-hidden="true"></div>
       <div class="hero-content">
-        <h1>مدیریت هوشمند آب، برق و گاز در خراسان رضوی</h1>
+        <h1 class="hero-title">مدیریت هوشمند آب، برق و گاز در خراسان رضوی</h1>
         <p>داشبوردهای تعاملی برای آگاهی، بهینه‌سازی و تصمیم‌گیری بهتر</p>
       </div>
     </section>

--- a/docs/page/landing/landing.css
+++ b/docs/page/landing/landing.css
@@ -1,9 +1,10 @@
+.site-header{ position:sticky; top:0; z-index:50; height:64px; background:rgba(255,255,255,.85); backdrop-filter:blur(6px); border-bottom:1px solid rgba(0,0,0,.08); box-shadow:0 2px 6px rgba(0,0,0,.05); }
 .parallax-section{ position:relative; min-height:100svh; overflow:hidden; isolation:isolate; perspective:1200px; }
 .parallax-layer{ position:absolute; inset:-12% 0 0 0; background-size:cover; background-position:center top; will-change:transform; transform:translate3d(0,0,0) scale(var(--pz,1.10)); transform-origin:center center; }
 .layer-front{ filter:contrast(1.05) saturate(1.05) blur(.2px); opacity:.55; }
 .parallax-section::after{ content:""; position:absolute; inset:0; z-index:1; pointer-events:none; background:linear-gradient(to bottom, rgba(0,0,0,.35) 0%, rgba(0,0,0,.15) 40%, rgba(0,0,0,.55) 100%); }
-.hero-content{ position:relative; z-index:2; display:grid; place-items:center; text-align:center; color:#fff; padding:14vh 1rem 8vh; }
-.hero-content h1{ font-size:clamp(22px,4vw,42px); line-height:1.25; text-shadow:0 2px 6px rgba(0,0,0,.35); }
+.hero-content{ position:relative; z-index:2; display:grid; place-items:center; text-align:center; color:#fff; padding:0 1rem 8vh; }
+.hero-title{ margin-top:15vh; font-size:2rem; line-height:1.25; text-shadow:0 2px 6px rgba(0,0,0,.35); }
 .hero-content p{ margin-top:.75rem; font-size:clamp(14px,2.1vw,18px); opacity:.95; }
 
 .cards-section{ display:grid; grid-template-columns:repeat(3, minmax(210px,1fr)); gap:1.25rem; max-width:980px; margin:-60px auto 48px; padding:0 16px; }
@@ -12,6 +13,7 @@
 
 @media (max-width:768px){
   .parallax-section::after{ background:linear-gradient(to bottom, rgba(0,0,0,.25) 0%, rgba(0,0,0,.1) 50%, rgba(0,0,0,.35) 100%); }
+  .hero-title{ margin-top:10vh; font-size:1.6rem; padding-left:16px; padding-right:16px; }
 }
 
 @media (max-width:992px){ .cards-section{ grid-template-columns:1fr 1fr; } }
@@ -19,7 +21,7 @@
   .parallax-section{ perspective:900px; }
   .parallax-layer{ inset:-8% 0 0 0; transform:translate3d(0,0,0) scale(1.06); }
   .cards-section{ grid-template-columns:1fr; margin-top:-30px; }
-  .hero-content{ padding:12vh 1rem 6vh; }
+  .hero-content{ padding:0 1rem 6vh; }
   .layer-front{ display:none; }
 }
 @media (prefers-reduced-motion: reduce){


### PR DESCRIPTION
## Summary
- modernize header with sticky semi-transparent background, blur, and subtle divider
- tighten hero title spacing and scale typography for small screens

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a56632288c83288df87c7336de7d69