### PR TITLE
Add CLD coachmarks tour

### DIFF
--- a/docs/assets/water-cld.tour.css
+++ b/docs/assets/water-cld.tour.css
@@ -1,0 +1,39 @@
+/* ===== CLD Coachmarks (RTL + Dark) ===== */
+:root{
+  --tour-z: 9999;
+  --tour-bg: rgba(0,0,0,.55);
+  --tour-card: #16312d;
+  --tour-bd: #1f413c;
+  --tour-fg: #e9f3f0;
+  --tour-accent: #1d776e;
+}
+#cld-tour-backdrop{
+  position: fixed; inset: 0; background: var(--tour-bg);
+  z-index: var(--tour-z); display: none;
+}
+#cld-tour-stage{
+  position: fixed; z-index: calc(var(--tour-z) + 1); pointer-events: none;
+}
+#cld-tour-focus{
+  position: fixed; border: 2px solid #fff; border-radius: 12px;
+  box-shadow: 0 0 0 4px rgba(255,255,255,.25);
+  z-index: calc(var(--tour-z) + 2); pointer-events: none; display: none;
+}
+.cld-tour-pop{
+  position: fixed; max-width: 360px; background: var(--tour-card);
+  border: 1px solid var(--tour-bd); color: var(--tour-fg);
+  border-radius: 12px; padding: 12px 14px; z-index: calc(var(--tour-z) + 3);
+  box-shadow: 0 10px 28px rgba(0,0,0,.35);
+}
+.cld-tour-pop h4{margin:0 0 6px 0; font-size:15px}
+.cld-tour-pop p{margin:0; font-size:13px; opacity:.9; line-height:1.6}
+.cld-tour-actions{display:flex; gap:8px; justify-content:flex-end; margin-top:10px}
+.cld-tour-btn{
+  background: transparent; color: var(--tour-fg); border:1px solid var(--tour-bd);
+  border-radius: 10px; padding: 6px 10px; cursor: pointer; font-size: 12px;
+}
+.cld-tour-btn.primary{ background: var(--tour-accent); border-color: var(--tour-accent); color:#fff }
+.cld-tour-badge{ position: fixed; top: 8px; left: 8px; z-index: calc(var(--tour-z)+4);
+  background: var(--tour-card); border:1px solid var(--tour-bd); color: var(--tour-fg);
+  border-radius: 999px; font-size: 11px; padding: 4px 8px; opacity:.9 }
+@media (max-width: 560px){ .cld-tour-pop{ max-width: 92vw } }

--- a/docs/assets/water-cld.tour.js
+++ b/docs/assets/water-cld.tour.js
@@ -1,0 +1,185 @@
+// ===== CLD Coachmarks (singleton, CSP-safe, no interference) =====
+(function(){
+  if (window.__CLD_TOUR_BOUND__) return;   // گارد عدم‌تداخل
+  window.__CLD_TOUR_BOUND__ = true;
+
+  // کمک‌ها
+  const qs  = (s, r=document)=> r.querySelector(s);
+  const qsa = (s, r=document)=> Array.from(r.querySelectorAll(s));
+  const once = (el,ev,fn)=> el.addEventListener(ev,fn,{once:true});
+  const LS  = window.localStorage;
+  const KEY_DONE = 'cld_tour_done';
+
+  // اگر کاربر نخواسته یا بار دوم است، فقط با ?tour=1 فعال شود
+  const url = new URL(location.href);
+  const force = url.searchParams.get('tour') === '1';
+  const reset = url.searchParams.get('tour') === 'reset';
+  if (reset) LS.removeItem(KEY_DONE);
+  if (!force && LS.getItem(KEY_DONE) === '1') return;
+
+  // عناصر تور
+  let backdrop, focus, pop, stepIndex = 0, steps = [];
+
+  // جستجوی انعطاف‌پذیر هدف‌ها (بدون شکنندگی)
+  function findRunSampleBtn(){
+    // 1) ID متداول
+    let el = qs('#btn-run-sample');
+    if (el) return el;
+    // 2) دکمه‌ای که متنش شامل «اجرای سناریو» یا «Run sample» است
+    el = qsa('button').find(b => /اجرای.*سناریو|Run.*sample/i.test(b.textContent||''));
+    if (el) return el;
+    // 3) هر دکمه داخل hero
+    const hero = qs('#hero-kpi'); if (hero) {
+      el = qsa('button', hero).find(x => /سناریو|Scenario/i.test(x.textContent||''));
+      if (el) return el;
+    }
+    return null;
+  }
+  function findKPIBar(){
+    return qs('#hero-kpi .hero-kpis') || qs('.hero-kpis') || qs('#hero-kpi') || null;
+  }
+  function findLoopsPanel(){
+    // نیاز به cy یا legend
+    const legend = qsa('.legend, .loops, [aria-label="Loops"]')
+      .find(x => /Loop|حلقه|Loops/i.test(x.textContent||''));
+    if (legend) return legend;
+    // اگر داخل سمت راست پنل loops دارید:
+    const pane = qsa('*').find(x => /Loops/i.test(x?.textContent||'') && x.clientWidth>120 && x.clientHeight>40);
+    if (pane) return pane;
+    // در نهایت، اگر cy حاضر است، کل بوم را هدف می‌گیریم
+    if (window.cy && window.cy.container) return window.cy.container();
+    return null;
+  }
+
+  // ساخت DOM تور
+  function ensureScaffold(){
+    if (!qs('#cld-tour-backdrop')){
+      backdrop = document.createElement('div'); backdrop.id='cld-tour-backdrop';
+      focus    = document.createElement('div'); focus.id='cld-tour-focus';
+      pop      = document.createElement('div'); pop.className='cld-tour-pop'; pop.dir='rtl';
+      document.body.append(backdrop, focus, pop);
+    }else{
+      backdrop = qs('#cld-tour-backdrop'); focus = qs('#cld-tour-focus'); pop = qs('.cld-tour-pop');
+    }
+  }
+
+  // جایگذاری رینگ تمرکز و پاپ‌اور
+  function placeAround(target, side='bottom'){
+    if (!target) return;
+    const r = target.getBoundingClientRect();
+    const pad = 8;
+    focus.style.display='block';
+    focus.style.left = `${Math.max(8, r.left - pad)}px`;
+    focus.style.top  = `${Math.max(8, r.top  - pad)}px`;
+    focus.style.width  = `${r.width + pad*2}px`;
+    focus.style.height = `${r.height + pad*2}px`;
+
+    // جای پاپ‌اور: ترجیح پایین/راست؛ اگر جا نبود، تطبیق بده
+    let x = r.left, y = r.bottom + 10;
+    if (side==='right'){ x = r.right + 12; y = r.top; }
+    const vw = window.innerWidth, vh = window.innerHeight, pw = Math.min(360, pop.offsetWidth||320), ph = pop.offsetHeight||120;
+    if (x + pw + 8 > vw) x = Math.max(8, vw - pw - 8);
+    if (y + ph + 8 > vh) y = Math.max(8, r.top - ph - 12);
+    pop.style.left = `${x}px`; pop.style.top = `${y}px`;
+  }
+
+  // محتوای هر مرحله
+  function renderStep(s){
+    backdrop.style.display='block';
+    const { title, html, target, side } = s;
+    pop.innerHTML = `
+      <h4>${title}</h4>
+      <p>${html}</p>
+      <div class="cld-tour-actions" dir="rtl">
+        <button class="cld-tour-btn" data-act="skip">عدم نمایش مجدد</button>
+        ${stepIndex>0 ? '<button class="cld-tour-btn" data-act="prev">قبلی</button>' : ''}
+        <button class="cld-tour-btn primary" data-act="${stepIndex<steps.length-1 ? 'next' : 'done'}">
+          ${stepIndex<steps.length-1 ? 'بعدی' : 'شروع کنید'}
+        </button>
+      </div>`;
+    placeAround(target(), side || 'bottom');
+  }
+
+  function teardown(done=false){
+    window.removeEventListener('resize', onRelayout);
+    window.removeEventListener('scroll', onRelayout, true);
+    if (backdrop) backdrop.style.display='none';
+    if (focus) focus.style.display='none';
+    if (done) LS.setItem(KEY_DONE, '1');
+  }
+
+  function onRelayout(){ // با هر تغییر اندازه/اسکرول، جای پاپ‌اور را دوباره حساب کن
+    const s = steps[stepIndex]; if (!s) return;
+    placeAround(s.target(), s.side || 'bottom');
+  }
+
+  // تعریف مراحل (با fallback امن)
+  steps = [
+    {
+      key:'run',
+      title:'۱) اجرای سناریوی نمونه',
+      html:'برای دیدن اثر سیاست، یک سناریوی نمونه را اجرا کنید.',
+      target: findRunSampleBtn,
+      side:'bottom'
+    },
+    {
+      key:'kpi',
+      title:'۲) اثر را در KPI ببینید',
+      html:'این‌جا تغییرات KPI (Δ نسبت به Baseline) نمایش داده می‌شود.',
+      target: findKPIBar,
+      side:'bottom'
+    },
+    {
+      key:'loops',
+      title:'۳) حلقه‌های کلیدی',
+      html:'از این بخش، حلقه‌های تقویتی/تعادلی را انتخاب و مسیرشان را های‌لایت کنید.',
+      target: findLoopsPanel,
+      side:'right'
+    }
+  ];
+
+  // اگر هدف مرحله‌ای پیدا نشد، خودکار به مرحلهٔ بعد برو
+  function advanceIfMissing(){
+    const t = steps[stepIndex]?.target();
+    if (!t){ stepIndex++; if (stepIndex < steps.length) renderStep(steps[stepIndex]); else teardown(true); }
+  }
+
+  // راه‌اندازی تور
+  function startTour(){
+    ensureScaffold();
+    stepIndex = 0;
+    renderStep(steps[0]);
+    window.addEventListener('resize', onRelayout);
+    window.addEventListener('scroll', onRelayout, true);
+
+    pop.addEventListener('click', (e)=>{
+      const act = e.target?.dataset?.act;
+      if (!act) return;
+      if (act==='skip'){ teardown(true); }
+      else if (act==='prev'){ stepIndex = Math.max(0, stepIndex-1); renderStep(steps[stepIndex]); }
+      else if (act==='next'){ stepIndex = Math.min(steps.length-1, stepIndex+1); renderStep(steps[stepIndex]); }
+      else if (act==='done'){ teardown(true); }
+    });
+    // اگر هدف در دسترس نبود (بارگذاری پویا)، چک تأخیری
+    setTimeout(advanceIfMissing, 400);
+  }
+
+  // مرحلهٔ Loops نیازمند cy/legend است؛ وقتی آماده شد هم‌تراز کن
+  function startWhenReady(){
+    // اگر کاربر خودش خواسته (tour=1) یا بار اول است
+    const eligible = force || LS.getItem(KEY_DONE) !== '1';
+    if (!eligible) return;
+
+    // شروع پس از DOM
+    const domReady = () => startTour();
+    if (document.readyState === 'complete' || document.readyState === 'interactive') domReady();
+    else once(document, 'DOMContentLoaded', domReady);
+
+    // اگر cy بعداً آماده شد، فقط جای مرحله ۳ را دقیق‌تر کن
+    document.addEventListener('cy:ready', ()=> {
+      if (steps[2] && typeof steps[2].target === 'function') onRelayout();
+    });
+  }
+
+  startWhenReady();
+})();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/webp" href="/page/landing/logo2.webp"/>
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/water-cld.css">
+  <link rel="stylesheet" href="../assets/water-cld.tour.css">
   </head>
 <body class="rtl">
   <!-- ===== HERO KPI BAR (start) ===== -->
@@ -222,6 +223,7 @@
   <script defer src="../assets/water-cld.runtime-guards.js"></script>
   <script defer src="../assets/model-bridge.js"></script>
   <script defer src="../assets/water-cld.extras-hero.js"></script>
+  <script defer src="../assets/water-cld.tour.js"></script>
   <script defer src="../assets/water-cld.extras-readability.js"></script>
   <script defer src="../assets/water-cld.extras-controls.js"></script>
 


### PR DESCRIPTION
## Summary
- style dark-theme coachmarks overlay for CLD walkthrough
- implement singleton RTL tour script with flexible element targeting and localStorage persistence
- wire tour into test page via new CSS and JS assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7d629aeec83288f7b3635a12cf46f