### PR TITLE
Add KPI delta tracking and UI enhancements

### DIFF
--- a/docs/assets/water-cld.aha-metrics.js
+++ b/docs/assets/water-cld.aha-metrics.js
@@ -1,0 +1,15 @@
+(function(){ if(window.__AHA_METRICS__)return; window.__AHA_METRICS__=true;
+const LS=window.localStorage; let t0=null, done=false;
+function markStart(){ if(t0!=null) return; t0=Date.now(); try{LS.setItem('aha_start_ts',String(t0))}catch(_){}}
+function markEvent(name){ try{const arr=JSON.parse(LS.getItem('aha_events')||'[]'); arr.push({name,t:Date.now()}); LS.setItem('aha_events',JSON.stringify(arr))}catch(_){ } }
+function markDeltaShown(){ if(done||t0==null) return; done=true; const dt=Date.now()-t0; try{LS.setItem('aha_time_ms',String(dt))}catch(_){ } console.info('[AHA]',dt,'ms') }
+function bindFirstInteraction(){
+  ['p-eff','p-dem','p-delay','btn-run','btn-run-sample'].forEach(id=>{
+    const el=document.getElementById(id); if(!el) return;
+    const ev=el.tagName==='INPUT'?'input':'click';
+    el.addEventListener(ev,()=>{ markStart(); markEvent('start') }, {once:true});
+  });
+}
+document.addEventListener('model:updated',()=>{ markEvent('delta-shown'); markDeltaShown() });
+document.readyState!=='loading'?bindFirstInteraction():window.addEventListener('DOMContentLoaded',bindFirstInteraction,{once:true});
+})();

--- a/docs/assets/water-cld.delta-kpi.css
+++ b/docs/assets/water-cld.delta-kpi.css
@@ -1,0 +1,5 @@
+.kpi{position:relative}
+.kpi .delta-chip{position:absolute;top:6px;inset-inline-end:6px;font-size:11px;padding:2px 6px;border-radius:999px}
+.delta-up{background:#103a2f;color:#a8f5de}
+.delta-down{background:#3a1212;color:#ffd4d4}
+.delta-zero{background:#2a2a2a;color:#ddd}

--- a/docs/assets/water-cld.delta-kpi.js
+++ b/docs/assets/water-cld.delta-kpi.js
@@ -1,0 +1,22 @@
+(function(){ if(window.__DELTA_KPI__)return; window.__DELTA_KPI__=true;
+const LS=window.localStorage; const THRESH=1.0; // % \u0645\u0639\u0646\u06cc\u200c\u062f\u0627\u0631
+function $$(s,r=document){return Array.from(r.querySelectorAll(s))}
+function readKPIs(){ const map={}; $$('.kpi').forEach(k=>{ const key=k.dataset.kpi||k.querySelector('.kpi-title')?.textContent?.trim(); const v=parseFloat(k.querySelector('.kpi-value .val')?.textContent||'0'); if(key) map[key]=v }); return map }
+function ensureChips(){ $$('.kpi').forEach(k=>{ if(!k.querySelector('.delta-chip')){ const s=document.createElement('span'); s.className='delta-chip delta-zero'; s.textContent='0%'; k.appendChild(s) } }) }
+function showToast(msg){ let t=document.getElementById('kpi-toast'); if(!t){ t=document.createElement('div'); t.id='kpi-toast'; t.className='toast'; document.body.appendChild(t) } t.textContent=msg; t.classList.add('show'); setTimeout(()=>t.classList.remove('show'),3000) }
+function loadBase(){ try{ const s=LS.getItem('kpi_base_v1'); if(s) return JSON.parse(s) }catch(_){} const b=readKPIs(); try{LS.setItem('kpi_base_v1',JSON.stringify(b))}catch(_){} return b }
+function applyDelta(base){
+  let biggest={k:null,d:0,val:0};
+  $$('.kpi').forEach(k=>{ const key=k.dataset.kpi||k.querySelector('.kpi-title')?.textContent?.trim(); const v=parseFloat(k.querySelector('.kpi-value .val')?.textContent||'0'); const b=base[key]; if(typeof b!=='number') return;
+    const d = ((v-b)/Math.max(Math.abs(b),1e-9))*100;
+    const chip=k.querySelector('.delta-chip'); if(!chip) return;
+    let cls='delta-zero', txt='0%'; if(Math.abs(d)>=0.1){ cls=d>=0?'delta-up':'delta-down'; txt=(d>=0?'+':'')+d.toFixed(1)+'%' }
+    chip.className='delta-chip '+cls; chip.textContent=txt;
+    if(Math.abs(d)>Math.abs(biggest.d)){ biggest={k:key,d,val:v} }
+  });
+  if(Math.abs(biggest.d)>=THRESH){ showToast(`\u0627\u062b\u0631 \u0633\u0646\u0627\u0631\u06cc\u0648 \u0631\u0648\u06cc \u00ab${biggest.k}\u00bb: ${(biggest.d>=0?'+':'')}${biggest.d.toFixed(1)}% (\u0646\u0633\u0628\u062a \u0628\u0647 Baseline)`) }
+}
+function init(){ ensureChips(); const base=loadBase(); applyDelta(base) }
+document.readyState!=='loading'?init():window.addEventListener('DOMContentLoaded',init,{once:true});
+document.addEventListener('model:updated',()=>{ const base=loadBase(); ensureChips(); applyDelta(base) });
+})();

--- a/docs/assets/water-cld.explain-10s.js
+++ b/docs/assets/water-cld.explain-10s.js
@@ -1,0 +1,23 @@
+(function(){ if(window.__EXPLAIN10__)return; window.__EXPLAIN10__=true;
+function bestDelta(){
+  const cards=[...document.querySelectorAll('.kpi')].map(k=>{
+    const key=k.dataset.kpi||k.querySelector('.kpi-title')?.textContent?.trim();
+    const chip=k.querySelector('.delta-chip')?.textContent||'0%'; const m=chip.match(/([+-]?\d+(\.\d+)?)%/);
+    const d=m?parseFloat(m[1]):0; return {key,d};
+  });
+  return cards.sort((a,b)=>Math.abs(b.d)-Math.abs(a.d))[0]||{key:null,d:0};
+}
+function sentence(){
+  const eff=parseFloat(document.getElementById('p-eff')?.value||'0.3');
+  const dem=parseFloat(document.getElementById('p-dem')?.value||'0.6');
+  const {key,d}=bestDelta(); if(!key) return '—';
+  const dir=d>=0?'\u0627\u0641\u0632\u0627\u06cc\u0634':'\u06a9\u0627\u0647\u0634'; const kfa= key==='supply_demand_gap'?\u0027\u0634\u06a9\u0627\u0641 \u0639\u0631\u0636\u0647\u2013\u062a\u0642\u0627\u0636\u0627\u0027: key==='per_capita_use'?\u0027\u0645\u0635\u0631\u0641 \u0633\u0631\u0627\u0646\u0647\u0027:'\u0646\u0631\u062e \u062a\u0644\u0641\u0627\u062a';
+  return `\u0628\u0627 \u062a\u0646\u0638\u06cc\u0645 eff=${eff.toFixed(2)} \u0648 dem=${dem.toFixed(2)}, ${kfa} ${dir} ${Math.abs(d).toFixed(1)}\u066a \u062f\u0627\u0634\u062a.`;
+}
+function render(){
+  let el=document.getElementById('explain-10s'); if(!el){ el=document.createElement('div'); el.id='explain-10s'; el.style.cssText='margin-top:6px;color:#9fb3ad;font-size:12.5px'; const hero=document.querySelector('#hero-kpi .hero-left'); hero?.appendChild(el) }
+  el.textContent=sentence();
+}
+document.addEventListener('model:updated',render);
+document.readyState!=='loading'?render():window.addEventListener('DOMContentLoaded',render,{once:true});
+})();

--- a/docs/assets/water-cld.ghost-delta.js
+++ b/docs/assets/water-cld.ghost-delta.js
@@ -1,0 +1,25 @@
+(function(){ if(window.__GHOST_DELTA__)return; window.__GHOST_DELTA__=true;
+const $=(s,r=document)=>r.querySelector(s); const $$=(s,r=document)=>Array.from(r.querySelectorAll(s));
+function predictDelta(){ // \u062a\u062e\u0645\u06cc\u0646 \u0633\u0628\u06a9: \u0641\u0642\u0637 \u062c\u0647\u062a\u200c\u0646\u0645\u0627
+  const eff=parseFloat($('#p-eff')?.value||'0.3'); const dem=parseFloat($('#p-dem')?.value||'0.6');
+  const ghosts={}; // \u0627\u062b\u0631\u0627\u062a \u062a\u0642\u0631\u06cc\u0628\u06cc
+  ghosts.per_capita_use = (dem-0.6)*100;         // \u2191dem \u2192 \u2191 \u0645\u0635\u0631\u0641
+  ghosts.leakage_rate   = (0.3-eff)*60;          // \u2191eff \u2192 \u2193 \u062a\u0644\u0641\u0627\u062a
+  ghosts.supply_demand_gap = (dem - eff)*40;     // gap ~ dem - eff
+  return ghosts;
+}
+function renderGhost(g){
+  $$('.kpi').forEach(k=>{
+    const key=k.dataset.kpi; if(!key||g[key]==null) return;
+    let tag=k.querySelector('.ghost'); if(!tag){ tag=document.createElement('span'); tag.className='ghost'; tag.style.cssText='position:absolute;bottom:6px;inset-inline-end:6px;font-size:11px;opacity:.7'; k.appendChild(tag) }
+    const d=g[key]; const s=(d>=0?'+':'')+d.toFixed(1)+'%~'; tag.textContent=s;
+  });
+}
+function bind(){
+  ['p-eff','p-dem'].forEach(id=>{ const el=document.getElementById(id); if(!el) return;
+    ['input','change'].forEach(ev=> el.addEventListener(ev,()=>renderGhost(predictDelta())) );
+  });
+}
+document.readyState!=='loading'?(()=>{bind();renderGhost(predictDelta())})():window.addEventListener('DOMContentLoaded',()=>{bind();renderGhost(predictDelta())},{once:true});
+document.addEventListener('model:updated',()=>{ $$('.kpi .ghost').forEach(e=>e.remove()) }); // \u067e\u0633 \u0627\u0632 Run\u060c \u0645\u0642\u062f\u0627\u0631 \u0648\u0627\u0642\u0639\u06cc \u062c\u0627\u06cc\u06af\u0632\u06cc\u0646 \u0634\u0648\u062f
+})();

--- a/docs/assets/water-cld.param-chips.css
+++ b/docs/assets/water-cld.param-chips.css
@@ -1,0 +1,2 @@
+#param-chips{display:flex;flex-wrap:wrap;gap:6px;margin:8px 0}
+.param-chip{background:#122826;border:1px solid #1f413c;color:#e9f3f0;border-radius:999px;padding:4px 10px;font-size:12px}

--- a/docs/assets/water-cld.param-chips.js
+++ b/docs/assets/water-cld.param-chips.js
@@ -1,0 +1,10 @@
+(function(){ if(window.__PARAM_CHIPS__)return; window.__PARAM_CHIPS__=true;
+const IDS=['p-eff','p-dem','p-delay']; const $=(s,r=document)=>r.querySelector(s);
+function getParams(){ const o={}; IDS.forEach(id=>{ const el=document.getElementById(id); if(el){ o[id]=el.type==='range'?+el.value:el.value } }); return o }
+let last=null;
+function render(diff){ let bar=document.getElementById('param-chips'); if(!bar){ bar=document.createElement('div'); bar.id='param-chips'; const host=document.querySelector('#panel-param .actions')||document.querySelector('#panel-param'); host?.after(bar) }
+  bar.innerHTML=''; Object.entries(diff).forEach(([k,v])=>{ const s=document.createElement('span'); s.className='param-chip'; s.textContent=`${k.replace('p-','')} ${v.from} → ${v.to}`; bar.appendChild(s) }) }
+function compute(){ const cur=getParams(); if(!last){ last=cur; return } const diff={}; Object.keys(cur).forEach(k=>{ if(cur[k]!==last[k]) diff[k]={from:last[k],to:cur[k]} }); if(Object.keys(diff).length) render(diff); last=cur }
+document.addEventListener('model:updated',compute);
+document.readyState!=='loading'?(()=>{last=getParams()})():window.addEventListener('DOMContentLoaded',()=>{last=getParams()},{once:true});
+})();

--- a/docs/assets/water-cld.quick-preset.css
+++ b/docs/assets/water-cld.quick-preset.css
@@ -1,0 +1,3 @@
+.quick-cta{position:sticky;top:0;z-index:30;background:#0f2220;border-bottom:1px solid #1f413c;padding:8px 12px;display:flex;gap:8px;align-items:center}
+.quick-cta .btn{background:#16312d;border:1px solid #1f413c;color:#e9f3f0;border-radius:10px;padding:6px 10px;font-size:12px;cursor:pointer}
+.quick-cta .hint{font-size:12px;color:#9fb3ad}

--- a/docs/assets/water-cld.quick-preset.js
+++ b/docs/assets/water-cld.quick-preset.js
@@ -1,0 +1,19 @@
+(function(){ if(window.__QUICK_PRESET__)return; window.__QUICK_PRESET__=true;
+const LS=window.localStorage;
+function setParam(id,val){ const el=document.getElementById(id); if(!el) return false; el.value=val; el.dispatchEvent(new Event('input',{bubbles:true})); el.dispatchEvent(new Event('change',{bubbles:true})); return true }
+async function runModel(){ document.dispatchEvent(new CustomEvent('model:updated',{detail:{source:'quick-preset'}})) }
+function applyPresetLeakage20(){
+  // \u062a\u0644\u0627\u0634 \u0628\u0627 ModelBridge \u0627\u06af\u0631 \u0647\u0633\u062a
+  if(window.ModelBridge?.setParam){ try{ window.ModelBridge.setParam('leakage_rate',0.20) }catch(_){} }
+  // fallback \u0631\u0648\u06cc \u0627\u0633\u0644\u0627\u06cc\u062f\u0631\u0647\u0627\n  setParam('p-eff',0.35); // \u0646\u0645\u0648\u0646\u0647\u200c\u0627\u06cc \u0628\u0631\u0627\u06cc \u0627\u062b\u0631\u06af\u0630\u0627\u0631\u06cc
+  runModel();
+}
+function boot(){
+  try{ if(LS.getItem('seenAha')==='1') return }catch(_){ }
+  const bar=document.createElement('div'); bar.className='quick-cta'; bar.id='quick-cta';
+  bar.innerHTML=`<button id="cta-see-effect" class="btn">\u0627\u062b\u0631 \u0633\u06cc\u0627\u0633\u062a \u0646\u0645\u0648\u0646\u0647 \u0631\u0627 \u0628\u0628\u06cc\u0646</button><span class="hint">\u06f2 \u06a9\u0644\u06cc\u06a9 \u062a\u0627 \u062f\u06cc\u062f\u0646 \u0627\u062b\u0631 \u0631\u0648\u06cc KPI\u0647\u0627</span>`;
+  const anchor=document.getElementById('hero-kpi')||document.body; anchor.parentElement.insertBefore(bar,anchor);
+  bar.querySelector('#cta-see-effect').addEventListener('click',()=>{ applyPresetLeakage20(); try{LS.setItem('seenAha','1')}catch(_){} });
+}
+document.readyState!=='loading'?boot():window.addEventListener('DOMContentLoaded',boot,{once:true});
+})();

--- a/docs/assets/water-cld.spotlight.css
+++ b/docs/assets/water-cld.spotlight.css
@@ -1,0 +1,2 @@
+.spot-dim .kpi{opacity:.35;transition:opacity .18s}
+.spot-dim .kpi .delta-chip{opacity:1}

--- a/docs/assets/water-cld.spotlight.js
+++ b/docs/assets/water-cld.spotlight.js
@@ -1,0 +1,4 @@
+(function(){ if(window.__SPOTLIGHT__)return; window.__SPOTLIGHT__=true;
+function flash(){ document.body.classList.add('spot-dim'); setTimeout(()=>document.body.classList.remove('spot-dim'),900) }
+document.addEventListener('model:updated',flash);
+})();

--- a/docs/assets/water-cld.toast.css
+++ b/docs/assets/water-cld.toast.css
@@ -1,0 +1,2 @@
+.toast{position:fixed;inset-inline:0;top:8px;margin-inline:auto;z-index:1000;max-width:720px;background:#122826;border:1px solid #1f413c;color:#e9f3f0;border-radius:12px;padding:10px 12px;font-size:13px;box-shadow:0 10px 32px rgba(0,0,0,.35);opacity:0;transform:translateY(-8px);transition:opacity .15s,transform .15s}
+.toast.show{opacity:1;transform:translateY(0)}

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -18,6 +18,11 @@
   <link rel="stylesheet" href="../assets/water-cld.paths.css">
   <link rel="stylesheet" href="../assets/chart.autofix.css">
   <link rel="stylesheet" href="../assets/water-cld.fix-hints.css">
+  <link rel="stylesheet" href="../assets/water-cld.delta-kpi.css">
+  <link rel="stylesheet" href="../assets/water-cld.param-chips.css">
+  <link rel="stylesheet" href="../assets/water-cld.quick-preset.css">
+  <link rel="stylesheet" href="../assets/water-cld.toast.css">
+  <link rel="stylesheet" href="../assets/water-cld.spotlight.css">
 </head>
 <body class="rtl">
   <!-- ===== HERO KPI BAR (start) ===== -->
@@ -244,5 +249,12 @@
   <script defer src="../assets/water-cld.paths.js"></script>
   <script defer src="../assets/chart.guard.js"></script>
   <script defer src="../assets/water-cld.fix-hints.js"></script>
+  <script defer src="../assets/water-cld.delta-kpi.js"></script>
+  <script defer src="../assets/water-cld.param-chips.js"></script>
+  <script defer src="../assets/water-cld.quick-preset.js"></script>
+  <script defer src="../assets/water-cld.aha-metrics.js"></script>
+  <script defer src="../assets/water-cld.ghost-delta.js"></script>
+  <script defer src="../assets/water-cld.spotlight.js"></script>
+  <script defer src="../assets/water-cld.explain-10s.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load new KPI delta, parameter chip, quick preset, toast, spotlight, ghost delta, Aha metrics, and explanation modules in water-cld demo
- implement KPI delta chips with toast notifications
- add parameter change chips, quick preset CTA, ghost delta preview, spotlight flash, Aha metrics logging, and 10‑second explanation

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a7ed555db88328a457150229275fb9