### PR TITLE
feat(cld): introduce single-owner graph-store

### DIFF
--- a/docs/assets/graph-store.js
+++ b/docs/assets/graph-store.js
@@ -1,0 +1,125 @@
+(function(){
+  if (window.__GRAPH_STORE__) return; window.__GRAPH_STORE__ = true;
+  'use strict';
+
+  // Tiny emitter (no deps)
+  function Evt(){ this._ = Object.create(null); }
+  Evt.prototype.on  = function(k,fn){ (this._[k]||(this._[k]=[])).push(fn); return fn; };
+  Evt.prototype.off = function(k,fn){ var a=this._[k]; if(!a) return; var i=a.indexOf(fn); if(i>-1) a.splice(i,1); };
+  Evt.prototype.emit= function(k,p){ var a=this._[k]||[]; for(var i=0;i<a.length;i++){ try{ a[i](p); }catch(_){}} };
+
+  var ev  = new Evt();
+  var cy  = null;
+  var st  = 'BOOT';        // BOOT → CY_READY → GRAPH_READY
+  var q   = [];            // deferred actions until CY_READY
+  var rdy = [];            // resolve fns for ready()
+
+  function setStatus(s){ st=s; ev.emit('status', s); }
+
+  function hasBatch(){ return cy && typeof cy.startBatch === 'function' && typeof cy.endBatch === 'function'; }
+
+  function safeRun(fn, opt){
+    if (cy){
+      if (opt && opt.batch && hasBatch()){ try{ cy.startBatch(); }catch(_){ } }
+      var out; try{ out = fn(cy); }catch(_){ }
+      if (opt && opt.batch && hasBatch()){ try{ cy.endBatch(); }catch(_){ } }
+      return out;
+    }
+    q.push({ fn: fn, opt: opt||{} });
+  }
+
+  function flush(){
+    if (!cy) return;
+    // drain queued tasks
+    for (var i=0;i<q.length;i++){
+      var t=q[i];
+      try { safeRun(t.fn,t.opt); } catch(_){ }
+    }
+    q.length=0;
+    while(rdy.length){ try{ rdy.shift()(cy); }catch(_){ } }
+  }
+
+  // install hooks for present/future cytoscape instances
+  function watchFactory(){
+    if (!window.cytoscape || window.cytoscape.__GRAPH_STORE_WRAPPED__) return;
+    var factory = window.cytoscape;
+    window.cytoscape = function(){
+      var inst = factory.apply(this, arguments);
+      try{ adopt(inst); }catch(_){ }
+      return inst;
+    };
+    window.cytoscape.__GRAPH_STORE_WRAPPED__ = true;
+  }
+
+  function adopt(inst){
+    if (!inst || inst === cy) return;
+    cy = inst;
+    setStatus('CY_READY');
+    ev.emit('cy', cy);
+    // mirror on window (works with cy-alias guard too)
+    try{ Object.defineProperty(window,'cy',{ configurable:true, get:function(){return cy;}}); }catch(_){ window.cy = cy; }
+    flush();
+  }
+
+  // PUBLIC API
+  var api = {
+    init: function(opts){
+      // if a cy instance already exists and container changed, destroy it
+      if (cy && opts && opts.container){
+        try{ cy.destroy(); }catch(_){ }
+        cy = null;
+      }
+      // create if factory exists & no cy
+      if (!cy && typeof window.cytoscape === 'function' && opts && opts.container){
+        try{ adopt(window.cytoscape(opts)); }catch(_){ }
+      }
+      return this;
+    },
+    destroy: function(){
+      if (!cy) return this;
+      try{ cy.destroy(); }catch(_){ }
+      cy=null;
+      setStatus('BOOT');
+      return this;
+    },
+    restore: function(json){
+      if (!json) return this;
+      // prefer safe-add/json if guards exist
+      return safeRun(function(cy){
+        if (typeof cy.json === 'function' && json && json.elements){
+          try{
+            if (hasBatch()) cy.startBatch();
+            cy.elements().remove();
+            // if safe-add altered json, rely on it; otherwise naive restore
+            cy.json({ elements: json.elements });
+          }finally{
+            if (hasBatch()) try{ cy.endBatch(); }catch(_){ }
+          }
+        } else if (Array.isArray(json)){
+          if (hasBatch()) cy.startBatch();
+          try{ cy.add(json); } finally { if (hasBatch()) try{ cy.endBatch(); }catch(_){ } }
+        }
+      }, { batch:false }), this;
+    },
+    run: function(fn, opt){ return safeRun(fn, opt); },
+    get: function(){ return cy; },
+    on: function(k,fn){ return ev.on(k,fn); },
+    off: function(k,fn){ return ev.off(k,fn); },
+    status: function(){ return st; },
+    ready: function(){
+      return new Promise(function(res){
+        if (cy) res(cy); else rdy.push(res);
+      });
+    }
+  };
+
+  // expose
+  window.graphStore = window.graphStore || api;
+
+  // wiring for current/future instances
+  if (window.cy) adopt(window.cy);
+  document.addEventListener('cy:ready', function(e){ try{ adopt(e && e.detail && e.detail.cy); }catch(_){ } });
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', watchFactory, { once:true });
+  } else { watchFactory(); }
+})();

--- a/docs/assets/water-cld.a11y.js
+++ b/docs/assets/water-cld.a11y.js
@@ -1,4 +1,5 @@
 // ===== A11Y & Mobile bootstrap (singleton, CSP-safe, no interference) =====
+/* global graphStore */
 (function(){
   if (window.__A11Y_BOUND__) return; window.__A11Y_BOUND__ = true;
 
@@ -70,24 +71,32 @@
 
   // 5) آرایش دسترس‌پذیر Cytoscape (بی‌تداخل)
   function a11yForCytoscape(){
-    // ظرف‌های رایج
-    const cyEl = $('#cy') || $('.cytoscape-container') || $('.cy-container') || $('#cld-canvas') || (window.cy && window.cy.container && window.cy.container());
-    const container = (cyEl && cyEl.nodeType ? cyEl : null) || (window.cy && window.cy.container && window.cy.container());
-    if (!container || container.__a11y_done) return;
+    var run = function(cy){
+      // ظرف‌های رایج
+      const cyEl = $('#cy') || $('.cytoscape-container') || $('.cy-container') || $('#cld-canvas') || (cy && cy.container && cy.container());
+      const container = (cyEl && cyEl.nodeType ? cyEl : null) || (cy && cy.container && cy.container());
+      if (!container || container.__a11y_done) return;
 
-    container.__a11y_done = true;
-    container.classList.add('cy-a11y-focus');
-    setOnce(container, 'tabindex', '0');                 // فوکوس‌پذیر
-    setOnce(container, 'role', 'application');           // محتوای تعاملی پیچیده
-    const descId = 'cy-a11y-desc';
-    if (!$('#'+descId)){
-      const sr = document.createElement('div');
-      sr.id = descId; sr.className = 'sr-only';
-      sr.textContent = 'بوم تعامل‌پذیر نمودار علّی. برای جابه‌جایی از ماوس/لمس استفاده کنید؛ برای بزرگ‌نمایی از Ctrl+اسکرول. برای خروج از بوم، کلید Tab را فشار دهید.';
-      document.body.appendChild(sr);
+      container.__a11y_done = true;
+      container.classList.add('cy-a11y-focus');
+      setOnce(container, 'tabindex', '0');                 // فوکوس‌پذیر
+      setOnce(container, 'role', 'application');           // محتوای تعاملی پیچیده
+      const descId = 'cy-a11y-desc';
+      if (!$('#'+descId)){
+        const sr = document.createElement('div');
+        sr.id = descId; sr.className = 'sr-only';
+        sr.textContent = 'بوم تعامل‌پذیر نمودار علّی. برای جابه‌جایی از ماوس/لمس استفاده کنید؛ برای بزرگ‌نمایی از Ctrl+اسکرول. برای خروج از بوم، کلید Tab را فشار دهید.';
+        document.body.appendChild(sr);
+      }
+      setOnce(container, 'aria-describedby', descId);
+      setOnce(container, 'aria-label', 'نمودار علّی-حلقه‌ای (CLD)');
+    };
+
+    if (window.graphStore && typeof window.graphStore.run === 'function') {
+      graphStore.run(run);
+    } else if (window.cy && typeof window.cy.container === 'function') {
+      try{ run(window.cy); }catch(_){ }
     }
-    setOnce(container, 'aria-describedby', descId);
-    setOnce(container, 'aria-label', 'نمودار علّی-حلقه‌ای (CLD)');
   }
 
   // 6) کم‌کردن نویز TabOrder: حذف از Tab برای عناصر تزئینی/پنهان

--- a/docs/assets/water-cld.extras-readability.js
+++ b/docs/assets/water-cld.extras-readability.js
@@ -1,4 +1,5 @@
 // ===== CLD Readability (singleton, CSP-safe, no interference) =====
+/* global graphStore */
 (function(){
   // --- گارد عدم‌تداخل
   if (window.__READABILITY_BOUND__ || window.__CLD_READABILITY_BOUND__) return;
@@ -17,7 +18,7 @@
   const debounce = window.__cldDebounce || ((fn,ms=70)=>{ let t=0; return (...a)=>{ clearTimeout(t); t=setTimeout(()=>fn(...a),ms); }; });
 
   // --- شروع پس از آماده‌شدن Cytoscape
-  onCyReady((cy)=>{
+  function run(cy){
 
     // 1) یک‌بار استایل‌های پایه (بدون تغییر پالت موجود)
     if (!cy.scratch('_readability_style_applied')){
@@ -152,6 +153,11 @@
       // Legend شناور قبلی را پنهان کن تا دوبل نشود
       if (floatLegend) floatLegend.style.display = 'none';
     })();
+  }
 
-  }); // end onCyReady
+  if (window.graphStore && typeof window.graphStore.run === 'function') {
+    graphStore.run(run);
+  } else {
+    onCyReady(run);
+  }
 })();

--- a/docs/assets/water-cld.paths.js
+++ b/docs/assets/water-cld.paths.js
@@ -1,4 +1,5 @@
 // ===== Causal Path Search & Loops Chips (singleton, CSP-safe, no interference) =====
+/* global graphStore */
 (function(){
   if (window.__CLD_PATHS_BOUND__) return; window.__CLD_PATHS_BOUND__ = true;
 
@@ -55,7 +56,7 @@
   }
 
   // -------- Cytoscape logic --------
-  onCyReady((cy)=>{
+  function run(cy){
     buildUI();
 
     // Label helper
@@ -272,6 +273,11 @@
 
     renderLoops();
     cy.one('layoutstop', renderLoops); // بعد از چیدمان، یک‌بار باز-ارزیابی
+  }
 
-  }); // onCyReady
+  if (window.graphStore && typeof window.graphStore.run === 'function') {
+    graphStore.run(run);
+  } else {
+    onCyReady(run);
+  }
 })();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -260,6 +260,9 @@
   <script defer src="../assets/water-cld.cy-safe-add.js"></script>
   <script defer src="../assets/water-cld.cy-collection-guard.js"></script>
 
+  <!-- Graph owner (singleton) -->
+  <script defer src="../assets/graph-store.js"></script>
+
   <!-- Core app + extras -->
   <script defer src="../assets/water-cld.js"></script>
   <script defer src="../assets/water-cld.runtime-guards.js"></script>


### PR DESCRIPTION
## Summary
- add CSP-safe `graphStore` singleton to manage Cytoscape creation, restore, batching and event hooks
- wire graphStore into CLD test page and route path, readability and a11y modules through `graphStore.run`

## Testing
- `npm test`
- `npm run flag:test` *(fails: libatk-1.0.so.0: cannot open shared object file: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a8443d642c83288301c2b12c8fb50a