### PR TITLE
fix(water-cld): add Cytoscape batch guard and retain runtime protections

### DIFF
--- a/docs/assets/water-cld.cy-batch-guard.js
+++ b/docs/assets/water-cld.cy-batch-guard.js
@@ -1,26 +1,8 @@
-/* singleton */
-(function(){
-  if (window.__CY_BATCH_GUARD__) return; window.__CY_BATCH_GUARD__ = true;
-
-  function patch(){
-    if (!window.cytoscape || !window.cytoscape.Core) return;
-    const P = window.cytoscape.Core.prototype;
-
-    // Provide startBatch/endBatch if missing; prefer .batch(fn)
-    if (typeof P.startBatch !== 'function' || typeof P.endBatch !== 'function'){
-      if (typeof P.batch === 'function'){
-        if (typeof P.startBatch !== 'function'){ P.startBatch = function(){ this.___batched = true; }; }
-        if (typeof P.endBatch   !== 'function'){ P.endBatch   = function(){ this.___batched = false; }; }
-      } else {
-        if (typeof P.startBatch !== 'function') P.startBatch = function(){};
-        if (typeof P.endBatch   !== 'function') P.endBatch   = function(){};
-      }
-    }
+(function(){ if(window.__CY_BATCH_GUARD__)return; window.__CY_BATCH_GUARD__=true;
+  function patch(){ if(!window.cytoscape||!window.cytoscape.Core) return;
+    const P=window.cytoscape.Core.prototype;
+    if(typeof P.startBatch!=='function') P.startBatch=function(){};
+    if(typeof P.endBatch!=='function')   P.endBatch=function(){};
   }
-
-  if (document.readyState === 'loading'){
-    document.addEventListener('DOMContentLoaded', patch, { once:true });
-  } else {
-    patch();
-  }
+  (document.readyState==='loading')?document.addEventListener('DOMContentLoaded',patch,{once:true}):patch();
 })();

--- a/docs/assets/water-cld.explain-10s.js
+++ b/docs/assets/water-cld.explain-10s.js
@@ -28,8 +28,7 @@
       el = document.createElement('div');
       el.id = 'explain-10s';
       el.className = 'explain-10s';
-      const hero = document.querySelector('#hero-kpi .hero-left') || document.getElementById('hero-kpi');
-      hero?.appendChild(el);
+      (document.querySelector('#hero-kpi .hero-left') || document.getElementById('hero-kpi') || document.body).appendChild(el);
     }
     el.textContent = sentence();
   }

--- a/docs/assets/water-cld.runtime-guards.js
+++ b/docs/assets/water-cld.runtime-guards.js
@@ -1,7 +1,7 @@
 (function(){
   if (window.__CLD_RT_GUARD__) return; window.__CLD_RT_GUARD__=true;
 
-  // onCyReady: run callback once Cytoscape instance is ready
+  // Run callback once Cytoscape instance is ready
   if (!window.onCyReady) {
     window.__CLD_READY__ = false;
     window.onCyReady = function(run){
@@ -17,22 +17,13 @@
     };
   }
 
-  // lightweight debounce (global helper)
+  // lightweight debounce
   if (!window.__cldDebounce) {
-    window.__cldDebounce = function(fn, ms=60){
-      let t=0; return function(...a){ clearTimeout(t); t=setTimeout(()=>fn.apply(this,a), ms); };
-    };
+    window.__cldDebounce = function(fn, ms=60){ let t=0; return function(){ const a=arguments; clearTimeout(t); t=setTimeout(()=>fn.apply(this,a), ms); }; };
   }
 
-  // safe fit (if there are no elements, do nothing)
+  // safe fit
   if (!window.__cldSafeFit) {
-    window.__cldSafeFit = function(cy){
-      try{
-        if (!cy) return;
-        const els = cy.elements();
-        if (!els || els.length===0) return;
-        cy.fit(els, 40);
-      }catch(_){}
-    };
+    window.__cldSafeFit = function(cy){ try{ const els = cy?.elements(); if (!els || els.length===0) return; cy.fit(els, 40);}catch(_){} };
   }
 })();


### PR DESCRIPTION
## Summary
- add lightweight Cytoscape batch guard polyfill to stub `startBatch`/`endBatch` when missing
- keep guarded helpers for Cytoscape runtime, Chart.js reinit, and KPI explanation; revert other assets to `main`

Changed files:
- `docs/assets/water-cld.runtime-guards.js`
- `docs/assets/water-cld.cy-batch-guard.js`
- `docs/assets/water-cld.explain-10s.js`
- `docs/assets/chart.guard.js`

Reverted files:
- `docs/assets/electricity-quality.js`
- `docs/assets/cost-calculator.js`
- `docs/assets/sim-worker.js`
- `docs/assets/badge-updated.js`

## Testing
- `npm test`
- `npm run flag:test` *(fails: libatk-1.0.so.0 missing)*
- `npm run check:no-binary`
- `node -e "const p=require('puppeteer');(async()=>{const b=await p.launch();const pg=await b.newPage();await pg.goto('file://'+process.cwd()+'/docs/test/water-cld.html');await b.close();})();"` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f96831e0832898d86953d66b3a94