### PR TITLE
Add filter controls to water CLD demo

### DIFF
--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -31,6 +31,15 @@ window.addEventListener('DOMContentLoaded', async () => {
 
     // group (compound) nodes
     const groups = data.groups || [];
+    const groupSelect = document.getElementById('f-group');
+    if (groupSelect) {
+      groups.forEach(g => {
+        const opt = document.createElement('option');
+        opt.value = g.id;
+        opt.textContent = g.id;
+        groupSelect.appendChild(opt);
+      });
+    }
     groups.forEach(g => {
       elements.push({
         data: { id: g.id, color: g.color },
@@ -59,7 +68,7 @@ window.addEventListener('DOMContentLoaded', async () => {
           label: e.label,
           sign: e.sign
         },
-        classes: e.sign === '+' ? 'positive' : 'negative'
+        classes: e.sign === '+' ? 'positive pos' : 'negative neg'
       });
     });
 
@@ -142,6 +151,14 @@ window.addEventListener('DOMContentLoaded', async () => {
             'target-arrow-color': '#facc15',
             'width': 3
           }
+        },
+        {
+          selector: '.hide',
+          style: { 'display': 'none' }
+        },
+        {
+          selector: '.faded',
+          style: { 'opacity': 0.1 }
         }
       ],
       layout: { name: 'grid' }
@@ -211,6 +228,54 @@ window.addEventListener('DOMContentLoaded', async () => {
     document.addEventListener('keydown', e => {
       if (e.key === 'Escape') cy.elements().removeClass('highlighted');
     });
+
+    // filter controls
+    const fPos = document.getElementById('f-pos');
+    const fNeg = document.getElementById('f-neg');
+    const fGroup = document.getElementById('f-group');
+    const qInput = document.getElementById('q');
+
+    const updateSignFilter = () => {
+      if (fPos) cy.edges('.pos').toggleClass('hide', !fPos.checked);
+      if (fNeg) cy.edges('.neg').toggleClass('hide', !fNeg.checked);
+    };
+    if (fPos) fPos.addEventListener('change', updateSignFilter);
+    if (fNeg) fNeg.addEventListener('change', updateSignFilter);
+    updateSignFilter();
+
+    if (fGroup) {
+      fGroup.addEventListener('change', () => {
+        cy.elements().removeClass('faded');
+        const val = fGroup.value;
+        if (val) {
+          cy.nodes().filter(n => n.data('parent') !== val && n.id() !== val).addClass('faded');
+          cy.edges().filter(e => {
+            return e.source().data('parent') !== val || e.target().data('parent') !== val;
+          }).addClass('faded');
+        }
+      });
+    }
+
+    if (qInput) {
+      qInput.addEventListener('input', () => {
+        cy.elements().removeClass('faded');
+        cy.nodes().removeClass('highlighted');
+        const val = qInput.value.trim();
+        if (val) {
+          let re;
+          try {
+            re = new RegExp(val, 'i');
+          } catch (err) {
+            return;
+          }
+          cy.nodes().addClass('faded');
+          cy.edges().addClass('faded');
+          const matches = cy.nodes().filter(n => re.test(n.data('label')));
+          matches.removeClass('faded').addClass('highlighted');
+          matches.connectedEdges().removeClass('faded');
+        }
+      });
+    }
 
     // legend
     const legend = document.getElementById('legend');

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -9,6 +9,12 @@
   <main dir="rtl">
     <h1>مدل پویایی بهره‌وری آب در کشاورزی</h1>
     <div id="legend" style="margin:10px 0;"></div>
+    <div id="filters" style="margin:8px 16px;display:flex;gap:12px;flex-wrap:wrap">
+      <label><input type="checkbox" id="f-pos" checked> روابط مثبت</label>
+      <label><input type="checkbox" id="f-neg" checked> روابط منفی</label>
+      <select id="f-group"><option value="">همه گروه‌ها</option></select>
+      <input id="q" placeholder="جست‌وجوی گره..." style="padding:6px 8px;border:1px solid #e5e7eb;border-radius:8px">
+    </div>
     <div id="cy" style="width:100%;height:72vh;border:1px solid #e5e7eb;"></div>
     <section id="sim-panel" style="margin:12px 16px">
       <h2 style="font-size:16px;margin-bottom:8px">سناریو</h2>


### PR DESCRIPTION
## Summary
- Add UI toolbar for toggling edge sign, filtering by group, and searching nodes
- Populate group dropdown and attach Cytoscape filtering logic

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a699042c7c8328ab3d1fb5e54477ab