### PR TITLE
Add stock and flow demo

### DIFF
--- a/docs/assets/water-sfd.js
+++ b/docs/assets/water-sfd.js
@@ -1,0 +1,81 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    var cy = cytoscape({
+      container: document.getElementById('cy-sfd'),
+      layout: { name: 'preset' },
+      style: [
+        {
+          selector: 'node',
+          style: {
+            'label': 'data(label)',
+            'color': '#e6f1ef',
+            'text-valign': 'center',
+            'text-halign': 'center',
+            'font-family': 'Vazirmatn,Tahoma,sans-serif'
+          }
+        },
+        {
+          selector: '.stock',
+          style: {
+            'shape': 'rectangle',
+            'width': 120,
+            'height': 60,
+            'background-color': '#122825',
+            'border-width': 2,
+            'border-color': '#58a79a',
+            'border-radius': 6
+          }
+        },
+        {
+          selector: '.cloud',
+          style: {
+            'shape': 'ellipse',
+            'width': 80,
+            'height': 50,
+            'background-opacity': 0,
+            'border-style': 'dashed',
+            'border-width': 2,
+            'border-color': '#58a79a'
+          }
+        },
+        {
+          selector: 'edge',
+          style: {
+            'width': 2,
+            'line-color': '#58a79a',
+            'target-arrow-color': '#58a79a',
+            'target-arrow-shape': 'triangle',
+            'curve-style': 'bezier'
+          }
+        }
+      ],
+      elements: {
+        nodes: [
+          { data: { id: 'cloudIn' }, position: { x: 100, y: 100 }, classes: 'cloud' },
+          { data: { id: 'stock', label: 'Stock' }, position: { x: 250, y: 100 }, classes: 'stock' },
+          { data: { id: 'cloudOut' }, position: { x: 400, y: 100 }, classes: 'cloud' }
+        ],
+        edges: [
+          { data: { id: 'in', source: 'cloudIn', target: 'stock' } },
+          { data: { id: 'out', source: 'stock', target: 'cloudOut' } }
+        ]
+      }
+    });
+
+    cy.fit();
+
+    var edge = cy.getElementById('in');
+    var valve = document.createElement('div');
+    valve.style.cssText = 'position:absolute;width:14px;height:14px;border:2px solid #58a79a;border-radius:50%;background:#0b1d1a;';
+    cy.container().appendChild(valve);
+
+    function placeValve(){
+      var mid = edge.renderedMidpoint();
+      valve.style.left = (mid.x - 7) + 'px';
+      valve.style.top = (mid.y - 7) + 'px';
+    }
+
+    cy.on('render', placeValve);
+    placeValve();
+  });
+})();

--- a/docs/test/water-sfd.html
+++ b/docs/test/water-sfd.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="fa">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>نمودار ذخیره و جریان آب</title>
+  <link rel="icon" type="image/webp" href="/page/landing/logo2.webp"/>
+  <style>
+    :root{--bg:#0b1d1a;--card:#122825;--muted:#1a3430;--text:#e6f1ef;--accent:#58a79a;}
+    body{background:var(--bg);color:var(--text);font-family:Vazirmatn,Tahoma,sans-serif;}
+    .rtl{direction:rtl;}
+    .board{display:grid;grid-template-columns:1fr 320px;gap:16px;padding:12px;}
+    .card{background:var(--card);border:1px solid var(--muted);border-radius:16px;padding:12px;}
+    #cy-sfd{width:100%;height:100%;min-height:400px;border:1px solid var(--muted);border-radius:14px;position:relative;}
+    label.ctrl{display:flex;align-items:center;gap:8px;margin-bottom:12px;}
+    .btn{min-height:36px;padding:8px 12px;border-radius:10px;border:1px solid var(--muted);background:var(--muted);color:var(--text);cursor:pointer;}
+  </style>
+</head>
+<body class="rtl">
+  <div class="board">
+    <section class="card" id="graph-panel">
+      <div id="cy-sfd"></div>
+    </section>
+    <section class="card" id="param-panel">
+      <h3 style="margin-top:0">پارامترها</h3>
+      <label class="ctrl"><span>نرخ ورودی</span><input type="range" min="0" max="10" step="1" value="5"></label>
+      <label class="ctrl"><span>نرخ خروجی</span><input type="range" min="0" max="10" step="1" value="3"></label>
+      <button class="btn">اجرا</button>
+    </section>
+  </div>
+  <script defer src="/assets/vendor/cytoscape.min.js"></script>
+  <script defer src="/assets/vendor/elk.bundled.js"></script>
+  <script defer src="/assets/vendor/cytoscape-elk.js"></script>
+  <script defer src="/assets/vendor/dagre.min.js"></script>
+  <script defer src="/assets/vendor/cytoscape-dagre.js"></script>
+  <script defer src="/vendor/chart.umd.min.js"></script>
+  <script defer src="/assets/vendor/popper.min.js"></script>
+  <script defer src="/assets/vendor/tippy.umd.min.js"></script>
+  <script defer src="/assets/vendor/expr-eval.min.js"></script>
+  <script defer src="/assets/water-sfd.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add standalone Stock & Flow Diagram demo page with RTL layout and local vendor scripts.
- Implement minimal Cytoscape mock with one stock, inflow/outflow and valve overlay.

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a7181ab5bc832887614c9e5b594bf0