### PR TITLE
feat: organize CLD toolbar into grouped control hub

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -93,6 +93,34 @@
       .hero-kpis{grid-template-columns:1fr; gap:8px}
     }
   </style>
+  <style>
+    :root{
+      --bg:#0f1a17; --panel:#122826; --card:#16312d; --bd:#1f413c;
+      --fg:#e9f3f0; --muted:#9fb3ad; --accent:#1d776e;
+      --chip:#1a3a35;
+    }
+    #cld-control-hub{display:grid; grid-template-columns:1fr 1fr 1fr; gap:12px; margin-bottom:10px}
+    .ac-card{background:var(--panel); border:1px solid var(--bd); border-radius:12px; overflow:hidden}
+    .ac-card > summary{cursor:pointer; padding:10px 12px; font-weight:600; color:var(--fg); outline:none}
+    .ac-body{display:flex; flex-wrap:wrap; gap:8px; padding:10px 12px; align-items:flex-start}
+    .ac-adv{margin:6px 12px; border:1px dashed var(--bd); border-radius:10px}
+    .ac-adv > summary{cursor:pointer; padding:8px 10px; color:var(--muted)}
+
+    .ctl-chip{display:flex; align-items:center; gap:6px; background:var(--card);
+              border:1px solid var(--bd); padding:6px 8px; border-radius:10px}
+    .ctl-chip .meta{font-size:11px; color:var(--muted)}
+    .ctl-chip .unit{background:var(--chip); color:var(--fg); padding:2px 6px; border-radius:8px; font-size:11px}
+    .ctl-chip .rng{font-size:11px; color:var(--muted)}
+    .ctl-chip .def{font-size:11px; color:var(--muted)}
+    .ctl-help{opacity:.8}
+    .ctl-sep{width:1px; height:18px; background:var(--bd); margin:0 4px}
+
+    .btn-reset{margin-inline-start:auto; background:transparent; border:1px solid var(--bd);
+               color:var(--fg); padding:6px 8px; border-radius:8px; cursor:pointer; font-size:12px}
+    .btn-reset:hover{border-color:var(--accent)}
+    @media (max-width: 1100px){ #cld-control-hub{grid-template-columns:1fr 1fr} }
+    @media (max-width: 720px){  #cld-control-hub{grid-template-columns:1fr} }
+  </style>
 </head>
 <body class="rtl">
   <!-- ===== HERO KPI BAR (start) ===== -->
@@ -202,6 +230,25 @@
       </div>
     </section>
     <section class="card" id="right-panel">
+      <!-- ===== CLD CONTROL HUB (start) ===== -->
+      <section id="cld-control-hub" dir="rtl" class="cld-control-hub" aria-label="کنترل‌های نمودار">
+        <details class="ac-card mode" open>
+          <summary>حالت‌ها (Mode)</summary>
+          <div id="group-mode" class="ac-body"></div>
+        </details>
+
+        <details class="ac-card filter" open>
+          <summary>فیلترها (Filter)</summary>
+          <div id="group-filter" class="ac-body"></div>
+          <details class="ac-adv"><summary>Advanced</summary><div id="group-advanced" class="ac-body"></div></details>
+        </details>
+
+        <details class="ac-card layout">
+          <summary>چیدمان (Layout)</summary>
+          <div id="group-layout" class="ac-body"></div>
+        </details>
+      </section>
+      <!-- ===== CLD CONTROL HUB (end) ===== -->
       <div class="toolbar filters">
         <label class="ctrl">
           <span>حداقل وزن رابطه</span>
@@ -398,6 +445,139 @@
   <script defer src="/assets/vendor/popper.min.js"></script>
   <script defer src="/assets/vendor/tippy.umd.min.js"></script>
   <script defer src="/assets/water-cld.js"></script>
+  <script>
+  window.addEventListener('DOMContentLoaded', function(){
+    (function(){
+      // پیدا کردن نوار ابزار فعلی (fallback هوشمند)
+      const toolbar =
+        document.querySelector('#cld-toolbar') ||
+        document.querySelector('.toolbar, .topbar, [data-toolbar="cld"]') ||
+        // نزدیک‌ترین ظرفی که کنترل‌هایی با متن شناخته‌شده دارد:
+        ([...document.querySelectorAll('header, .controls, .panel, .row')].find(
+          el => /ELK|Poster|تاخیر|تأخیر|Layout|روابط|Loops|weak|strong/i.test(el.textContent||'')
+        ) || null);
+
+      // اگر پیدا نشد، بی‌خطر خارج شو
+      if(!toolbar) return;
+
+      // گروه‌ها
+      const gMode = document.getElementById('group-mode');
+      const gFilter = document.getElementById('group-filter');
+      const gAdv = document.getElementById('group-advanced');
+      const gLayout = document.getElementById('group-layout');
+
+      // عکسِ وضعیت برای Reset
+      const baselineState = new Map();
+
+      // تشخیص گروهِ هر کنترل بر اساس متن/ویژگی‌ها
+      function detectGroup(el){
+        const t = (el.innerText || el.value || el.getAttribute('aria-label') || '').trim();
+        if (/ELK|Poster|Layout|Auto[-\s]?layout|Grid|Dagre|Cola|Rank/i.test(t)) return 'layout';
+        if (/تاخیر|تأخیر|delay|وزن|weight|loops|حلقه|weak|strong|پنهان|نمایش|highlight|threshold/i.test(t)) return 'filter';
+        return 'mode';
+      }
+
+      // تشخیص «کم‌کاربرد» برای جابجایی به Advanced
+      function isAdvanced(el){
+        const t = (el.innerText || el.value || el.getAttribute('aria-label') || '').trim();
+        return /سه.?گره|only|debug|hidden|internal|poster test|alpha|beta|cluster.+edges?/i.test(t);
+      }
+
+      // واحد و برد از متن مجاور یا attributes
+      function extractUnit(el){
+        const nearText = (el.closest('label')?.innerText || el.parentElement?.innerText || '').trim();
+        if (/سال|year/i.test(nearText)) return 'سال';
+        if (/درصد|%|leak|weight|rate/i.test(nearText)) return '%';
+        return el.dataset?.unit || '';
+      }
+      function rangeMeta(el){
+        if (el.tagName === 'INPUT' && el.type === 'range'){
+          return {
+            min: el.min ?? '', max: el.max ?? '', step: el.step ?? '',
+            def: (el.getAttribute('value') ?? el.value ?? '')
+          };
+        }
+        return null;
+      }
+
+      // یک «چیپ» بساز که کنترل + متادیتایش را کنار هم نشان دهد
+      function wrapControl(el){
+        const chip = document.createElement('div'); chip.className = 'ctl-chip';
+        // سعی کن آیکن/دکمه راهنما کنار کنترل را هم جابجا کنی
+        const neighbors = [];
+        if (el.previousElementSibling && /\?/.test(el.previousElementSibling.textContent||'')) neighbors.push(el.previousElementSibling);
+        if (el.nextElementSibling && /\?/.test(el.nextElementSibling.textContent||'')) neighbors.push(el.nextElementSibling);
+
+        // متادیتا
+        const unit = extractUnit(el);
+        const rng = rangeMeta(el);
+
+        // ذخیره مقدار پیش‌فرض برای Reset
+        baselineState.set(el, (el.tagName==='INPUT' ? el.value : el.value || el.textContent));
+
+        // مونتاژ
+        chip.appendChild(el);
+        neighbors.forEach(h => { h.classList?.add('ctl-help'); chip.appendChild(h); });
+
+        const meta = document.createElement('div'); meta.className = 'meta';
+        if (unit) {
+          const u = document.createElement('span'); u.className='unit'; u.textContent = unit; meta.appendChild(u);
+        }
+        if (rng){
+          const r = document.createElement('span'); r.className='rng';
+          r.textContent = `min:${rng.min} • max:${rng.max} • step:${rng.step}`;
+          meta.appendChild(document.createTextNode(' '));
+          meta.appendChild(r);
+          const d = document.createElement('span'); d.className='def';
+          d.textContent = ` • default:${rng.def}`;
+          meta.appendChild(d);
+        }
+        if (unit || rng) chip.appendChild(meta);
+        return chip;
+      }
+
+      // همه کنترل‌های تعاملی در نوار فعلی
+      const controls = [...toolbar.querySelectorAll('button, select, input[type="range"], input[type="checkbox"], .toggle, .switch')]
+        // کنترل‌های ذخیره/بارگذاری/ساخت سناریو و… مربوط به سناریو را دست‌نزن
+        .filter(el => !/Save|Load|New|Export/i.test(el.innerText||el.value||''));
+
+      // جابجایی به گروه‌ها
+      controls.forEach(el => {
+        const chip = wrapControl(el);
+        const group = detectGroup(el);
+        if (group === 'layout'){ gLayout.appendChild(chip); }
+        else if (group === 'filter'){ (isAdvanced(el) ? gAdv : gFilter).appendChild(chip); }
+        else { gMode.appendChild(chip); }
+      });
+
+      // دکمه‌های Reset هر گروه
+      function addResetButton(container){
+        const btn = document.createElement('button');
+        btn.type='button'; btn.className='btn-reset'; btn.textContent='بازنشانی';
+        btn.addEventListener('click', () => {
+          container.querySelectorAll('input, select').forEach(el => {
+            const base = baselineState.get(el);
+            if (base != null){
+              if (el.tagName==='INPUT' && el.type==='checkbox'){
+                el.checked = !!base;
+                el.dispatchEvent(new Event('change', {bubbles:true}));
+              }else{
+                el.value = base;
+                el.dispatchEvent(new Event('input', {bubbles:true}));
+                el.dispatchEvent(new Event('change', {bubbles:true}));
+              }
+            }
+          });
+        });
+        const wrap = document.createElement('div'); wrap.className='ac-body'; wrap.appendChild(btn);
+        container.parentElement.appendChild(wrap);
+      }
+      addResetButton(gMode);
+      addResetButton(gFilter);
+      addResetButton(gLayout);
+    })();
+  });
+  </script>
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- group scattered CLD controls into Mode, Filter, Layout accordions with advanced section
- add dark-mode styles and metadata display for units, ranges, defaults
- script safely relocates existing controls and adds per-group reset buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7c581ca58832881ae8119daff333d