### PR TITLE
chore: remove unused weight range sliders

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -144,10 +144,6 @@
         <label class="btn outline" style="display:flex;align-items:center;gap:4px">
           <input type="checkbox" id="f-delay"/>تاخیر
         </label>
-        <div id="f-weight" class="btn outline" style="display:flex;align-items:center;gap:4px">
-          <input id="f-wmin" type="range" min="0" max="1" step="0.1" value="0"/>
-          <input id="f-wmax" type="range" min="0" max="1" step="0.1" value="1"/>
-        </div>
         <select id="layout" class="btn outline">
           <option value="elk" selected>ELK</option>
           <option value="dagre">Dagre</option>


### PR DESCRIPTION
## Summary
- clean up water CLD test page by removing inactive weight range sliders from toolbar

## Testing
- `npm test`
- `npm run flag:test` *(fails: libXcomposite.so.1 missing)*
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a70371aed0832883837bd66e0dfff0