### PR TITLE
feat(cld): stabilize boot with kernel, adapter, and graph store

### DIFF
--- a/docs/assets/graph-store.js
+++ b/docs/assets/graph-store.js
@@ -1,125 +1,37 @@
 (function(){
-  if (window.__GRAPH_STORE__) return; window.__GRAPH_STORE__ = true;
-  'use strict';
-
-  // Tiny emitter (no deps)
-  function Evt(){ this._ = Object.create(null); }
-  Evt.prototype.on  = function(k,fn){ (this._[k]||(this._[k]=[])).push(fn); return fn; };
-  Evt.prototype.off = function(k,fn){ var a=this._[k]; if(!a) return; var i=a.indexOf(fn); if(i>-1) a.splice(i,1); };
-  Evt.prototype.emit= function(k,p){ var a=this._[k]||[]; for(var i=0;i<a.length;i++){ try{ a[i](p); }catch(_){}} };
-
-  var ev  = new Evt();
-  var cy  = null;
-  var st  = 'BOOT';        // BOOT → CY_READY → GRAPH_READY
-  var q   = [];            // deferred actions until CY_READY
-  var rdy = [];            // resolve fns for ready()
-
-  function setStatus(s){ st=s; ev.emit('status', s); }
-
-  function hasBatch(){ return cy && typeof cy.startBatch === 'function' && typeof cy.endBatch === 'function'; }
-
-  function safeRun(fn, opt){
-    if (cy){
-      if (opt && opt.batch && hasBatch()){ try{ cy.startBatch(); }catch(_){ } }
-      var out; try{ out = fn(cy); }catch(_){ }
-      if (opt && opt.batch && hasBatch()){ try{ cy.endBatch(); }catch(_){ } }
-      return out;
-    }
-    q.push({ fn: fn, opt: opt||{} });
-  }
-
-  function flush(){
-    if (!cy) return;
-    // drain queued tasks
-    for (var i=0;i<q.length;i++){
-      var t=q[i];
-      try { safeRun(t.fn,t.opt); } catch(_){ }
-    }
-    q.length=0;
-    while(rdy.length){ try{ rdy.shift()(cy); }catch(_){ } }
-  }
-
-  // install hooks for present/future cytoscape instances
-  function watchFactory(){
-    if (!window.cytoscape || window.cytoscape.__GRAPH_STORE_WRAPPED__) return;
-    var factory = window.cytoscape;
-    window.cytoscape = function(){
-      var inst = factory.apply(this, arguments);
-      try{ adopt(inst); }catch(_){ }
-      return inst;
-    };
-    window.cytoscape.__GRAPH_STORE_WRAPPED__ = true;
-  }
-
-  function adopt(inst){
-    if (!inst || inst === cy) return;
-    cy = inst;
-    setStatus('CY_READY');
-    ev.emit('cy', cy);
-    // mirror on window (works with cy-alias guard too)
-    try{ Object.defineProperty(window,'cy',{ configurable:true, get:function(){return cy;}}); }catch(_){ window.cy = cy; }
+  if (window.__GRAPH_STORE__) return; window.__GRAPH_STORE__ = true; 'use strict';
+  var cy=null, q=[], rdy=[];
+  function hasBatch(){ return cy && typeof cy.startBatch==='function' && typeof cy.endBatch==='function'; }
+  function safeRun(fn, opt){ if(cy){ if(opt&&opt.batch&&hasBatch()) try{ cy.startBatch(); }catch(_){ }
+      var out; try{ out=fn(cy);}catch(_){ }
+      if(opt&&opt.batch&&hasBatch()) try{ cy.endBatch(); }catch(_){ }
+      return out; } q.push({fn:fn,opt:opt||{}}); }
+  function flush(){ if(!cy) return; for(var i=0;i<q.length;i++){ var t=q[i]; try{ safeRun(t.fn,t.opt);}catch(_){}} q.length=0; while(rdy.length){ try{ rdy.shift()(cy);}catch(_){}}
+  function adopt(inst){ if(!inst || inst===cy) return; cy=inst;
+    try{ document.dispatchEvent(new CustomEvent('cy:ready',{detail:{cy:inst}})); }catch(_){ }
+    if (window.waterKernel && typeof window.waterKernel.emit==='function'){ try{ window.waterKernel.emit('CY_READY', inst); }catch(_){ } }
     flush();
   }
-
-  // PUBLIC API
-  var api = {
-    init: function(opts){
-      // if a cy instance already exists and container changed, destroy it
-      if (cy && opts && opts.container){
-        try{ cy.destroy(); }catch(_){ }
-        cy = null;
-      }
-      // create if factory exists & no cy
-      if (!cy && typeof window.cytoscape === 'function' && opts && opts.container){
-        try{ adopt(window.cytoscape(opts)); }catch(_){ }
-      }
-      return this;
-    },
-    destroy: function(){
-      if (!cy) return this;
-      try{ cy.destroy(); }catch(_){ }
-      cy=null;
-      setStatus('BOOT');
-      return this;
-    },
-    restore: function(json){
-      if (!json) return this;
-      // prefer safe-add/json if guards exist
-      return safeRun(function(cy){
-        if (typeof cy.json === 'function' && json && json.elements){
-          try{
-            if (hasBatch()) cy.startBatch();
-            cy.elements().remove();
-            // if safe-add altered json, rely on it; otherwise naive restore
-            cy.json({ elements: json.elements });
-          }finally{
-            if (hasBatch()) try{ cy.endBatch(); }catch(_){ }
-          }
-        } else if (Array.isArray(json)){
-          if (hasBatch()) cy.startBatch();
-          try{ cy.add(json); } finally { if (hasBatch()) try{ cy.endBatch(); }catch(_){ } }
-        }
-      }, { batch:false }), this;
-    },
-    run: function(fn, opt){ return safeRun(fn, opt); },
-    get: function(){ return cy; },
-    on: function(k,fn){ return ev.on(k,fn); },
-    off: function(k,fn){ return ev.off(k,fn); },
-    status: function(){ return st; },
-    ready: function(){
-      return new Promise(function(res){
-        if (cy) res(cy); else rdy.push(res);
-      });
-    }
+  function watchFactory(){ if(!window.cytoscape || window.cytoscape.__GRAPH_STORE_WRAPPED__) return;
+    var factory=window.cytoscape; window.cytoscape=function(){ var inst=factory.apply(this,arguments); try{ adopt(inst);}catch(_){ } return inst; }; window.cytoscape.__GRAPH_STORE_WRAPPED__=true; }
+  var api={ init:function(opts){ if(cy && opts && opts.container){ try{ cy.destroy(); }catch(_){ } cy=null; }
+      if(!cy && typeof window.cytoscape==='function' && opts && opts.container){ try{ adopt(window.cytoscape(opts)); }catch(_){ } }
+      return this; },
+    destroy:function(){ if(!cy) return this; try{ cy.destroy(); }catch(_){ } cy=null; return this; },
+    restore:function(json){ if(!json) return this; return safeRun(function(c){
+        if(c.json && json.elements){ try{ if(hasBatch()) c.startBatch(); c.elements().remove(); c.json({elements:json.elements}); }
+            finally{ if(hasBatch()) try{ c.endBatch(); }catch(_){ } } }
+        else if(Array.isArray(json)){ if(hasBatch()) c.startBatch(); try{ c.add(json);} finally{ if(hasBatch()) try{ c.endBatch(); }catch(_){ } } }
+        try{ if (window.waterKernel && typeof window.waterKernel.emit==='function'){
+          if(c.elements && c.elements().length>0){ window.waterKernel.emit('GRAPH_READY', {count:c.elements().length}); }
+        } }catch(_){ }
+      }, {batch:false}), this; },
+    run:function(fn,opt){ return safeRun(fn,opt); },
+    get:function(){ return cy; },
+    ready:function(){ return new Promise(function(res){ if(cy) res(cy); else rdy.push(res); }); }
   };
-
-  // expose
   window.graphStore = window.graphStore || api;
-
-  // wiring for current/future instances
   if (window.cy) adopt(window.cy);
-  document.addEventListener('cy:ready', function(e){ try{ adopt(e && e.detail && e.detail.cy); }catch(_){ } });
-  if (document.readyState === 'loading'){
-    document.addEventListener('DOMContentLoaded', watchFactory, { once:true });
-  } else { watchFactory(); }
+  document.addEventListener('cy:ready', function(e){ try{ adopt(e && e.detail && e.detail.cy);}catch(_){ } });
+  if (document.readyState==='loading') document.addEventListener('DOMContentLoaded', watchFactory, {once:true}); else watchFactory();
 })();

--- a/docs/assets/water-cld.cy-alias.js
+++ b/docs/assets/water-cld.cy-alias.js
@@ -1,25 +1,6 @@
 (function(){
   if (window.__CY_ALIAS__) return; window.__CY_ALIAS__ = true;
-
-  function define(){
-    try{
-      Object.defineProperty(window, 'c', {
-        configurable: true,
-        get: function(){ return window.cy; },
-        set: function(v){ try { window.cy = v; } catch(_) {} }
-      });
-    }catch(_){ window.c = window.cy; }
-  }
-
-  define();
-  document.addEventListener('cy:ready', define);
-
-  // microtask/tick: اگر cy آماده است، رویداد را یک‌بار دیگر پخش کن
-  setTimeout(function(){
-    try{
-      if (window.cy && typeof window.cy.add === 'function') {
-        document.dispatchEvent(new CustomEvent('cy:ready', { detail:{ cy: window.cy } }));
-      }
-    }catch(_){}
-  }, 0);
+  function define(){ try{ Object.defineProperty(window,'c',{configurable:true,get:function(){return window.cy;},set:function(v){ try{ window.cy=v; }catch(_){ } }});}catch(_){ window.c=window.cy; } }
+  define(); document.addEventListener('cy:ready', define);
+  setTimeout(function(){ try{ if(window.cy && typeof window.cy.add==='function'){ document.dispatchEvent(new CustomEvent('cy:ready',{detail:{cy:window.cy}})); } }catch(_){ } }, 0);
 })();

--- a/docs/assets/water-cld.kernel-adapter.js
+++ b/docs/assets/water-cld.kernel-adapter.js
@@ -1,0 +1,21 @@
+(function(){
+  if (window.__WATER_KERNEL_ADAPTER__) return; window.__WATER_KERNEL_ADAPTER__ = true; 'use strict';
+  var K = window.waterKernel; if (!K) return;
+  var seenModel=false;
+  function handleModel(e){ if(seenModel) return; seenModel=true; try{ K.emit('MODEL_LOADED', e && e.detail || {}); }catch(_){} }
+  document.addEventListener('model:updated', handleModel, {once:true});
+  document.addEventListener('model:loaded',  handleModel, {once:true});
+  K.onReady('cy', function(){
+    try{
+      var cy = window.cy; if(!cy) return;
+      function tryGraph(){
+        try{ if (cy.elements && cy.elements().length>0){ K.emit('GRAPH_READY', {count: cy.elements().length}); return true; } }catch(_){ }
+        return false;
+      }
+      if (tryGraph()) return;
+      var done=false, onEvt=function(){ if(!done && tryGraph()){ done=true; cleanup(); } }, cleanup=function(){ try{ cy.off('add', onEvt); cy.off('layoutstop', onEvt); }catch(_){ } };
+      try{ cy.on('add', onEvt); cy.on('layoutstop', onEvt); }catch(_){ }
+      var ticks=8;(function tick(){ if(done) return; if(tryGraph()) return; if(--ticks<=0) return; setTimeout(tick,50);}());
+    }catch(_){ }
+  });
+})();

--- a/docs/assets/water-cld.kernel.js
+++ b/docs/assets/water-cld.kernel.js
@@ -1,0 +1,35 @@
+(function(){
+  if (window.__WATER_KERNEL__) return; window.__WATER_KERNEL__ = true; 'use strict';
+  function E(){ this._=Object.create(null); }
+  E.prototype.on=function(k,fn){ (this._[k]||(this._[k]=[])).push(fn); return fn; };
+  E.prototype.off=function(k,fn){ var a=this._[k]; if(!a) return; var i=a.indexOf(fn); if(i>-1) a.splice(i,1); };
+  E.prototype.emit=function(k,p){ var a=this._[k]||[]; for(var i=0;i<a.length;i++){ try{ a[i](p); }catch(_){ } } };
+
+  var PH = ['BOOT','VENDORS_READY','CY_READY','MODEL_LOADED','GRAPH_READY'];
+  var IDX = {}; PH.forEach(function(s,i){ IDX[s]=i; });
+  var MAP = { vendors:'VENDORS_READY', cy:'CY_READY', model:'MODEL_LOADED', graph:'GRAPH_READY' };
+
+  var ev  = new E(), st='BOOT';
+  var q   = { vendors:[], cy:[], model:[], graph:[] };
+  function canAdvance(to){ return IDX[to] > IDX[st]; }
+  function reached(phase){ return IDX[MAP[phase]||phase] <= IDX[st]; }
+  function _drain(phase){ var arr=q[phase]||[]; if(!arr.length) return; var copy=arr.splice(0,arr.length); for(var i=0;i<copy.length;i++){ try{ copy[i](); }catch(_){ } } }
+  function emit(next, payload){
+    var target = MAP[next] || next; if (!IDX[target]) return;
+    if (!canAdvance(target)){ ev.emit(target, payload); return; }
+    st = target; ev.emit(st, payload);
+    if (st==='VENDORS_READY') _drain('vendors');
+    if (IDX[st] >= IDX['CY_READY'])     _drain('cy');
+    if (IDX[st] >= IDX['MODEL_LOADED']) _drain('model');
+    if (IDX[st] >= IDX['GRAPH_READY'])  _drain('graph');
+  }
+  function onReady(phase, fn){ var s=MAP[phase]||phase; if (reached(phase)){ try{ fn(); }catch(_){ } return fn; } return ev.on(s, fn); }
+  function queue(phase, fn){ (q[phase]||(q[phase]=[])).push(fn); }
+  function state(){ return st; }
+
+  function onDomReady(){ emit('VENDORS_READY'); }
+  if (document.readyState==='loading') document.addEventListener('DOMContentLoaded', onDomReady, {once:true}); else onDomReady();
+  document.addEventListener('cy:ready', function(e){ emit('CY_READY', e && e.detail && e.detail.cy); });
+
+  window.waterKernel = window.waterKernel || { state, emit, onReady, queue };
+})();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -260,7 +260,9 @@
   <script defer src="../assets/water-cld.cy-safe-add.js"></script>
   <script defer src="../assets/water-cld.cy-collection-guard.js"></script>
 
-  <!-- Graph owner (singleton) -->
+  <!-- Kernel + Adapter + Graph owner -->
+  <script defer src="../assets/water-cld.kernel.js"></script>
+  <script defer src="../assets/water-cld.kernel-adapter.js"></script>
   <script defer src="../assets/graph-store.js"></script>
 
   <!-- Core app + extras -->


### PR DESCRIPTION
## Summary
- streamline boot with a lightweight state-machine kernel exposing onReady/queue hooks
- bridge model and graph readiness events into the kernel and adopt Cytoscape instances via a single-owner graph store
- load guards, kernel, adapter, and graph store in deterministic order in the CLD test page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a8470e741c8328a0952dfa7c77f411