### PR TITLE
fix: guard cy collections and safe add sequencing

### DIFF
--- a/docs/assets/water-cld.cy-alias.js
+++ b/docs/assets/water-cld.cy-alias.js
@@ -1,0 +1,26 @@
+(function(){
+  if (window.__CY_ALIAS__) return; window.__CY_ALIAS__ = true;
+
+  function define(){
+    try{
+      Object.defineProperty(window, 'c', {
+        configurable: true,
+        get: function(){ return window.cy; },
+        set: function(v){ try{ window.cy = v; }catch(_){ } }
+      });
+    }catch(_){ window.c = window.cy; }
+  }
+
+  define();
+  // اگر cy بعداً آماده شد دوباره alias را مطمئن کن
+  document.addEventListener('cy:ready', define);
+
+  // یک microtask/tick برای فلش کردن صف‌های آماده
+  setTimeout(function(){
+    try{
+      if (window.cy && typeof window.cy.add === 'function'){
+        document.dispatchEvent(new CustomEvent('cy:ready', { detail:{ cy: window.cy } }));
+      }
+    }catch(_){ }
+  }, 0);
+})();

--- a/docs/assets/water-cld.cy-collection-guard.js
+++ b/docs/assets/water-cld.cy-collection-guard.js
@@ -1,0 +1,140 @@
+/* singleton, idempotent */
+(function(){
+  if (window.__CY_COLL_GUARD__) return; window.__CY_COLL_GUARD__ = true;
+
+  function install(cy){
+    if (!cy || cy.__SAFE_COLL_INSTALLED__) return;
+    const pending = []; // { selectorPath: string[], method: string, args: any[] }
+
+    function ensureListeners(){
+      if (cy.__SAFE_COLL_LISTENERS__) return;
+      cy.on('add', '*', function(){
+        try{
+          if (!pending.length) return;
+          // Try apply pending ops whose selector now matches something
+          for (let i = pending.length - 1; i >= 0; i--){
+            const p = pending[i];
+            const sel = p.selectorPath.join('');
+            const coll = cy.$(sel);
+            if (coll.length > 0){
+              const fn = coll[p.method];
+              if (typeof fn === 'function') try{ fn.apply(coll, p.args); }catch(_){ }
+              pending.splice(i,1);
+            }
+          }
+        }catch(_){ }
+      });
+      cy.__SAFE_COLL_LISTENERS__ = true;
+    }
+
+    // Build a wrapped collection with index-safe access and queue-on-empty actions
+    function wrapCollection(coll, selectorPath){
+      if (!coll) coll = cy.collection();
+      if (coll.__SAFE_WRAPPED__) return coll;
+
+      selectorPath = selectorPath || ['']; // default to empty selector
+
+      const actions = ['add','remove','addClass','removeClass','toggleClass','style','data','animate','layout','move'];
+      const chainers = ['filter']; // extend if needed
+
+      const handler = {
+        get(target, prop){
+          // numeric index → return a "singular" proxy that delegates to the collection methods
+          if (typeof prop === 'string' && /^\d+$/.test(prop)){
+            // return an object exposing actions; if empty → queue
+            const singular = {};
+            actions.forEach(m=>{
+              singular[m] = function(){
+                if (target.length > 0){
+                  const els = target; // first element's collection-like methods exist on collection as well
+                  const fn  = els[m];
+                  if (typeof fn === 'function') return fn.apply(els, arguments);
+                } else {
+                  pending.push({ selectorPath, method: m, args: Array.prototype.slice.call(arguments) });
+                  ensureListeners();
+                }
+                return singular;
+              };
+            });
+            return singular;
+          }
+
+          if (actions.includes(prop)){
+            return function(){
+              if (target.length > 0){
+                const fn = target[prop];
+                if (typeof fn === 'function') return fn.apply(target, arguments);
+              } else {
+                pending.push({ selectorPath, method: prop, args: Array.prototype.slice.call(arguments) });
+                ensureListeners();
+              }
+              return wrapCollection(target, selectorPath);
+            };
+          }
+
+          if (chainers.includes(prop)){
+            return function(){
+              const args = Array.prototype.slice.call(arguments);
+              // best-effort: only string selector paths are supported for queuing
+              const selToken = (typeof args[0] === 'string') ? args[0] : '';
+              const nextPath = selectorPath.concat([ selToken ]);
+              const next = target[prop].apply(target, args);
+              return wrapCollection(next, nextPath);
+            };
+          }
+
+          const val = target[prop];
+          return (typeof val === 'function') ? val.bind(target) : val;
+        }
+      };
+
+      const proxy = new Proxy(coll, handler);
+      proxy.__SAFE_WRAPPED__ = true;
+      return proxy;
+    }
+
+    // wrap factory-like selectors on the cy instance
+    const orig = {
+      elements: cy.elements.bind(cy),
+      nodes:    cy.nodes.bind(cy),
+      edges:    cy.edges.bind(cy),
+      $:        cy.$.bind(cy),
+      getElementById: cy.getElementById.bind(cy),
+      collection: cy.collection.bind(cy)
+    };
+
+    cy.elements = function(sel){ return wrapCollection(orig.elements(sel), [''+(sel||'')]); };
+    cy.nodes    = function(sel){ return wrapCollection(orig.nodes(sel),    [''+(sel||'')]); };
+    cy.edges    = function(sel){ return wrapCollection(orig.edges(sel),    [''+(sel||'')]); };
+    cy.$        = function(q){   return wrapCollection(orig.$(q),          [''+(q||'')]); };
+    cy.getElementById = function(id){
+      // emulate a selector path that resolves to a single id
+      return wrapCollection(orig.getElementById(id), ['[#'+id+']']);
+    };
+
+    cy.__SAFE_COLL_INSTALLED__ = true;
+  }
+
+  function tryInstall(){
+    try{
+      if (window.cy) install(window.cy);
+      // also wrap future instances if created later
+      if (window.cytoscape && !window.cytoscape.__SAFE_WRAP_COLLECTIONS__){
+        const orig = window.cytoscape;
+        window.cytoscape = function(){
+          const inst = orig.apply(this, arguments);
+          try{ install(inst); }catch(_){ }
+          return inst;
+        };
+        window.cytoscape.__SAFE_WRAP_COLLECTIONS__ = true;
+      }
+    }catch(_){ }
+  }
+
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', tryInstall, { once:true });
+  } else {
+    tryInstall();
+  }
+  document.addEventListener('cy:ready', function(e){ try{ install(e && e.detail && e.detail.cy); }catch(_){ } });
+})();

--- a/docs/assets/water-cld.cy-safe-add.js
+++ b/docs/assets/water-cld.cy-safe-add.js
@@ -1,0 +1,167 @@
+(function(){
+  if (window.__CY_SAFE_ADD__) return; window.__CY_SAFE_ADD__ = true;
+  'use strict';
+
+  function install(cy){
+    if (!cy || cy.__SAFE_ADD_INSTALLED__) return;
+
+    const orig = {
+      add:  cy.add.bind(cy),
+      json: cy.json.bind(cy),
+      $:    cy.$.bind(cy),
+      id:   (id)=> cy.getElementById ? cy.getElementById(id) : cy.$('#'+id)
+    };
+
+    // Edge queue for unresolved endpoints
+    const pendingEdges = []; // { data, scratch, classes }
+
+    function existsNode(id){
+      if (!id && id !== 0) return false;
+      const col = orig.id(String(id));
+      return !!(col && col.length && col.length > 0);
+    }
+
+    function isNode(el){ return el && (el.group === 'nodes' || el.data?.id && !el.data?.source && !el.data?.target); }
+    function isEdge(el){ return el && (el.group === 'edges' || (el.data?.source && el.data?.target)); }
+
+    function normalize(input){
+      // return {nodes:[], edges:[], passthrough:null}
+      if (typeof input === 'string') return { passthrough: input };
+      if (Array.isArray(input))      return splitArray(input);
+      if (input && input.elements)   return splitArray(input.elements);
+      if (input && (isNode(input) || isEdge(input))) return splitArray([input]);
+      return { passthrough: input };
+    }
+
+    function splitArray(arr){
+      const nodes = [], edges = [];
+      for (const el of arr || []){
+        if (isEdge(el)) edges.push(clean(el));
+        else if (isNode(el)) nodes.push(clean(el));
+      }
+      return { nodes, edges };
+    }
+
+    function clean(el){
+      // minimal deep clone without functions
+      try{ return JSON.parse(JSON.stringify(el)); }catch(_){ return el; }
+    }
+
+    function dedupe(list){
+      const out = [], seen = new Set();
+      for (const el of list){
+        const id = el?.data?.id;
+        if (id && !seen.has(id)){
+          seen.add(id); out.push(el);
+        }
+      }
+      return out;
+    }
+
+    function addNodes(nodes){
+      if (!nodes || !nodes.length) return cy.collection();
+      // skip if already exist
+      const fresh = nodes.filter(n => !existsNode(n?.data?.id));
+      if (!fresh.length) return cy.collection();
+      try{ cy.startBatch && cy.startBatch(); }catch(_){ }
+      const out = orig.add(fresh);
+      try{ cy.endBatch && cy.endBatch(); }catch(_){ }
+      if (pendingEdges.length){
+        setTimeout(function(){
+          if (!pendingEdges.length) return;
+          tryAddEdges(pendingEdges.splice(0, pendingEdges.length));
+        }, 0);
+      }
+      return out;
+    }
+
+    function tryAddEdges(edges){
+      if (!edges || !edges.length) return cy.collection();
+      const ready = [], wait = [];
+      for (const e of edges){
+        const s = e?.data?.source, t = e?.data?.target;
+        (existsNode(s) && existsNode(t)) ? ready.push(e) : wait.push(e);
+      }
+      let added = cy.collection();
+      if (ready.length){
+        try{ cy.startBatch && cy.startBatch(); }catch(_){ }
+        added = orig.add(ready);
+        try{ cy.endBatch && cy.endBatch(); }catch(_){ }
+      }
+      if (wait.length){
+        pendingEdges.push.apply(pendingEdges, wait);
+        // یک tick کوتاه برای تلاش مجدد، حتی اگر رویداد add نیاید
+        setTimeout(function(){
+          if (!pendingEdges.length) return;
+          tryAddEdges(pendingEdges.splice(0, pendingEdges.length));
+        }, 0);
+      }
+      return added;
+    }
+
+    // replay pending edges when nodes land
+    function attachReplayOnce(){
+      if (cy.__SAFE_ADD_REPLAY__) return;
+      cy.on('add', 'node', function(){
+        if (!pendingEdges.length) return;
+        tryAddEdges(pendingEdges.splice(0, pendingEdges.length));
+      });
+      cy.__SAFE_ADD_REPLAY__ = true;
+    }
+
+    // Wrapped cy.add
+    cy.add = function(input){
+      const pack = normalize(input);
+      if (pack.passthrough !== undefined) {
+        // fall back for selectors/unknown structures
+        return orig.add(pack.passthrough);
+      }
+      const nodes = dedupe(pack.nodes);
+      const edges = dedupe(pack.edges);
+      const col1  = addNodes(nodes);
+      const col2  = tryAddEdges(edges);
+      attachReplayOnce();
+      return col1.union(col2);
+    };
+
+    // Wrapped cy.json: if elements exist, apply through safe add
+    cy.json = function(obj){
+      if (obj && obj.elements){
+        const pack = normalize(obj);
+        const nodes = dedupe(pack.nodes);
+        const edges = dedupe(pack.edges);
+        cy.elements().remove(); // reset current
+        addNodes(nodes);
+        tryAddEdges(edges);
+        attachReplayOnce();
+        return orig.json({ elements: cy.elements().jsons() });
+      }
+      return orig.json(obj);
+    };
+
+    cy.__SAFE_ADD_INSTALLED__ = true;
+  }
+
+  function tryInstall(){
+    try{
+      if (window.cy) install(window.cy);
+      // also wrap future instances
+      if (window.cytoscape && !window.cytoscape.__SAFE_ADD_WRAP__){
+        const factory = window.cytoscape;
+        window.cytoscape = function(){
+          const inst = factory.apply(this, arguments);
+          try{ install(inst); }catch(_){ }
+          return inst;
+        };
+        window.cytoscape.__SAFE_ADD_WRAP__ = true;
+      }
+    }catch(_){ }
+  }
+
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', tryInstall, { once:true });
+  } else {
+    tryInstall();
+  }
+  document.addEventListener('cy:ready', function(e){ try{ install(e && e.detail && e.detail.cy); }catch(_){ } });
+})();

--- a/docs/assets/water-cld.cy-stub.js
+++ b/docs/assets/water-cld.cy-stub.js
@@ -1,21 +1,38 @@
 (function(){
   if (window.__CY_STUB__) return; window.__CY_STUB__ = true;
+  'use strict';
 
   // ---- utils ----
   const noop  = function(){};
   const toArr = (a)=> Array.prototype.slice.call(a || []);
 
-  // Queue operations called before real cy exists
+  // صف عملیات قبل از آماده‌شدن cy واقعی
   const queue = [];
-  function enqueue(kind, method, args, selector){
-    queue.push({ kind, method, args: toArr(args), selector: selector == null ? null : selector });
+  function enqueue(kind, method, args, selectorRef){
+    queue.push({ kind, method, args: toArr(args), selectorRef: selectorRef || null });
   }
 
-  function resolveCollection(real, selector){
-    if (!selector) return real.elements();
-    if (selector.__type === 'id')    return real.getElementById(String(selector.value));
-    if (selector.__type === 'query') return real.$(String(selector.value));
-    return real.elements(selector);
+  // ساخت یک reference برای انتخاب، با قابلیت نگه‌داری زنجیرهٔ فیلترها
+  function makeSelectorRef(base){
+    // base: { type:'elements'|'id'|'query', value:any }
+    return { type: base.type, value: base.value, ops: [] }; // ops: [{method:'filter', args:[...]}]
+  }
+
+  function resolveBase(real, ref){
+    if (!ref) return real.elements();
+    if (ref.type === 'id')    return real.getElementById(String(ref.value));
+    if (ref.type === 'query') return real.$(String(ref.value));
+    return real.elements(ref.value);
+  }
+
+  function applyOps(coll, ops){
+    let cur = coll;
+    for (const op of (ops || [])){
+      if (typeof cur?.[op.method] === 'function'){
+        cur = cur[op.method].apply(cur, toArr(op.args));
+      }
+    }
+    return cur;
   }
 
   function flush(real){
@@ -26,51 +43,67 @@
           const fn = real[op.method];
           if (typeof fn === 'function') fn.apply(real, op.args);
         } else if (op.kind === 'collection'){
-          const coll = resolveCollection(real, op.selector);
-          if (!coll) continue;
-          const fn = coll[op.method];
+          const base = resolveBase(real, op.selectorRef);
+          const coll = applyOps(base, op.selectorRef?.ops);
+          const fn = coll && coll[op.method];
           if (typeof fn === 'function') fn.apply(coll, op.args);
         }
       }
-    }catch(_){} // swallow
+    }catch(_){ }
     queue.length = 0;
   }
 
-  // ---- collection proxy so cy.elements(...).remove().data() doesn't throw ----
-  function makeCollectionProxy(selector){
+  // ---- کالکشن پروکسی: متدهای زنجیره‌ای و عملیاتی ----
+  function makeCollectionProxy(selectorRef){
     const api = {};
-    const chain = [
+    // متدهای زنجیره‌ای که مجموعه را تغییر می‌دهند و باید در ops ذخیره شوند
+    const chainOps = ['filter']; // درصورت نیاز می‌شود 'union','difference','merge' را هم افزود
+    chainOps.forEach(m=>{
+      api[m] = function(){
+        selectorRef.ops.push({ method: m, args: arguments });
+        return api;
+      };
+    });
+
+    // متدهای عملیاتی که باید در صف اعمال روی کالکشن ثبت شوند
+    const actionOps = [
       'add','remove',
       'addClass','removeClass','toggleClass',
-      'style','data','animate','layout','merge','difference','union'
+      'style','data','animate','layout','move' // ← move اضافه شد
     ];
-    chain.forEach(m=>{
-      api[m] = function(){ enqueue('collection', m, arguments, selector); return api; };
+    actionOps.forEach(m=>{
+      api[m] = function(){ enqueue('collection', m, arguments, selectorRef); return api; };
     });
-    // readonly helpers
+
+    // کمکی‌های فقط‌خواندنی
     api.forEach = noop;
     api.map     = function(){ return []; };
-    api.filter  = function(){ return makeCollectionProxy(selector); };
-    Object.defineProperty(api, 'length', { get: ()=>0 });
+    api.filter  = api.filter; // از بالا
+    Object.defineProperty(api,'length',{ get: ()=>0 });
+    api[0] = api; // allow nodes(...)[0].addClass(...) without throwing
+    try{
+      Object.defineProperty(api,1,{ get: ()=>api });
+      Object.defineProperty(api,2,{ get: ()=>api });
+    }catch(_){ }
     return api;
   }
 
-  // ---- stub cy object ----
+  // ---- شیء استاب cy ----
   let realCy = null;
   const cyStub = {
     // selectors
-    elements(sel){ return makeCollectionProxy(sel); },
-    nodes(sel){ return makeCollectionProxy(sel); },
-    edges(sel){ return makeCollectionProxy(sel); },
-    getElementById(id){ return makeCollectionProxy({ __type:'id', value:String(id) }); },
-    $: function(query){ return makeCollectionProxy({ __type:'query', value:String(query) }); },
+    elements(sel){ return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
+    nodes(sel){    return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
+    edges(sel){    return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
+    getElementById(id){ return makeCollectionProxy(makeSelectorRef({ type:'id', value: String(id) })); },
+    $ (query){        return makeCollectionProxy(makeSelectorRef({ type:'query', value: String(query) })); },
 
     // events & batching
     on: noop, off: noop,
     startBatch: noop, endBatch: noop,
     batch(fn){ try{ typeof fn === 'function' && fn.call(this); } catch(_){ } },
 
-    // cy-level mutations (queued)
+    // cy-level ops (queued)
     fit(){       enqueue('cy','fit',       arguments); },
     add(){       enqueue('cy','add',       arguments); },
     remove(){    enqueue('cy','remove',    arguments); },
@@ -81,7 +114,7 @@
     layout(){    enqueue('cy','layout',    arguments); }
   };
 
-  // Expose window.cy with getter/setter; flush when real instance is set
+  // Getter/Setter روی window.cy + flush
   try{
     Object.defineProperty(window, 'cy', {
       configurable: true,
@@ -92,16 +125,14 @@
     window.cy = window.cy || cyStub;
   }
 
-  // Capture via event too
+  // گرفتن instance از رویداد
   document.addEventListener('cy:ready', function(e){
     const inst = e && e.detail && e.detail.cy;
     if (inst){ try{ realCy = inst; flush(realCy); }catch(_){ } }
   });
 
-  // Late flush fallback (in case ready event fired before setter)
+  // Late flush fallback
   setTimeout(function(){
-    try{
-      if (window.cy && window.cy !== cyStub) flush(window.cy);
-    }catch(_){}
+    try{ if (window.cy && window.cy !== cyStub) flush(window.cy); }catch(_){ }
   }, 200);
 })();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -220,8 +220,12 @@
       </div>
     </section>
   </div>
-    <script defer src="../assets/water-cld.cy-stub.js"></script>
-    <script defer src="/assets/vendor/cytoscape.min.js"></script>
+  <!-- Cytoscape guards -->
+  <script defer src="../assets/water-cld.cy-stub.js"></script>
+  <script defer src="../assets/water-cld.cy-alias.js"></script>
+
+  <!-- Vendor libs -->
+  <script defer src="/assets/vendor/cytoscape.min.js"></script>
   <script defer src="/assets/vendor/elk.bundled.js"></script>
   <script defer src="/assets/vendor/cytoscape-elk.js"></script>
   <script defer src="/assets/vendor/dagre.min.js"></script>
@@ -232,10 +236,14 @@
   <script defer src="/assets/loop-detect.js"></script>
   <script defer src="/assets/layout-presets.js"></script>
   <script defer src="/assets/vendor/popper.min.js"></script>
-    <script defer src="/assets/vendor/tippy.umd.min.js"></script>
-    <script defer src="../assets/water-cld.cy-batch-guard.js"></script>
+  <script defer src="/assets/vendor/tippy.umd.min.js"></script>
 
-    <script defer src="../assets/water-cld.js"></script>
+  <!-- Runtime guards -->
+  <script defer src="../assets/water-cld.cy-batch-guard.js"></script>
+  <script defer src="../assets/water-cld.cy-safe-add.js"></script>
+  <script defer src="../assets/water-cld.cy-collection-guard.js"></script>
+
+  <script defer src="../assets/water-cld.js"></script>
   <script defer src="../assets/water-cld.runtime-guards.js"></script>
   <script defer src="../assets/model-bridge.js"></script>
   <script defer src="../assets/water-cld.extras-hero.js"></script>
@@ -258,6 +266,6 @@
   <script defer src="../assets/water-cld.spotlight.js"></script>
   <script defer src="../assets/water-cld.explain-10s.js"></script>
     <!-- Guards / Fixes (additive, idempotent) -->
-    <script defer src="../assets/chart.guard.js"></script>
+  <script defer src="../assets/chart.guard.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add window.c alias with ready tick to trigger queued cy actions
- batch node and edge insertion in safe-add guard and retry pending edges on a microtask
- guard Cytoscape collections against empty selections and deferred ops
- enforce strict mode on guard scripts and tidy CLD test page script block

## Testing
- `npm test`
- `npm run flag:test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68a837db7028832885a6d42ca88e7ed2