### PR TITLE
feat: add runtime guards and stabilize readability extras

### DIFF
--- a/docs/assets/water-cld.extras-readability.js
+++ b/docs/assets/water-cld.extras-readability.js
@@ -1,11 +1,11 @@
 (function(){
-  if (window.__READABILITY_BOUND__) return;  // singleton
+  if (window.__READABILITY_BOUND__) return;
   window.__READABILITY_BOUND__ = true;
 
   onCyReady((cy) => {
     const debounce = window.__cldDebounce;
 
-    // --- 2.1: استایل فقط یک‌بار ---
+    // ---- 2.1: استایل فقط یک‌بار، بدون تغییر پالت موجود ----
     if (!cy.scratch('_readability_style_applied')) {
       cy.batch(() => {
         cy.style()
@@ -33,15 +33,21 @@
       cy.scratch('_readability_style_applied', true);
     }
 
-    // --- 2.2: برچسب‌ها و اندازهٔ نود ---
-    const ctx = document.createElement('canvas').getContext('2d');
+    // ---- 2.2: برچسب نودها ----
     function updateNodeLabels(){
       cy.nodes().forEach(n=>{
         const lbl = n.data('label') ?? n.data('name') ?? n.data('title') ?? n.id();
         if (n.data('_label') !== lbl) n.data('_label', lbl);
       });
     }
-    function autosizeNodes(){
+
+    // ---- 2.3: اندازه‌گذاری نودها (ترجیح با تابع اصلی پروژه) ----
+    const hasCoreAutosize = typeof window.measureAndResizeNodes === 'function';
+    const ctx = hasCoreAutosize ? null : document.createElement('canvas').getContext('2d');
+
+    function autosizeNodesFallback(){
+      // فقط اگر تابع اصلی وجود ندارد؛ تا تداخل پیش نیاید.
+      if (!ctx) return;
       cy.batch(() => {
         cy.nodes().forEach(n=>{
           const label = (n.data('_label')||'').toString();
@@ -58,31 +64,60 @@
       });
     }
 
-    // --- 2.3: قطبیت و تأخیر یال ---
+    // ---- 2.4: قطبیت و تأخیر یال‌ها (+/– و dotted) ----
     function updateEdges(){
       cy.batch(() => {
         cy.edges().forEach(e=>{
-          const sign = (e.data('sign') ?? e.data('polarity') ?? (Number(e.data('weight'))>=0 ? +1 : -1));
-          e.data('_signLabel', sign>=0 ? '+' : '–');
-          const delayed = !!(e.data('delay') || e.data('lag') || Number(e.data('tau'))>0);
+          const s = (e.data('sign') ?? e.data('polarity') ?? (Number(e.data('weight'))>=0 ? +1 : -1));
+          e.data('_signLabel', s>=0 ? '+' : '–');
+          const delayed = !!(e.data('delay') || e.data('lag') || Number(e.data('tau'))>0 || Number(e.data('delayYears'))>0);
           e.toggleClass('delayed', delayed);
         });
       });
     }
 
-    // --- 2.4: رفرش Debounce و بدون رویداد style (تا حلقه نشود) ---
-    const refresh = () => { updateNodeLabels(); autosizeNodes(); updateEdges(); };
-    const schedule = debounce(refresh, 60);
+    // ---- 2.5: رفرش Debounce و بدون رویداد style ----
+    const refresh = () => {
+      updateNodeLabels();
+      if (hasCoreAutosize) {
+        try { window.measureAndResizeNodes(cy); } catch(_) {}
+      } else {
+        autosizeNodesFallback();
+      }
+      updateEdges();
+    };
+    const schedule = debounce(refresh, 70);
 
     refresh(); // بار اول
 
-    // توجه: عمداً «style» را از لیست حذف کردیم تا update() → event loop نشود.
+    // عمداً 'style' را اضافه نکن؛ با 'style' حلقه ایجاد می‌شود.
     const ev = 'data add remove position pan zoom layoutstop';
-    cy.off(ev, schedule); // اگر نسخهٔ قبلی گوش داده بود
     cy.on(ev, schedule);
 
-    // --- 2.5: fit ایمن یک‌بار پس از layout ---
+    // ---- 2.6: یک‌بار fit پس از layoutstop ----
     cy.one('layoutstop', () => requestAnimationFrame(() => window.__cldSafeFit(cy)));
+
+    // ---- 2.7: دکمه High-contrast (بدون تغییر خودکار style) ----
+    if (!document.getElementById('toggle-high-contrast')) {
+      const btn = document.createElement('button');
+      btn.id = 'toggle-high-contrast';
+      btn.type = 'button';
+      btn.textContent = 'کنتراست بالا';
+      btn.className = 'btn-soft';
+      (document.querySelector('#cld-toolbar')
+        || document.querySelector('#cld-control-hub .mode .ac-body')
+        || document.querySelector('header') || document.body).appendChild(btn);
+
+      let on = false;
+      btn.addEventListener('click', () => {
+        on = !on;
+        cy.batch(() => {
+          cy.style()
+            .selector('node').style({'text-outline-width': on?3:1, 'text-outline-color': on?'#000':'transparent'})
+            .selector('edge').style({'text-outline-width': on?3:0, 'text-outline-color': on?'#000':'transparent'})
+            .update();
+        });
+      });
+    }
   });
 })();
-

--- a/docs/assets/water-cld.runtime-guards.js
+++ b/docs/assets/water-cld.runtime-guards.js
@@ -1,0 +1,26 @@
+(function(){
+  // گِیت آماده‌سازی Cytoscape (اگر از قبل نبود)
+  if (!window.onCyReady) {
+    window.__CLD_READY__ = false;
+    window.onCyReady = function(run){
+      if (window.cy && typeof window.cy.on === 'function') { try { run(window.cy); } catch(_){} return; }
+      if (!window.__CLD_READY__) {
+        window.__CLD_READY__ = true;
+        document.addEventListener('cy:ready', e => { const c = e.detail?.cy || window.cy; if (c) try{ run(c); }catch(_){} }, { once:true });
+        if (window.whenModelReady) window.whenModelReady(() => { if (window.cy) try{ run(window.cy); }catch(_){} });
+        if (document.readyState !== 'loading') { setTimeout(()=>{ if (window.cy) try{ run(window.cy); }catch(_){} }, 0); }
+        else document.addEventListener('DOMContentLoaded', ()=>{ if (window.cy) try{ run(window.cy); }catch(_){} }, { once:true });
+      }
+    };
+  }
+
+  // دی‌بونس عمومی سبک
+  if (!window.__cldDebounce) {
+    window.__cldDebounce = function(fn, ms=60){ let t=0; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a), ms); }; };
+  }
+
+  // fit ایمن (اگر صفر المنت بود، کاری نکن)
+  if (!window.__cldSafeFit) {
+    window.__cldSafeFit = function(cy){ if (!cy || cy.elements().length===0) return; try{ cy.fit(cy.elements(), 40); }catch(_){} };
+  }
+})();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -337,10 +337,12 @@
     .btn-soft:hover{border-color:rgba(255,255,255,.28)}
   </style>
 
-  <script defer src="/assets/water-cld.js"></script>
-  <script defer src="/assets/water-cld.extras-hero.js"></script>
-  <script defer src="/assets/water-cld.extras-readability.js"></script>
-  <script defer src="/assets/water-cld.extras-controls.js"></script>
+  <script defer src="../assets/water-cld.js"></script>
+  <script defer src="../assets/water-cld.runtime-guards.js"></script>
+  <script defer src="../assets/water-cld.extras-readability.js"></script>
+  <!-- سایر extras (hero/controls) بعد از این بیایند -->
+  <script defer src="../assets/water-cld.extras-hero.js"></script>
+  <script defer src="../assets/water-cld.extras-controls.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- provide runtime guard helpers to expose `onCyReady`, a debounce util, and safe `fit`
- rewrite readability plugin to avoid style event loops, honor core autosizer, and add high-contrast toggle
- load runtime guards before extras in CLD test page

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run flag:test` *(fails: Failed to launch the browser process: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d28a225c83289792f891e151f1df