### PR TITLE
Add tippy tooltips to water CLD controls

### DIFF
--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -181,7 +181,12 @@
     if (!container || typeof window.cytoscape === 'undefined') return;
 
     if (window.tippy) {
-      tippy('.hint', { allowHTML:true, theme:'light', delay:[80,0], placement:'bottom', maxWidth: 320, interactive: true });
+      tippy('.hint', {
+        theme: 'light',
+        delay: [80, 0],
+        placement: 'bottom',
+        maxWidth: 320
+      });
     }
 
     const rootStyle = getComputedStyle(document.documentElement);
@@ -216,7 +221,11 @@
       });
     }
     groups.forEach(g => elements.push({ data: { id: g.id, color: g.color, isGroup: true }, classes: 'group' }));
-    (modelData.nodes || []).forEach(n => elements.push({ data: { id: n.id, label: n.label, parent: n.group } }));
+    (modelData.nodes || []).forEach(n => elements.push({
+      data: { id: n.id, label: n.label, parent: n.group },
+      classes: 'node',
+      scratch: { tooltip: n.desc || n.label }
+    }));
     (modelData.edges || []).forEach((e, idx) => elements.push({
       data: {
         id: `e${idx}`,
@@ -338,7 +347,23 @@
       layout: { name: 'grid' }
     });
 
-    cy.on('ready', () => setTimeout(() => cy.fit(undefined, 24), 0));
+    cy.on('ready', () => {
+      setTimeout(() => cy.fit(undefined, 24), 0);
+      if (window.tippy) {
+        cy.nodes().forEach(n => {
+          const content = n.scratch('tooltip');
+          if (content) {
+            tippy(n.popperRef(), {
+              content,
+              trigger: 'mouseenter',
+              placement: 'top',
+              theme: 'light',
+              arrow: true
+            });
+          }
+        });
+      }
+    });
     window.addEventListener('resize', () => requestAnimationFrame(safeFit));
     window.addEventListener('orientationchange', () => setTimeout(safeFit,150));
     if (document.fonts && document.fonts.ready) {

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -67,18 +67,21 @@
           <div class="slider">
             <label for="p-eff">بهره‌وری آبیاری <span id="val-eff">0.3</span></label>
             <input id="p-eff" type="range" min="0" max="1" step="0.05" value="0.3"/>
+            <span class="hint" data-tippy-content="تنظیم بهره‌وری آبیاری در سناریو">❔</span>
           </div>
           <div class="slider">
             <label for="p-dem">شدت تقاضا <span id="val-dem">0.6</span></label>
             <input id="p-dem" type="range" min="0" max="1" step="0.05" value="0.6"/>
+            <span class="hint" data-tippy-content="میزان شدت تقاضای آب در سناریو">❔</span>
           </div>
           <div class="slider">
             <label for="p-delay">تاخیر (سال) <span id="val-delay">1</span></label>
             <input id="p-delay" type="range" min="0" max="5" step="1" value="1"/>
+            <span class="hint" data-tippy-content="تأخیر زمانی واکنش سیستم بر حسب سال">❔</span>
           </div>
         </div>
         <div class="actions">
-          <button id="btn-run" class="btn">اجرای سناریو</button><button class="hint" data-tippy-content="سناریو/چارت: با اجرای سناریو، نمودار نتایج به‌روزرسانی می‌شود.">!</button>
+          <button id="btn-run" class="btn">اجرای سناریو</button><span class="hint" data-tippy-content="سناریو/چارت: با اجرای سناریو، نمودار نتایج به‌روزرسانی می‌شود.">❔</span>
           <button id="btn-reset" class="btn outline">بازنشانی</button>
           <button id="btn-export" class="btn outline">Export CSV</button>
         </div>
@@ -130,28 +133,30 @@
           <span>حداقل وزن رابطه</span>
           <input id="flt-weight-min" type="range" min="0" max="1" step="0.05" value="0">
           <output id="flt-weight-min-val">0</output>
+          <span class="hint" data-tippy-content="کمترین مقدار قدرت رابطه برای نمایش در نمودار">❔</span>
         </label>
         <label class="ctrl">
           <span>حداکثر تاخیر (سال)</span>
           <input id="flt-delay-max" type="range" min="0" max="5" step="1" value="5">
           <output id="flt-delay-max-val">5</output>
+          <span class="hint" data-tippy-content="حداکثر تأخیر زمانی (سال)">❔</span>
         </label>
         <!-- باقی کنترل‌ها (جستجو/گروه‌ها/Layout/Loops) -->
-        <button id="f-pos" class="btn outline">روابط مثبت</button><button class="hint" data-tippy-content="نمایش تنها یال‌های دارای اثر مثبت.">!</button>
-        <button id="f-neg" class="btn outline">روابط منفی</button><button class="hint" data-tippy-content="نمایش تنها یال‌های دارای اثر منفی.">!</button>
-        <select id="f-group" class="btn outline"><option value="">همه گروه‌ها</option></select><button class="hint" data-tippy-content="انتخاب گروه: فقط گره‌ها و روابط همان گروه نشان داده می‌شوند.">!</button>
-        <input id="q" class="btn outline" placeholder="جستجو"/>
+        <button id="f-pos" class="btn outline">روابط مثبت</button><span class="hint" data-tippy-content="نمایش تنها یال‌های دارای اثر مثبت.">❔</span>
+        <button id="f-neg" class="btn outline">روابط منفی</button><span class="hint" data-tippy-content="نمایش تنها یال‌های دارای اثر منفی.">❔</span>
+        <select id="f-group" class="btn outline"><option value="">همه گروه‌ها</option></select><span class="hint" data-tippy-content="نمایش گروه خاصی از متغیرها">❔</span>
+        <input id="q" class="btn outline" placeholder="جستجو"/><span class="hint" data-tippy-content="جست‌وجوی نام گره‌ها">❔</span>
         <label class="btn outline" style="display:flex;align-items:center;gap:4px">
           <input type="checkbox" id="f-delay"/>تاخیر
-        </label>
+        </label><span class="hint" data-tippy-content="نمایش روابط دارای تأخیر زمانی">❔</span>
         <div id="f-weight" class="btn outline" style="display:flex;align-items:center;gap:4px">
           <input id="f-wmin" type="range" min="0" max="1" step="0.1" value="0"/>
           <input id="f-wmax" type="range" min="0" max="1" step="0.1" value="1"/>
-        </div>
+        </div><span class="hint" data-tippy-content="فیلتر بازه وزن یال‌ها">❔</span>
         <select id="layout" class="btn outline">
           <option value="elk" selected>ELK</option>
           <option value="dagre">Dagre</option>
-        </select><button class="hint" data-tippy-content="Layout: نحوه چیدمان گره‌ها در نمودار را تعیین می‌کند.">!</button>
+        </select><span class="hint" data-tippy-content="انتخاب الگوریتم چیدمان (ELK یا Dagre)">❔</span>
       </div>
       <details id="panel-loops" style="margin:8px 0">
         <summary>Loops</summary>


### PR DESCRIPTION
## Summary
- add ❔ hint buttons to sliders, filters, and search in water CLD demo
- initialize tippy.js for hints and graph node tooltips
- load popper/tippy locally for CSP compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a70477ca7c832888a025cc15418274