### PR TITLE
feat(cld): introduce boot kernel and adapter for phased init

### DIFF
--- a/docs/assets/water-cld.kernel-adapter.js
+++ b/docs/assets/water-cld.kernel-adapter.js
@@ -1,0 +1,67 @@
+(function(){
+  if (window.__WATER_KERNEL_ADAPTER__) return; window.__WATER_KERNEL_ADAPTER__ = true;
+  'use strict';
+
+  var K = window.waterKernel;
+
+  if (!K){ // fail-safe
+    console && console.warn && console.warn('[kernel-adapter] kernel missing');
+    return;
+  }
+
+  // 1) MODEL_LOADED: از رویدادهای موجود پروژه استفاده کن (model-bridge)
+  // هم‌اکنون پروژه شما از `model:updated` استفاده می‌کند.
+  var modelSeen = false;
+  function handleModelUpdated(e){
+    if (modelSeen) return;
+    modelSeen = true;
+    try{ K.emit('MODEL_LOADED', e && e.detail || {}); }catch(_){ }
+  }
+  document.addEventListener('model:updated', handleModelUpdated, { once:true });
+
+  // برای سازگاری اگر پروژه «model:loaded» داشته باشد:
+  document.addEventListener('model:loaded', handleModelUpdated, { once:true });
+
+  // 2) GRAPH_READY: پس از CY_READY، وقتی اولین المان‌ها وجود داشتند
+  K.onReady('cy', function(){
+    try{
+      var cy = window.cy; // alias/guards already in place
+      if (!cy) return;
+
+      function fireWhenReady(){
+        try{
+          if (cy && cy.elements && cy.elements().length > 0){
+            K.emit('GRAPH_READY', { count: cy.elements().length });
+            return true;
+          }
+        }catch(_){ }
+        return false;
+      }
+
+      if (fireWhenReady()) return;
+
+      // یک‌بار پس از add یا layoutstop
+      var done = false;
+      function tryEmit(){ if (!done && fireWhenReady()) { done=true; cleanup(); } }
+      function cleanup(){
+        try{ cy.off('add', tryEmit); }catch(_){ }
+        try{ cy.off('layoutstop', tryEmit); }catch(_){ }
+      }
+      try{ cy.on('add', tryEmit); }catch(_){ }
+      try{ cy.on('layoutstop', tryEmit); }catch(_){ }
+
+      // fallback: چند تیک کوتاه
+      var ticks = 8;
+      (function tick(){
+        if (done) return;
+        if (tryEmit()) return;
+        if (--ticks <= 0) return;
+        setTimeout(tick, 50);
+      })();
+    }catch(_){ }
+  });
+
+  // 3) API کمکی برای ماژول‌ها: اجرای امن بر اساس فاز
+  // مثال استفاده: waterKernel.queue('graph', () => cy.$('#x').addClass('on'));
+  // (در کنار graphStore.run نیز قابل استفاده است)
+})();

--- a/docs/assets/water-cld.kernel.js
+++ b/docs/assets/water-cld.kernel.js
@@ -1,0 +1,96 @@
+(function(){
+  if (window.__WATER_KERNEL__) return; window.__WATER_KERNEL__ = true;
+  'use strict';
+
+  // ---- tiny emitter (no deps)
+  function E(){ this._=Object.create(null); }
+  E.prototype.on=function(k,fn){ (this._[k]||(this._[k]=[])).push(fn); return fn; };
+  E.prototype.off=function(k,fn){ var a=this._[k]; if(!a) return; var i=a.indexOf(fn); if(i>-1) a.splice(i,1); };
+  E.prototype.emit=function(k,p){ var a=this._[k]||[]; for(var i=0;i<a.length;i++){ try{ a[i](p); }catch(_){ } } };
+
+  // ---- phases & states
+  // BOOT → VENDORS_READY → CY_READY → MODEL_LOADED → GRAPH_READY
+  var PH = ['BOOT','VENDORS_READY','CY_READY','MODEL_LOADED','GRAPH_READY'];
+  var IDX = {}; PH.forEach(function(s,i){ IDX[s]=i; });
+  var MAP = { vendors:'VENDORS_READY', cy:'CY_READY', model:'MODEL_LOADED', graph:'GRAPH_READY' };
+
+  var ev  = new E();
+  var st  = 'BOOT';
+  var q   = { vendors:[], cy:[], model:[], graph:[] }; // deferred actions per phase
+  var once = Object.create(null);
+  var debugOn = false;
+
+  function log(){ if(debugOn && console && console.log) try{ console.log.apply(console, arguments); }catch(_){ } }
+  function state(){ return st; }
+  function canAdvance(to){ return IDX[to] > IDX[st]; }
+  function reached(phase){ return IDX[MAP[phase]||phase] <= IDX[st]; }
+
+  function _drain(phase){
+    var arr = q[phase]||[];
+    if (!arr.length) return;
+    var copy = arr.splice(0, arr.length);
+    for (var i=0;i<copy.length;i++){
+      try{ copy[i](); }catch(_){ }
+    }
+  }
+
+  function emit(next, payload){
+    if (!MAP[next] && !IDX[next]) return; // ignore unknown
+    var target = MAP[next] || next;
+    if (!canAdvance(target)) { // allow duplicate emits silently
+      ev.emit(target, payload);
+      return;
+    }
+    st = target;
+    log('[kernel] →', st, payload||'');
+    ev.emit(st, payload);
+    // auto drain queues for all phases <= current state
+    if (st==='VENDORS_READY'){ _drain('vendors'); }
+    if (IDX[st] >= IDX['CY_READY'])     { _drain('cy'); }
+    if (IDX[st] >= IDX['MODEL_LOADED']) { _drain('model'); }
+    if (IDX[st] >= IDX['GRAPH_READY'])  { _drain('graph'); }
+  }
+
+  function onReady(phase, fn){
+    var stName = MAP[phase]||phase;
+    if (reached(phase)) { try{ fn(); }catch(_){ } return fn; }
+    return ev.on(stName, fn);
+  }
+  function onceReady(phase, fn){
+    var key = phase + '::' + (fn && fn.name || Math.random());
+    if (once[key]) return once[key];
+    var off = onReady(phase, function(){
+      try{ fn(); }finally{ ev.off(MAP[phase]||phase, off); }
+    });
+    once[key] = off;
+    return off;
+  }
+  function queue(phase, fn){
+    (q[phase]||(q[phase]=[])).push(fn);
+  }
+  function debug(v){ debugOn = !!v; return api; }
+
+  // ---- bootstrap wiring
+  function onDomReady(){
+    emit('VENDORS_READY');
+  }
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', onDomReady, { once:true });
+  } else { onDomReady(); }
+
+  // bridge existing cy:ready
+  document.addEventListener('cy:ready', function(e){
+    emit('CY_READY', e && e.detail && e.detail.cy);
+  });
+
+  // public api
+  var api = {
+    state: state,
+    emit: emit,            // used by adapters only
+    onReady: onReady,
+    onceReady: onceReady,
+    queue: queue,
+    debug: debug
+  };
+  window.waterKernel = window.waterKernel || api;
+})();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -260,6 +260,10 @@
   <script defer src="../assets/water-cld.cy-safe-add.js"></script>
   <script defer src="../assets/water-cld.cy-collection-guard.js"></script>
 
+  <!-- ✳️ Kernel + Adapter (new) -->
+  <script defer src="../assets/water-cld.kernel.js"></script>
+  <script defer src="../assets/water-cld.kernel-adapter.js"></script>
+
   <!-- Graph owner (singleton) -->
   <script defer src="../assets/graph-store.js"></script>
 


### PR DESCRIPTION
## Summary
- add CSP-safe kernel with BOOT→VENDORS_READY→CY_READY→MODEL_LOADED→GRAPH_READY phases and onReady/queue API
- bridge existing `model:updated` and graph readiness events into kernel via adapter
- load kernel and adapter in test HTML before core app

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8470e741c8328a0952dfa7c77f411