### PR TITLE
feat: improve cy stub with selector references

### DIFF
--- a/docs/assets/water-cld.cy-stub.js
+++ b/docs/assets/water-cld.cy-stub.js
@@ -5,17 +5,33 @@
   const noop  = function(){};
   const toArr = (a)=> Array.prototype.slice.call(a || []);
 
-  // Queue operations called before real cy exists
+  // صف عملیات قبل از آماده‌شدن cy واقعی
   const queue = [];
-  function enqueue(kind, method, args, selector){
-    queue.push({ kind, method, args: toArr(args), selector: selector == null ? null : selector });
+  function enqueue(kind, method, args, selectorRef){
+    queue.push({ kind, method, args: toArr(args), selectorRef: selectorRef || null });
   }
 
-  function resolveCollection(real, selector){
-    if (!selector) return real.elements();
-    if (selector.__type === 'id')    return real.getElementById(String(selector.value));
-    if (selector.__type === 'query') return real.$(String(selector.value));
-    return real.elements(selector);
+  // ساخت یک reference برای انتخاب، با قابلیت نگه‌داری زنجیرهٔ فیلترها
+  function makeSelectorRef(base){
+    // base: { type:'elements'|'id'|'query', value:any }
+    return { type: base.type, value: base.value, ops: [] }; // ops: [{method:'filter', args:[...]}]
+  }
+
+  function resolveBase(real, ref){
+    if (!ref) return real.elements();
+    if (ref.type === 'id')    return real.getElementById(String(ref.value));
+    if (ref.type === 'query') return real.$(String(ref.value));
+    return real.elements(ref.value);
+  }
+
+  function applyOps(coll, ops){
+    let cur = coll;
+    for (const op of (ops || [])){
+      if (typeof cur?.[op.method] === 'function'){
+        cur = cur[op.method].apply(cur, toArr(op.args));
+      }
+    }
+    return cur;
   }
 
   function flush(real){
@@ -26,51 +42,62 @@
           const fn = real[op.method];
           if (typeof fn === 'function') fn.apply(real, op.args);
         } else if (op.kind === 'collection'){
-          const coll = resolveCollection(real, op.selector);
-          if (!coll) continue;
-          const fn = coll[op.method];
+          const base = resolveBase(real, op.selectorRef);
+          const coll = applyOps(base, op.selectorRef?.ops);
+          const fn = coll && coll[op.method];
           if (typeof fn === 'function') fn.apply(coll, op.args);
         }
       }
-    }catch(_){} // swallow
+    }catch(_){ }
     queue.length = 0;
   }
 
-  // ---- collection proxy so cy.elements(...).remove().data() doesn't throw ----
-  function makeCollectionProxy(selector){
+  // ---- کالکشن پروکسی: متدهای زنجیره‌ای و عملیاتی ----
+  function makeCollectionProxy(selectorRef){
     const api = {};
-    const chain = [
+    // متدهای زنجیره‌ای که مجموعه را تغییر می‌دهند و باید در ops ذخیره شوند
+    const chainOps = ['filter']; // درصورت نیاز می‌شود 'union','difference','merge' را هم افزود
+    chainOps.forEach(m=>{
+      api[m] = function(){
+        selectorRef.ops.push({ method: m, args: arguments });
+        return api;
+      };
+    });
+
+    // متدهای عملیاتی که باید در صف اعمال روی کالکشن ثبت شوند
+    const actionOps = [
       'add','remove',
       'addClass','removeClass','toggleClass',
-      'style','data','animate','layout','merge','difference','union'
+      'style','data','animate','layout','move' // ← move اضافه شد
     ];
-    chain.forEach(m=>{
-      api[m] = function(){ enqueue('collection', m, arguments, selector); return api; };
+    actionOps.forEach(m=>{
+      api[m] = function(){ enqueue('collection', m, arguments, selectorRef); return api; };
     });
-    // readonly helpers
+
+    // کمکی‌های فقط‌خواندنی
     api.forEach = noop;
     api.map     = function(){ return []; };
-    api.filter  = function(){ return makeCollectionProxy(selector); };
-    Object.defineProperty(api, 'length', { get: ()=>0 });
+    api.filter  = api.filter; // از بالا
+    Object.defineProperty(api,'length',{ get: ()=>0 });
     return api;
   }
 
-  // ---- stub cy object ----
+  // ---- شیء استاب cy ----
   let realCy = null;
   const cyStub = {
     // selectors
-    elements(sel){ return makeCollectionProxy(sel); },
-    nodes(sel){ return makeCollectionProxy(sel); },
-    edges(sel){ return makeCollectionProxy(sel); },
-    getElementById(id){ return makeCollectionProxy({ __type:'id', value:String(id) }); },
-    $: function(query){ return makeCollectionProxy({ __type:'query', value:String(query) }); },
+    elements(sel){ return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
+    nodes(sel){    return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
+    edges(sel){    return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
+    getElementById(id){ return makeCollectionProxy(makeSelectorRef({ type:'id', value: String(id) })); },
+    $ (query){        return makeCollectionProxy(makeSelectorRef({ type:'query', value: String(query) })); },
 
     // events & batching
     on: noop, off: noop,
     startBatch: noop, endBatch: noop,
     batch(fn){ try{ typeof fn === 'function' && fn.call(this); } catch(_){ } },
 
-    // cy-level mutations (queued)
+    // cy-level ops (queued)
     fit(){       enqueue('cy','fit',       arguments); },
     add(){       enqueue('cy','add',       arguments); },
     remove(){    enqueue('cy','remove',    arguments); },
@@ -81,7 +108,7 @@
     layout(){    enqueue('cy','layout',    arguments); }
   };
 
-  // Expose window.cy with getter/setter; flush when real instance is set
+  // Getter/Setter روی window.cy + flush
   try{
     Object.defineProperty(window, 'cy', {
       configurable: true,
@@ -92,16 +119,14 @@
     window.cy = window.cy || cyStub;
   }
 
-  // Capture via event too
+  // گرفتن instance از رویداد
   document.addEventListener('cy:ready', function(e){
     const inst = e && e.detail && e.detail.cy;
     if (inst){ try{ realCy = inst; flush(realCy); }catch(_){ } }
   });
 
-  // Late flush fallback (in case ready event fired before setter)
+  // Late flush fallback
   setTimeout(function(){
-    try{
-      if (window.cy && window.cy !== cyStub) flush(window.cy);
-    }catch(_){}
+    try{ if (window.cy && window.cy !== cyStub) flush(window.cy); }catch(_){ }
   }, 200);
 })();


### PR DESCRIPTION
## Summary
- replace `water-cld.cy-stub.js` with selector-aware queueing stub
- support chainable filters and add `move` to collection actions

## Testing
- `npm test`
- `npm run flag:test` *(fails: libdrm.so.2 missing)*
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a837db7028832885a6d42ca88e7ed2