### PR TITLE
chore(cld): stabilize boot with c→cy alias and safe-add batching

### DIFF
--- a/docs/assets/water-cld.cy-alias.js
+++ b/docs/assets/water-cld.cy-alias.js
@@ -1,0 +1,25 @@
+(function(){
+  if (window.__CY_ALIAS__) return; window.__CY_ALIAS__ = true;
+
+  function define(){
+    try{
+      Object.defineProperty(window, 'c', {
+        configurable: true,
+        get: function(){ return window.cy; },
+        set: function(v){ try { window.cy = v; } catch(_) {} }
+      });
+    }catch(_){ window.c = window.cy; }
+  }
+
+  define();
+  document.addEventListener('cy:ready', define);
+
+  // microtask/tick: اگر cy آماده است، رویداد را یک‌بار دیگر پخش کن
+  setTimeout(function(){
+    try{
+      if (window.cy && typeof window.cy.add === 'function') {
+        document.dispatchEvent(new CustomEvent('cy:ready', { detail:{ cy: window.cy } }));
+      }
+    }catch(_){}
+  }, 0);
+})();

--- a/docs/assets/water-cld.cy-safe-add.js
+++ b/docs/assets/water-cld.cy-safe-add.js
@@ -11,20 +11,18 @@
       id:   (id)=> cy.getElementById ? cy.getElementById(id) : cy.$('#'+id)
     };
 
-    // Edge queue for unresolved endpoints
     const pendingEdges = []; // { data, scratch, classes }
 
     function existsNode(id){
-      if (!id && id !== 0) return false;
+      if (id === undefined || id === null) return false;
       const col = orig.id(String(id));
       return !!(col && col.length && col.length > 0);
     }
 
-    function isNode(el){ return el && (el.group === 'nodes' || el.data?.id && !el.data?.source && !el.data?.target); }
-    function isEdge(el){ return el && (el.group === 'edges' || (el.data?.source && el.data?.target)); }
+    function isNode(el){ return el && (el.group === 'nodes' || (el.data && el.data.id && !el.data.source && !el.data.target)); }
+    function isEdge(el){ return el && (el.group === 'edges' || (el.data && el.data.source && el.data.target)); }
 
     function normalize(input){
-      // return {nodes:[], edges:[], passthrough:null}
       if (typeof input === 'string') return { passthrough: input };
       if (Array.isArray(input))      return splitArray(input);
       if (input && input.elements)   return splitArray(input.elements);
@@ -34,65 +32,88 @@
 
     function splitArray(arr){
       const nodes = [], edges = [];
-      for (const el of arr || []){
-        if (isEdge(el)) edges.push(clean(el));
-        else if (isNode(el)) nodes.push(clean(el));
+      for (const el of (arr||[])){
+        if (isEdge(el)) edges.push(clone(el));
+        else if (isNode(el)) nodes.push(clone(el));
       }
       return { nodes, edges };
     }
 
-    function clean(el){
-      // minimal deep clone without functions
-      try{ return JSON.parse(JSON.stringify(el)); }catch(_){ return el; }
-    }
+    function clone(el){ try { return JSON.parse(JSON.stringify(el)); } catch(_) { return el; } }
 
     function dedupe(list){
       const out = [], seen = new Set();
-      for (const el of list){
-        const id = el?.data?.id;
-        if (id && !seen.has(id)){
-          seen.add(id); out.push(el);
-        }
+      for (const el of list||[]){
+        const id = el && el.data && el.data.id;
+        if (id && !seen.has(id)){ seen.add(id); out.push(el); }
       }
       return out;
     }
 
     function addNodes(nodes){
       if (!nodes || !nodes.length) return cy.collection();
-      // skip if already exist
-      const fresh = nodes.filter(n => !existsNode(n?.data?.id));
-      return fresh.length ? orig.add(fresh) : cy.collection();
+      const fresh = nodes.filter(n => !existsNode(n && n.data && n.data.id));
+      if (!fresh.length) return cy.collection();
+      try { cy.startBatch && cy.startBatch(); } catch(_){ }
+      const out = orig.add(fresh);
+      try { cy.endBatch && cy.endBatch(); } catch(_){ }
+      return out;
     }
 
     function tryAddEdges(edges){
       if (!edges || !edges.length) return cy.collection();
       const ready = [], wait = [];
       for (const e of edges){
-        const s = e?.data?.source, t = e?.data?.target;
+        const s = e && e.data && e.data.source;
+        const t = e && e.data && e.data.target;
         (existsNode(s) && existsNode(t)) ? ready.push(e) : wait.push(e);
       }
-      const added = ready.length ? orig.add(ready) : cy.collection();
-      if (wait.length) pendingEdges.push.apply(pendingEdges, wait);
+
+      let added = cy.collection();
+      if (ready.length){
+        try { cy.startBatch && cy.startBatch(); } catch(_){ }
+        added = orig.add(ready);
+        try { cy.endBatch && cy.endBatch(); } catch(_){ }
+      }
+
+      if (wait.length){
+        pendingEdges.push.apply(pendingEdges, wait);
+        // tick: در اولین فرصت دوباره تلاش کن (حتی اگر event نیاید)
+        setTimeout(function(){
+          if (!pendingEdges.length) return;
+          try { cy.startBatch && cy.startBatch(); } catch(_){ }
+          const copy = pendingEdges.splice(0, pendingEdges.length);
+          const r2 = [], w2 = [];
+          for (const e of copy){
+            const s = e && e.data && e.data.source;
+            const t = e && e.data && e.data.target;
+            (existsNode(s) && existsNode(t)) ? r2.push(e) : w2.push(e);
+          }
+          if (r2.length) try { orig.add(r2); } catch(_){ }
+          if (w2.length) pendingEdges.push.apply(pendingEdges, w2);
+          try { cy.endBatch && cy.endBatch(); } catch(_){ }
+        }, 0);
+      }
+
       return added;
     }
 
-    // replay pending edges when nodes land
     function attachReplayOnce(){
       if (cy.__SAFE_ADD_REPLAY__) return;
       cy.on('add', 'node', function(){
         if (!pendingEdges.length) return;
-        tryAddEdges(pendingEdges.splice(0, pendingEdges.length));
+        try { cy.startBatch && cy.startBatch(); } catch(_){ }
+        const copy = pendingEdges.splice(0, pendingEdges.length);
+        tryAddEdges(copy);
+        try { cy.endBatch && cy.endBatch(); } catch(_){ }
       });
       cy.__SAFE_ADD_REPLAY__ = true;
     }
 
-    // Wrapped cy.add
+    // wrap cy.add
     cy.add = function(input){
       const pack = normalize(input);
-      if (pack.passthrough !== undefined) {
-        // fall back for selectors/unknown structures
-        return orig.add(pack.passthrough);
-      }
+      if (pack.passthrough !== undefined) return orig.add(pack.passthrough);
       const nodes = dedupe(pack.nodes);
       const edges = dedupe(pack.edges);
       const col1  = addNodes(nodes);
@@ -101,15 +122,17 @@
       return col1.union(col2);
     };
 
-    // Wrapped cy.json: if elements exist, apply through safe add
+    // wrap cy.json برای restore ایمن
     cy.json = function(obj){
       if (obj && obj.elements){
         const pack = normalize(obj);
         const nodes = dedupe(pack.nodes);
         const edges = dedupe(pack.edges);
-        cy.elements().remove(); // reset current
+        try { cy.startBatch && cy.startBatch(); } catch(_){ }
+        cy.elements().remove();
         addNodes(nodes);
         tryAddEdges(edges);
+        try { cy.endBatch && cy.endBatch(); } catch(_){ }
         attachReplayOnce();
         return orig.json({ elements: cy.elements().jsons() });
       }
@@ -122,12 +145,12 @@
   function tryInstall(){
     try{
       if (window.cy) install(window.cy);
-      // also wrap future instances
+      // wrap factory برای نمونه‌های آینده
       if (window.cytoscape && !window.cytoscape.__SAFE_ADD_WRAP__){
         const factory = window.cytoscape;
         window.cytoscape = function(){
           const inst = factory.apply(this, arguments);
-          try{ install(inst); }catch(_){ }
+          try { install(inst); } catch(_){ }
           return inst;
         };
         window.cytoscape.__SAFE_ADD_WRAP__ = true;
@@ -140,5 +163,7 @@
   } else {
     tryInstall();
   }
-  document.addEventListener('cy:ready', function(e){ try{ install(e && e.detail && e.detail.cy); }catch(_){ } });
+  document.addEventListener('cy:ready', function(e){
+    try { install(e && e.detail && e.detail.cy); } catch(_){ }
+  });
 })();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -238,8 +238,9 @@
     </section>
   </div>
 
-  <!-- Guards: pre-core (singleton, idempotent) -->
+  <!-- Guards: pre-core -->
   <script defer src="../assets/water-cld.cy-stub.js"></script>
+  <script defer src="../assets/water-cld.cy-alias.js"></script>
 
   <!-- Vendors -->
   <script defer src="/assets/vendor/cytoscape.min.js"></script>


### PR DESCRIPTION
## Summary
- add CSP-safe global `c` alias for `window.cy`
- batch `safe-add` operations and replay pending edges asynchronously
- load pre-core and guard scripts in deterministic order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a842cff2f083289fddf97e2fca3fcd