### PR TITLE
feat: add edge filtering controls

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -30,9 +30,21 @@
     #sc-table{width:100%;border-collapse:collapse;margin-top:8px;font-size:14px;}
     #sc-table th,#sc-table td{border:1px solid var(--muted);padding:4px;text-align:center;}
     #sc-table tr.selected{background:var(--muted);}
+    .hidden{display:none;}
+    label.ctrl output{margin-inline-start:8px;font-variant-numeric:tabular-nums;}
   </style>
 </head>
 <body class="rtl">
+  <div class="toolbar">
+    <label class="ctrl"><span>حداقل وزن رابطه</span>
+      <input id="flt-weight-min" type="range" min="0" max="1" step="0.05" value="0" aria-label="حداقل وزن رابطه"/>
+      <output id="flt-weight-min-val">0</output>
+    </label>
+    <label class="ctrl"><span>حداکثر تاخیر (سال)</span>
+      <input id="flt-delay-max" type="range" min="0" max="5" step="1" value="5" aria-label="حداکثر تاخیر (سال)"/>
+      <output id="flt-delay-max-val">5</output>
+    </label>
+  </div>
   <div class="board">
     <div class="card">
       <div class="toolbar">


### PR DESCRIPTION
## Summary
- add top-level weight and delay sliders with output values and labels
- implement debounced edge filtering in Cytoscape graph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6b047c398832888f1a161e8b24823