### PR TITLE
fix: load water CLD data reliably

### DIFF
--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -3,7 +3,13 @@ window.addEventListener('DOMContentLoaded', async () => {
   if (!container || typeof window.cytoscape === 'undefined') return;
 
   try {
-    const res = await fetch('/docs/data/water-cld.json');
+    const base = window.location.pathname.startsWith('/docs/') ? '/docs' : '';
+    const jsonUrl = `${base}/data/water-cld.json?v=1`;
+    const res = await fetch(jsonUrl, { cache: 'no-store' });
+    if (res.status === 404) {
+      console.error('water-cld.json not found at', jsonUrl);
+      return;
+    }
     const data = await res.json();
 
     const elements = [];


### PR DESCRIPTION
## Summary
- dynamically resolve water CLD JSON path with version query and no-store caching
- log missing JSON path when fetch responds 404

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5fb31278883289a397c9fb3f563ee