### PR TITLE
Add controls metadata wrappers with help and counts

### DIFF
--- a/docs/assets/water-cld.controls-meta.css
+++ b/docs/assets/water-cld.controls-meta.css
@@ -1,0 +1,28 @@
+/* ===== Controls Meta (RTL + Dark, no conflicts) ===== */
+.controls-meta-card{position:relative}
+.controls-meta-header{display:flex;align-items:center;gap:8px}
+.controls-meta-count{margin-inline-start:auto;font-size:11.5px;color:#9fb3ad}
+.controls-help-btn{
+  border:1px solid #1f413c;background:#16312d;color:#e9f3f0;border-radius:8px;
+  padding:2px 8px;font-size:12px;cursor:pointer
+}
+.controls-help-pop{
+  position:absolute; inset-inline-end:10px; top:36px; z-index:40; min-width:240px;
+  background:#16312d;border:1px solid #1f413c;border-radius:12px;padding:10px; display:none;
+  box-shadow:0 10px 28px rgba(0,0,0,.35)
+}
+.controls-help-pop ul{margin:0;padding-inline-start:18px}
+.controls-help-pop li{font-size:12px;color:#e9f3f0;opacity:.9;line-height:1.6}
+
+.ctl-chip{
+  display:flex;flex-wrap:wrap;align-items:center;gap:6px;
+  background:#16312d;border:1px solid #1f413c;border-radius:10px;
+  padding:6px 8px
+}
+.ctl-chip > .ctl-title{font-size:12.5px;color:#e9f3f0;opacity:.95}
+.ctl-chip .unit{background:#1a3a35;color:#e9f3f0;border-radius:8px;padding:0 6px;font-size:11px}
+.ctl-chip .rng,.ctl-chip .def{font-size:11px;color:#9fb3ad}
+.ctl-chip .sep{width:1px;height:16px;background:#1f413c;margin:0 4px}
+
+.card-collapsed .controls-body{display:none}
+.card-collapsed .controls-meta-count{opacity:.85}

--- a/docs/assets/water-cld.controls-meta.js
+++ b/docs/assets/water-cld.controls-meta.js
@@ -1,0 +1,214 @@
+// ===== Controls Meta & Grouping (singleton, CSP-safe, no interference) =====
+(function(){
+  if (window.__CTL_META_BOUND__) return;
+  window.__CTL_META_BOUND__ = true;
+
+  // ---------- ابزارهای کمکی ----------
+  const qs  = (s, r=document)=> r.querySelector(s);
+  const qsa = (s, r=document)=> Array.from(r.querySelectorAll(s));
+  const norm = s => (s||'').replace(/\s+/g,' ').trim();
+  const txt  = el => norm(el?.textContent||'');
+  const isIn = (t, arr) => arr.some(p=>p.test(t));
+
+  // کارت‌ها را با عناوین (Mode/Filter/Layout) پیدا کن – RTL-aware و انعطاف‌پذیر
+  function findCards(){
+    const candidates = qsa('section, div, .ac-card, .card, details');
+    const roles = {mode:null, filter:null, layout:null};
+    candidates.forEach(el=>{
+      const h = txt(el.querySelector('summary, .title, .header, h3, h4, [role="heading"]'));
+      if (!h) return;
+      const H = h.toLowerCase();
+      if (!roles.mode   && isIn(H,[/mode|حالت/i]))   roles.mode   = el;
+      if (!roles.filter && isIn(H,[/filter|فیلتر/i])) roles.filter = el;
+      if (!roles.layout && isIn(H,[/layout|چیدمان/i]))roles.layout = el;
+    });
+    return roles;
+  }
+
+  // عنوان کارت را با دکمه Help و شمارنده n فعال ارتقا بده (بدون تغییر متن اصلی)
+  function enhanceHeader(card){
+    if (!card || card.__hdr_done) return;
+    card.__hdr_done = true;
+    const header = card.querySelector('summary, .title, .header, h3, h4, [role="heading"]');
+    if (!header) return;
+    header.classList.add('controls-meta-header');
+    card.classList.add('controls-meta-card');
+
+    // شمارنده
+    let count = document.createElement('span');
+    count.className = 'controls-meta-count';
+    count.textContent = ''; // بعداً پر می‌شود
+    header.appendChild(count);
+
+    // Help
+    let btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'controls-help-btn';
+    btn.textContent = 'راهنما';
+    header.appendChild(btn);
+
+    let pop = document.createElement('div');
+    pop.className = 'controls-help-pop';
+    pop.innerHTML = '<ul></ul>';
+    card.appendChild(pop);
+
+    // جمع‌آوری همه «؟»های پراکنده داخل کارت → به لیست راهنما
+    const helpItems = [];
+    qsa('*', card).forEach(el=>{
+      const t = txt(el);
+      if (t === '?' || el.dataset?.help){
+        const item = el.dataset?.help || el.getAttribute('title') || 'راهنمای این کنترل';
+        helpItems.push(item);
+        // پنهان کن تا مزاحم نباشد (دست نزدن به کنترل‌های واقعی)
+        el.style.display = 'none';
+      }
+    });
+    if (helpItems.length){
+      const ul = pop.querySelector('ul');
+      helpItems.forEach(s => { const li = document.createElement('li'); li.textContent = s; ul.appendChild(li); });
+    }else{
+      btn.style.display = 'none';
+    }
+
+    // باز/بسته کردن پاپ‌اور
+    btn.addEventListener('click', (e)=>{
+      e.stopPropagation();
+      pop.style.display = (pop.style.display === 'block') ? 'none' : 'block';
+    });
+    document.addEventListener('click', ()=> pop.style.display='none');
+  }
+
+  // خواندن متادیتای کنترل
+  function metaFor(el){
+    // متن عنوان نزدیک کنترل
+    const label = el.closest('label')?.innerText
+               || el.getAttribute('aria-label')
+               || el.name || el.id || el.dataset?.param || el.placeholder || 'کنترل';
+    // واحد از متن نزدیک یا data-unit
+    let unit = el.dataset?.unit || '';
+    const near = (el.closest('label')?.innerText || el.parentElement?.innerText || '').toLowerCase();
+    if (!unit){
+      if (/%|درصد|percent|rate/i.test(near)) unit = '%';
+      else if (/سال|year/i.test(near)) unit = 'سال';
+      else if (/روز|day/i.test(near)) unit = 'روز';
+    }
+    // رنج
+    let rng = null, def = null;
+    if (el.tagName==='INPUT' || el.tagName==='SELECT'){
+      const t = (el.type||'').toLowerCase();
+      if (['range','number'].includes(t) || el.tagName==='SELECT'){
+        rng = { min: el.min ?? '', max: el.max ?? '', step: el.step ?? '' };
+        def = el.getAttribute('value') ?? el.defaultValue ?? el.value ?? '';
+      }
+    }
+    return {label: norm(label), unit, rng, def};
+  }
+
+  // ساخت «چیپ» اطراف کنترل (بدون تغییر رفتار کنتر‌ل)
+  function wrap(el){
+    // اگر قبلاً wrap شده، خروج
+    if (el.closest('.ctl-chip')) return el.closest('.ctl-chip');
+
+    const m = metaFor(el);
+    const chip = document.createElement('div');
+    chip.className = 'ctl-chip';
+
+    const title = document.createElement('span');
+    title.className = 'ctl-title';
+    title.textContent = m.label;
+
+    chip.appendChild(title);
+    chip.appendChild(document.createElement('span')).className = 'sep';
+    chip.appendChild(el); // خود کنترل را جابه‌جا می‌کنیم؛ لیسنرها حفظ می‌شوند
+
+    const meta = document.createElement('span');
+    // واحد
+    if (m.unit){
+      const u = document.createElement('span'); u.className='unit'; u.textContent=m.unit;
+      meta.appendChild(u);
+    }
+    // رنج و پیش‌فرض
+    if (m.rng){
+      const r = document.createElement('span'); r.className='rng';
+      r.textContent = `min:${m.rng.min||'—'} • max:${m.rng.max||'—'} • step:${m.rng.step||'—'}`;
+      meta.appendChild(document.createTextNode(' '));
+      meta.appendChild(r);
+      const d = document.createElement('span'); d.className='def';
+      d.textContent = ` • default:${m.def||'—'}`;
+      meta.appendChild(d);
+    }
+    if (meta.childNodes.length) chip.appendChild(meta);
+    return chip;
+  }
+
+  // محاسبه «n فعال» = تعداد کنترل‌هایی که از مقدار پیش‌فرض خارج شده‌اند
+  function computeActiveCount(card){
+    let n = 0;
+    qsa('input, select', card).forEach(el=>{
+      const def = el.getAttribute('value') ?? el.defaultValue;
+      if (el.type==='checkbox'){
+        const base = el.hasAttribute('checked') ? true : (def ? def==='1' : false);
+        if (el.checked !== base) n++;
+      }else if (def != null){
+        if (String(el.value) !== String(def)) n++;
+      }
+    });
+    return n;
+  }
+
+  // پردازش یک کارت: wrap controls + header + counter + collapse
+  function processCard(card){
+    if (!card || card.__processed) return;
+    card.__processed = true;
+
+    enhanceHeader(card);
+    const body = card.querySelector('.ac-body, .controls, .body, .content') || card; // fallback امن
+
+    // فقط input/select را wrap کن تا با دکمه‌های عملیاتی تداخل نشود
+    const controls = qsa('input, select', body)
+      .filter(el => !el.closest('.ctl-chip')); // از wrap مجدد جلوگیری
+
+    if (!controls.length){
+      // کارت خالی → collapse
+      card.classList.add('card-collapsed');
+    }else{
+      card.classList.remove('card-collapsed');
+    }
+
+    controls.forEach(el=>{
+      const chip = wrap(el);
+      // اگر chip هنوز در body نیست، اضافه‌اش کن (نزدیک همان کنترل)
+      if (chip && !chip.parentElement) body.appendChild(chip);
+    });
+
+    // شمارنده فعال
+    const setCount = ()=>{
+      const n = computeActiveCount(card);
+      const countEl = card.querySelector('.controls-meta-count');
+      if (countEl){
+        const title = txt(card.querySelector('summary, .title, .header, h3, h4, [role="heading"]')) || '';
+        // نمایش مثل: "Filter (۳ فعال)"
+        if (/filter|فیلتر/i.test(title)) countEl.textContent = n ? `(${n} فعال)` : '(۰ فعال)';
+        else countEl.textContent = n ? `(${n} تغییر)` : '';
+      }
+    };
+    setCount();
+
+    // به تغییرات گوش بده (بدون حذف لیسنرهای موجود)
+    card.__meta_oninput && card.removeEventListener('input', card.__meta_oninput);
+    card.__meta_onchange && card.removeEventListener('change', card.__meta_onchange);
+    card.__meta_oninput = ()=> setCount();
+    card.__meta_onchange = ()=> setCount();
+    card.addEventListener('input', card.__meta_oninput);
+    card.addEventListener('change', card.__meta_onchange);
+  }
+
+  // اجرای کل فرآیند
+  function init(){
+    const {mode, filter, layout} = findCards();
+    [mode, filter, layout].forEach(processCard);
+  }
+
+  if (document.readyState === 'complete' || document.readyState === 'interactive') init();
+  else window.addEventListener('DOMContentLoaded', init, { once:true });
+})();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -7,11 +7,12 @@
   <link rel="icon" type="image/webp" href="/page/landing/logo2.webp"/>
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/water-cld.css">
-  <link rel="stylesheet" href="../assets/water-cld.tour.css">
-  <link rel="stylesheet" href="../assets/water-cld.presets.css">
-  <link rel="stylesheet" href="../assets/water-cld.aha.css">
+    <link rel="stylesheet" href="../assets/water-cld.tour.css">
+    <link rel="stylesheet" href="../assets/water-cld.presets.css">
+    <link rel="stylesheet" href="../assets/water-cld.aha.css">
+    <link rel="stylesheet" href="../assets/water-cld.controls-meta.css">
 
-  </head>
+    </head>
 <body class="rtl">
   <!-- ===== HERO KPI BAR (start) ===== -->
   <section id="hero-kpi" dir="rtl" class="hero-kpi">
@@ -229,9 +230,10 @@
   <script defer src="../assets/water-cld.aha.js"></script>
   <script defer src="../assets/water-cld.tour.js"></script>
   <script defer src="../assets/water-cld.extras-readability.js"></script>
-  <script defer src="../assets/water-cld.extras-controls.js"></script>
-  <script defer src="../assets/water-cld.presets.js"></script>
+    <script defer src="../assets/water-cld.extras-controls.js"></script>
+    <script defer src="../assets/water-cld.presets.js"></script>
+    <script defer src="../assets/water-cld.controls-meta.js"></script>
 
-</body>
+  </body>
 </html>
 


### PR DESCRIPTION
## Summary
- Add dark-themed control metadata styles and layout
- Wrap Mode/Filter/Layout controls with labels, units, ranges, defaults, and help tooltip
- Integrate new assets into test page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7dea6a4788328b0e82298a46af2da