### PR TITLE
feat: add layout switcher and node pinning

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -8,7 +8,13 @@
 <body>
   <main dir="rtl">
     <h1>مدل پویایی بهره‌وری آب در کشاورزی</h1>
-    <div id="legend" style="margin:10px 0;"></div>
+    <div id="controls" style="margin:10px 0;display:flex;gap:8px;align-items:center">
+      <div id="legend"></div>
+      <select id="layout">
+        <option value="elk" selected>ELK (لایه‌ای)</option>
+        <option value="dagre">Dagre (چپ→راست)</option>
+      </select>
+    </div>
     <div id="cy" style="width:100%;height:72vh;border:1px solid #e5e7eb;"></div>
     <section id="sim-panel" style="margin:12px 16px">
       <h2 style="font-size:16px;margin-bottom:8px">سناریو</h2>

--- a/docs/test/water-efficiency.html
+++ b/docs/test/water-efficiency.html
@@ -10,6 +10,12 @@
     <h1>آزمایش: بهره‌وری آب در کشاورزی</h1>
     <section>
       <h2>نمودار علی و معلولی (CLD)</h2>
+      <div style="margin:10px 0;">
+        <select id="layout">
+          <option value="elk" selected>ELK (لایه‌ای)</option>
+          <option value="dagre">Dagre (چپ→راست)</option>
+        </select>
+      </div>
       <div id="cy" style="width:100%;height:70vh;border:1px solid #e5e7eb;"></div>
     </section>
     <section style="margin-top:2rem">


### PR DESCRIPTION
## Summary
- add layout select to switch between ELK and Dagre layouts
- support node pin/unpin on double-click with border highlight

## Testing
- `npm test`
- `npm run check:no-binary`

------
https://chatgpt.com/codex/tasks/task_e_68a69a00fb208328be1928cf8be29292