### PR TITLE
Add accessibility support for water CLD test page

### DIFF
--- a/docs/assets/water-cld.a11y.css
+++ b/docs/assets/water-cld.a11y.css
@@ -1,0 +1,57 @@
+/* ===== A11Y & Mobile (RTL + Dark), non-invasive ===== */
+:root{
+  --a11y-ring: #9fd5cd;         /* رنگ حلقه فوکوس با کنتراست بالا */
+  --a11y-ring-bg: #0a1f1d;      /* پس‌زمینهٔ تیره طبیعی پروژه */
+  --a11y-outline-w: 3px;        /* ضخامت حلقهٔ فوکوس */
+  --a11y-min-touch: 44px;       /* حداقل سایز لمس مطابق WCAG */
+}
+
+/* Skip link */
+.a11y-skiplink{
+  position: fixed; inset-inline-start: 8px; top: 8px; z-index: 9999;
+  background: #16312d; color: #e9f3f0; border: 1px solid #1f413c; border-radius: 10px;
+  padding: 6px 10px; font-size: 12px; text-decoration: none;
+  transform: translateY(-140%); transition: transform .12s ease-out;
+}
+.a11y-skiplink:focus{ transform: translateY(0); outline: var(--a11y-outline-w) solid var(--a11y-ring); outline-offset: 2px }
+
+/* Focus ring (به‌صورت افزایشی، بدون دست‌کاری استایل‌های فعلی) */
+a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible,
+textarea:focus-visible, [role="button"]:focus-visible, [tabindex]:focus-visible {
+  outline: var(--a11y-outline-w) solid var(--a11y-ring) !important;
+  outline-offset: 2px !important;
+  box-shadow: 0 0 0 2px rgba(159,213,205,.25);
+}
+
+/* حالت‌های Hover/Disabled با کنتراست بهتر (ملایم و افزایشی) */
+button:hover, .btn-soft:hover { border-color: rgba(255,255,255,.35) }
+button[disabled], .btn-soft[disabled]{ opacity:.6; cursor: not-allowed }
+
+/* کلاس کمک برای عناصر کوچک: افزایش سایز لمس بدون برهم‌زدن layout */
+.a11y-touch { min-width: var(--a11y-min-touch); min-height: var(--a11y-min-touch); }
+.a11y-touch.round { border-radius: 999px }
+
+/* متن مخفی برای Screen Reader */
+.sr-only{
+  position:absolute !important; width:1px; height:1px; padding:0; margin:-1px;
+  overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0;
+}
+
+/* بهبود کنتراست لینک‌ها */
+a { text-underline-offset: 2px }
+a:focus-visible { text-decoration-thickness: 2px }
+
+/* Cytoscape container (اگر فوکوس بگیرد) */
+.cy-a11y-focus:focus-visible {
+  outline: var(--a11y-outline-w) solid var(--a11y-ring) !important;
+  outline-offset: 2px !important;
+}
+
+/* احترام به ترجیحات کاربر */
+@media (prefers-reduced-motion: reduce){
+  * { animation: none !important; transition: none !important }
+}
+@media (prefers-contrast: more){
+  :root{ --a11y-outline-w: 4px }
+}
+

--- a/docs/assets/water-cld.a11y.js
+++ b/docs/assets/water-cld.a11y.js
@@ -1,0 +1,121 @@
+// ===== A11Y & Mobile bootstrap (singleton, CSP-safe, no interference) =====
+(function(){
+  if (window.__A11Y_BOUND__) return; window.__A11Y_BOUND__ = true;
+
+  // ------- Helpers -------
+  const $  = (s, r=document)=> r.querySelector(s);
+  const $$ = (s, r=document)=> Array.from(r.querySelectorAll(s));
+  const hasText = (el)=> !!(el && (el.textContent||'').trim().length);
+  const setOnce = (el, attr, val)=> { if (el && !el.hasAttribute(attr)) el.setAttribute(attr, val); };
+
+  // 1) Skip to main content
+  function ensureSkipLink(){
+    if ($('#a11y-skip')) return;
+    const a = document.createElement('a');
+    a.id='a11y-skip'; a.className='a11y-skiplink'; a.href='#main-content';
+    a.textContent = 'پرش به محتوای اصلی';
+    document.body.appendChild(a);
+
+    // اگر هدف پرش وجود ندارد، یکی بسازیم (بی‌تداخل)
+    let target = $('#main-content') || $('main') || $('#hero-kpi');
+    if (!target){
+      target = document.createElement('div'); target.id='main-content';
+      // تلاش برای جای‌گذاری قبل از بوم/هیرو
+      const host = $('#hero-kpi') || $('header') || document.body;
+      host.parentElement?.insertBefore(target, host);
+    }
+  }
+
+  // 2) Accessible Name برای عناصر تعاملی بدون نام
+  function ensureAccessibleNames(){
+    const interactive = $$('button, [role="button"], a[href], input, select, textarea');
+    interactive.forEach(el=>{
+      const hasName = el.hasAttribute('aria-label') || el.hasAttribute('aria-labelledby') || hasText(el) || !!el.getAttribute('title');
+      if (!hasName){
+        // سعی کن از dataset یا placeholder یا name استفاده کنی
+        const guess = el.dataset?.label || el.placeholder || el.name || el.id || 'دکمه بدون برچسب';
+        setOnce(el, 'aria-label', guess);
+      }
+      // نقش دکمه‌های غیر‌native
+      if (el.getAttribute('role')==='button'){ el.setAttribute('tabindex', el.getAttribute('tabindex')||'0'); }
+    });
+  }
+
+  // 3) Keyboard activation برای role="button"
+  function wireKeyboardActivation(){
+    $$('[role="button"]').forEach(el=>{
+      if (el.__a11y_keybound) return;
+      el.__a11y_keybound = true;
+      el.addEventListener('keydown', (e)=>{
+        if (e.key==='Enter' || e.key===' '){
+          e.preventDefault();
+          // «کلیک» غیرمزاحم
+          el.click?.();
+        }
+      });
+    });
+  }
+
+  // 4) Touch target ≥ 44px برای عناصر کوچک
+  function ensureTouchTargets(){
+    const candidates = $$('button, .btn, .btn-soft, [role="button"], .icon-btn');
+    candidates.forEach(el=>{
+      const r = el.getBoundingClientRect();
+      if (r.width < 44 || r.height < 44){
+        el.classList.add('a11y-touch');
+        if (/icon/i.test(el.className)) el.classList.add('round'); // برای آیکن‌های دایره‌ای
+      }
+    });
+  }
+
+  // 5) آرایش دسترس‌پذیر Cytoscape (بی‌تداخل)
+  function a11yForCytoscape(){
+    // ظرف‌های رایج
+    const cyEl = $('#cy') || $('.cytoscape-container') || $('.cy-container') || $('#cld-canvas') || (window.cy && window.cy.container && window.cy.container());
+    const container = (cyEl && cyEl.nodeType ? cyEl : null) || (window.cy && window.cy.container && window.cy.container());
+    if (!container || container.__a11y_done) return;
+
+    container.__a11y_done = true;
+    container.classList.add('cy-a11y-focus');
+    setOnce(container, 'tabindex', '0');                 // فوکوس‌پذیر
+    setOnce(container, 'role', 'application');           // محتوای تعاملی پیچیده
+    const descId = 'cy-a11y-desc';
+    if (!$('#'+descId)){
+      const sr = document.createElement('div');
+      sr.id = descId; sr.className = 'sr-only';
+      sr.textContent = 'بوم تعامل‌پذیر نمودار علّی. برای جابه‌جایی از ماوس/لمس استفاده کنید؛ برای بزرگ‌نمایی از Ctrl+اسکرول. برای خروج از بوم، کلید Tab را فشار دهید.';
+      document.body.appendChild(sr);
+    }
+    setOnce(container, 'aria-describedby', descId);
+    setOnce(container, 'aria-label', 'نمودار علّی-حلقه‌ای (CLD)');
+  }
+
+  // 6) کم‌کردن نویز TabOrder: حذف از Tab برای عناصر تزئینی/پنهان
+  function pruneDecorativesFromTab(){
+    // Legend یا عناصر راهنما که نیازی به فوکوس ندارند
+    $$('.legend-sticky, .legend, [aria-hidden="true"]').forEach(el=>{
+      if (getComputedStyle(el).display==='none') return;
+      if (!el.matches('a,button,input,select,textarea,[role="button"]')){
+        setOnce(el, 'tabindex', '-1');
+      }
+    });
+  }
+
+  // 7) اجرای مرحله‌ای و امن
+  function init(){
+    ensureSkipLink();
+    ensureAccessibleNames();
+    wireKeyboardActivation();
+    ensureTouchTargets();
+    a11yForCytoscape();
+    pruneDecorativesFromTab();
+  }
+
+  if (document.readyState==='complete' || document.readyState==='interactive') init();
+  else window.addEventListener('DOMContentLoaded', init, { once:true });
+
+  // اگر بعداً بوم/پنل‌ها لود/تغییر کردند، یک رفرش سبک
+  document.addEventListener('model:updated', ()=>{ ensureAccessibleNames(); ensureTouchTargets(); a11yForCytoscape(); });
+
+})();
+

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="../assets/water-cld.controls-meta.css">
     <link rel="stylesheet" href="../assets/water-cld.readability.css">
     <link rel="stylesheet" href="../assets/water-cld.scenarios.css">
+    <link rel="stylesheet" href="../assets/water-cld.a11y.css">
 
     </head>
 <body class="rtl">
@@ -231,11 +232,12 @@
   <script defer src="../assets/water-cld.extras-hero.js"></script>
   <script defer src="../assets/water-cld.aha.js"></script>
   <script defer src="../assets/water-cld.tour.js"></script>
-  <script defer src="../assets/water-cld.extras-readability.js"></script>
+    <script defer src="../assets/water-cld.extras-readability.js"></script>
     <script defer src="../assets/water-cld.extras-controls.js"></script>
     <script defer src="../assets/water-cld.presets.js"></script>
     <script defer src="../assets/water-cld.controls-meta.js"></script>
     <script defer src="../assets/water-cld.scenarios.js"></script>
+    <script defer src="../assets/water-cld.a11y.js"></script>
 
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add non-invasive A11Y CSS for skip link, focus rings, touch targets and reduced motion
- bootstrap accessibility JS for skip link, ARIA names, keyboard activation and Cytoscape focus
- wire the new CSS/JS into `docs/test/water-cld.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a7e4aa3fd0832888c799ad5146043b