### PR TITLE
feat: add cytoscape tooltips

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -175,11 +175,11 @@
   <script defer src="/assets/vendor/cytoscape-dagre.js"></script>
   <!-- Chart.js محلی -->
   <script defer src="/vendor/chart.umd.min.js"></script>
-  <script defer src="/assets/vendor/popper.min.js"></script>
-  <script defer src="/assets/vendor/tippy.umd.min.js"></script>
   <script defer src="/assets/vendor/expr-eval.min.js"></script>
   <script defer src="/assets/loop-detect.js"></script>
   <script defer src="/assets/layout-presets.js"></script>
+  <script defer src="/assets/vendor/popper.min.js"></script>
+  <script defer src="/assets/vendor/tippy.umd.min.js"></script>
   <script defer src="/assets/water-cld.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load local Popper and Tippy vendors before CLD demo script
- show data-driven Tippy tooltips on CLD nodes and edges, updating with pan/zoom

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a73cae3b088328a4307e0e0f0c2d8c