### PR TITLE
chore: use local Chart.js and fix vendor paths

### DIFF
--- a/docs/electricity/peak.html
+++ b/docs/electricity/peak.html
@@ -6,15 +6,15 @@
     <title>داشبورد مدیریت مصرف برق — استان خراسان رضوی</title>
     <!-- Tailwind CSS -->
     <script src="https://cdn.tailwindcss.com"></script>
-    <!-- Chart.js -->
-    <script src="../vendor/chart.umd.min.js"></script>
+    <!-- Chart.js (نسخه محلی) -->
+    <script src="/vendor/chart.umd.min.js"></script>
 
     <title>داشبورد مدیریت مصرف برق - خراسان رضوی</title>
     <meta name="section" content="electricity" />
       <!-- Tailwind CSS -->
       <link rel="stylesheet" href="../assets/tailwind.css">
       <!-- Chart.js for charts -->
-      <script src="../vendor/chart.umd.min.js"></script>
+      <script src="/vendor/chart.umd.min.js"></script>
       <script src="../assets/electricity-management.js"></script>
     <!-- فونت محلی -->
     <link rel="stylesheet" href="../assets/fonts.css">

--- a/docs/electricity/quality.html
+++ b/docs/electricity/quality.html
@@ -9,8 +9,8 @@
     <!-- Tailwind CSS (نسخهٔ محلی همسان با سایر صفحات برق) -->
     <link rel="stylesheet" href="../assets/tailwind.css">
 
-    <!-- Chart.js: ابتدا تلاش برای ../vendor/chart.umd.min.js؛ در غیر این‌صورت همان نسخهٔ رایج پروژه -->
-    <script src="../vendor/chart.umd.min.js"></script>
+    <!-- Chart.js: نسخه محلی پروژه -->
+    <script src="/vendor/chart.umd.min.js"></script>
 
     <!-- فونت محلی Vazirmatn -->
   <link rel="stylesheet" href="../assets/fonts.css">

--- a/docs/gas/energy.html
+++ b/docs/gas/energy.html
@@ -138,7 +138,7 @@
   </div>
 
   <!-- کتابخانه‌ها و اسکریپت‌ها (محلی) -->
-  <script defer src="../assets/libs/chart.umd.min.js"></script>
+  <script defer src="/vendor/chart.umd.min.js"></script>
   <script defer src="../assets/numfmt.js"></script>
   <script defer src="./energy.js"></script>
   <script defer src="../assets/badge-updated.js"></script>

--- a/docs/test/water-efficiency.html
+++ b/docs/test/water-efficiency.html
@@ -18,13 +18,13 @@
     </section>
     <p style="margin-top:1rem;font-size:0.875rem;"><a href="/test/water-cld.html">تست CLD جدید</a></p>
   </main>
-  <script src="/docs/assets/vendor/cytoscape.min.js" defer></script>
-  <script src="/docs/assets/vendor/elk.bundled.js" defer></script>
-  <script src="/docs/assets/vendor/cytoscape-elk.js" defer></script>
-  <script src="/docs/assets/vendor/dagre.min.js" defer></script>
-  <script src="/docs/assets/vendor/cytoscape-dagre.js" defer></script>
-  <script src="/docs/vendor/chart.umd.min.js" defer></script>
-  <script src="/docs/assets/water-cld.js" defer></script>
-  <script src="/docs/assets/water-efficiency.js" defer></script>
+  <script src="/assets/vendor/cytoscape.min.js" defer></script>
+  <script src="/assets/vendor/elk.bundled.js" defer></script>
+  <script src="/assets/vendor/cytoscape-elk.js" defer></script>
+  <script src="/assets/vendor/dagre.min.js" defer></script>
+  <script src="/assets/vendor/cytoscape-dagre.js" defer></script>
+  <script src="/vendor/chart.umd.min.js" defer></script>
+  <script src="/assets/water-cld.js" defer></script>
+  <script src="/assets/water-efficiency.js" defer></script>
 </body>
 </html>

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -116,7 +116,7 @@
   <div class="footer-note">با هر تغییر در ورودی‌ها، نتایج به‌صورت زنده محاسبه می‌شوند.</div>
 </main>
 
-  <script src="../assets/libs/chart.umd.min.js"></script>
+  <script src="/vendor/chart.umd.min.js"></script>
   <script defer src="../assets/water-cost.js"></script>
   <script defer src="../assets/water-init.js"></script>
 </body>

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -213,8 +213,8 @@
     <div id="error-modal" class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden items-center justify-center p-4"><div class="bg-white p-6 rounded-lg shadow-lg max-w-sm mx-auto text-center"><div class="text-red-500 mb-4"><span class="text-5xl" aria-hidden="true">❗</span></div><h3 class="text-lg font-bold text-red-600 mb-2">خطا در ارتباط با سرور</h3><p id="error-message" class="text-slate-700">متاسفانه مشکلی در دریافت اطلاعات پیش آمد. لطفا دوباره تلاش کنید.</p><button id="close-modal-btn" type="button" class="mt-6 bg-red-500 text-white px-6 py-2 rounded-lg hover:bg-red-600 transition">بستن</button></div></div>
     
     
-    
-    <script defer src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/4.4.3/chart.umd.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
+    <script defer src="/vendor/chart.umd.min.js"></script>
     <script defer src="../assets/water-init.js"></script>
     <script type="module" src="../assets/ai.js"></script>
     <script defer src="../assets/app.js"></script>


### PR DESCRIPTION
## Summary
- serve Chart.js from `/vendor/chart.umd.min.js` and remove CDN/usages of assets version
- correct vendor script paths in water efficiency test page
- verify vendor assets for network graphs exist in repo

## Testing
- `npm test`
- `npm run check:no-binary`
- `python3 -m http.server 8123 --directory docs & curl -I http://localhost:8123/vendor/chart.umd.min.js`


------
https://chatgpt.com/codex/tasks/task_e_68a691059dac8328ac6bbfc65b2c1914