### PR TITLE
Integrate loop detection and layout presets on water CLD dashboard

### DIFF
--- a/docs/assets/layout-presets.js
+++ b/docs/assets/layout-presets.js
@@ -40,4 +40,15 @@
     const preset = dagrePresets[name];
     return preset ? JSON.parse(JSON.stringify(preset)) : null;
   };
+
+  const generalPresets = {
+    grid: { name: 'grid', fit: true, padding: 50 },
+    radial: { name: 'concentric', fit: true, padding: 50, startAngle: Math.PI / 2 },
+    hierarchical: { name: 'breadthfirst', directed: true, fit: true, padding: 50, spacingFactor: 1.5 }
+  };
+
+  window.getLayoutPreset = function (name) {
+    const preset = generalPresets[name];
+    return preset ? JSON.parse(JSON.stringify(preset)) : null;
+  };
 })();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -153,6 +153,13 @@
           <option value="elk" selected>ELK</option>
           <option value="dagre">Dagre</option>
         </select><span class="hint" data-tippy-content="انتخاب الگوریتم چیدمان (ELK یا Dagre)">❔</span>
+        <select id="layout-preset" class="btn outline">
+          <option value="">پیش‌فرض</option>
+          <option value="grid">Grid</option>
+          <option value="radial">Radial</option>
+          <option value="hierarchical">Hierarchical</option>
+        </select><span class="hint" data-tippy-content="چیدمان‌های آماده (Grid, Radial, Hierarchical)">❔</span>
+        <button id="btn-loops" class="btn outline">حلقه‌ها</button><span class="hint" data-tippy-content="شناسایی حلقه‌های بازخورد">❔</span>
       </div>
       <details id="panel-loops" style="margin:8px 0">
         <summary>Loops</summary>
@@ -171,6 +178,8 @@
   <script defer src="/assets/vendor/popper.min.js"></script>
   <script defer src="/assets/vendor/tippy.umd.min.js"></script>
   <script defer src="/assets/vendor/expr-eval.min.js"></script>
+  <script defer src="/assets/loop-detect.js"></script>
+  <script defer src="/assets/layout-presets.js"></script>
   <script defer src="/assets/water-cld.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Display node descriptions and units via tooltips sourced from water-cld.json.
- Add loop detection button and panel powered by `cydetectLoops`.
- Introduce layout preset dropdown (grid, radial, hierarchical) using layout-presets.js.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a736234a7c8328a070f15ff54cfed6