### PR TITLE
fix: correct CLD data path and logging

### DIFF
--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -2,12 +2,11 @@ window.addEventListener('DOMContentLoaded', async () => {
   const container = document.getElementById('cy');
   if (!container || typeof window.cytoscape === 'undefined') return;
 
+  const dataUrl = "/data/water-cld.json?v=2";
   try {
-    const base = window.location.pathname.startsWith('/docs/') ? '/docs' : '';
-    const jsonUrl = `${base}/data/water-cld.json?v=1`;
-    const res = await fetch(jsonUrl, { cache: 'no-store' });
-    if (res.status === 404) {
-      console.error('water-cld.json not found at', jsonUrl);
+    const res = await fetch(dataUrl, { cache: 'no-store' });
+    if (!res.ok) {
+      console.error("CLD JSON load failed:", dataUrl, res && res.status);
       return;
     }
     const data = await res.json();
@@ -280,7 +279,7 @@ window.addEventListener('DOMContentLoaded', async () => {
       legend.innerHTML = items.join('');
     }
   } catch (err) {
-    console.error('Error loading CLD', err);
+    console.error("CLD JSON load failed:", dataUrl, err);
   }
 });
 


### PR DESCRIPTION
## Summary
- fix water CLD data URL for docs publishing and disable cache
- add detailed error logging for failed CLD JSON fetch

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a6901f4bb083289be45af4946faacb