### PR TITLE
fix: correct asset paths in water CLD test page

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="UTF-8" />
   <title>مدل پویایی بهره‌وری آب در کشاورزی</title>
-  <link rel="icon" type="image/webp" href="/docs/page/landing/logo2.webp" />
+  <link rel="icon" type="image/webp" href="/page/landing/logo2.webp" />
 </head>
 <body>
   <main dir="rtl">
     <h1>مدل پویایی بهره‌وری آب در کشاورزی</h1>
     <div id="legend" style="margin:10px 0;"></div>
-    <div id="cy" style="width:100%;height:70vh;border:1px solid #e5e7eb;"></div>
+    <div id="cy" style="width:100%;height:72vh;border:1px solid #e5e7eb;"></div>
     <section id="sim-panel" style="display:none;margin-top:1rem;">
       <form id="sim-form" style="margin-bottom:1rem;">
         <label>ضریب اثر
@@ -24,12 +24,12 @@
     </section>
   </main>
 
-  <script src="/docs/assets/vendor/cytoscape.min.js" defer></script>
-  <script src="/docs/assets/vendor/elk.bundled.js" defer></script>
-  <script src="/docs/assets/vendor/cytoscape-elk.js" defer></script>
-  <script src="/docs/assets/vendor/dagre.min.js" defer></script>
-  <script src="/docs/assets/vendor/cytoscape-dagre.js" defer></script>
-  <script src="/docs/vendor/chart.umd.min.js" defer></script>
-  <script src="/docs/assets/water-cld.js" defer></script>
+  <script src="/assets/vendor/cytoscape.min.js" defer></script>
+  <script src="/assets/vendor/elk.bundled.js" defer></script>
+  <script src="/assets/vendor/cytoscape-elk.js" defer></script>
+  <script src="/assets/vendor/dagre.min.js" defer></script>
+  <script src="/assets/vendor/cytoscape-dagre.js" defer></script>
+  <script src="/vendor/chart.umd.min.js" defer></script>
+  <script src="/assets/water-cld.js?v=2" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load vendor scripts and main water CLD script from `/assets` and `/vendor`
- update favicon path for published docs
- adjust graph container height for better layout

## Testing
- `npm test`
- `npm run flag:test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a68feccc8c8328be4fbfdc149adc02