### PR TITLE
Add scenario simulation panel for water CLD test

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -10,17 +10,16 @@
     <h1>مدل پویایی بهره‌وری آب در کشاورزی</h1>
     <div id="legend" style="margin:10px 0;"></div>
     <div id="cy" style="width:100%;height:72vh;border:1px solid #e5e7eb;"></div>
-    <section id="sim-panel" style="display:none;margin-top:1rem;">
-      <form id="sim-form" style="margin-bottom:1rem;">
-        <label>ضریب اثر
-          <input id="sim-effect" type="number" step="0.1" value="0.1" style="margin-right:4px;">
-        </label>
-        <label style="margin-right:8px;">تاخیر
-          <input id="sim-delay" type="number" step="1" value="0" min="0" style="margin-right:4px;">
-        </label>
-        <button type="submit">اجرا</button>
-      </form>
-      <canvas id="sim-chart" height="200"></canvas>
+    <section id="sim-panel" style="margin:12px 16px">
+      <h2 style="font-size:16px;margin-bottom:8px">سناریو</h2>
+      <div style="display:flex;gap:16px;flex-wrap:wrap">
+        <label>بهره‌وری آبیاری: <input id="p-eff" type="range" min="0" max="1" step="0.05" value="0.3"></label>
+        <label>شدت تقاضا: <input id="p-dem" type="range" min="0" max="1" step="0.05" value="0.6"></label>
+        <label>تاخیر (سال): <input id="p-delay" type="range" min="0" max="5" step="1" value="1"></label>
+        <button id="btn-run" style="padding:6px 10px;border:1px solid #e5e7eb;border-radius:8px">اجرای سناریو</button>
+        <button id="btn-reset" style="padding:6px 10px;border:1px solid #e5e7eb;border-radius:8px">بازنشانی</button>
+      </div>
+      <div style="margin-top:12px"><canvas id="sim-chart" height="160"></canvas></div>
     </section>
   </main>
 


### PR DESCRIPTION
## Summary
- Add interactive scenario panel with efficiency, demand, and delay controls under the water CLD graph.
- Load local Chart.js and simulate groundwater stock via new `simulate` function with baseline and scenario datasets.
- Configure Chart.js with Persian font defaults and run/reset buttons for scenario comparison.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a697adaf408328bd6dc4539ab032f1