### PR TITLE
feat(cld): switch CLD test page to bundles; keep legacy tags commented

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -6,23 +6,24 @@
   <title>مدل پویایی بهره‌وری آب در کشاورزی</title>
   <link rel="icon" type="image/webp" href="/page/landing/logo2.webp"/>
   <link rel="stylesheet" href="../assets/tailwind.css">
-  <link rel="stylesheet" href="../assets/water-cld.css">
-  <link rel="stylesheet" href="../assets/water-cld.tour.css">
-  <link rel="stylesheet" href="../assets/water-cld.presets.css">
-  <link rel="stylesheet" href="../assets/water-cld.aha.css">
-  <link rel="stylesheet" href="../assets/water-cld.controls-meta.css">
-  <link rel="stylesheet" href="../assets/water-cld.readability.css">
-  <link rel="stylesheet" href="../assets/water-cld.scenarios.css">
-  <link rel="stylesheet" href="../assets/water-cld.a11y.css">
-  <link rel="stylesheet" href="../assets/water-cld.provenance.css">
-  <link rel="stylesheet" href="../assets/water-cld.paths.css">
+  <!-- Legacy CLD includes (kept commented for rollback) -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.tour.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.presets.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.aha.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.controls-meta.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.readability.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.scenarios.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.a11y.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.provenance.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.paths.css"> -->
   <link rel="stylesheet" href="../assets/chart.autofix.css">
-  <link rel="stylesheet" href="../assets/water-cld.fix-hints.css">
-  <link rel="stylesheet" href="../assets/water-cld.delta-kpi.css">
-  <link rel="stylesheet" href="../assets/water-cld.param-chips.css">
-  <link rel="stylesheet" href="../assets/water-cld.quick-preset.css">
-  <link rel="stylesheet" href="../assets/water-cld.toast.css">
-  <link rel="stylesheet" href="../assets/water-cld.spotlight.css">
+  <!-- <link rel="stylesheet" href="../assets/water-cld.fix-hints.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.delta-kpi.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.param-chips.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.quick-preset.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.toast.css"> -->
+  <!-- <link rel="stylesheet" href="../assets/water-cld.spotlight.css"> -->
 </head>
 <body class="rtl">
   <!-- ===== HERO KPI BAR (start) ===== -->
@@ -238,10 +239,6 @@
     </section>
   </div>
 
-  <!-- Guards: pre-core -->
-  <script defer src="../assets/water-cld.cy-stub.js"></script>
-  <script defer src="../assets/water-cld.cy-alias.js"></script>
-
   <!-- Vendors -->
   <script defer src="/assets/vendor/cytoscape.min.js"></script>
   <script defer src="/assets/vendor/elk.bundled.js"></script>
@@ -255,41 +252,46 @@
   <script defer src="/assets/vendor/popper.min.js"></script>
   <script defer src="/assets/vendor/tippy.umd.min.js"></script>
 
-  <!-- Guards after vendors -->
-  <script defer src="../assets/water-cld.cy-batch-guard.js"></script>
-  <script defer src="../assets/water-cld.cy-safe-add.js"></script>
-  <script defer src="../assets/water-cld.cy-collection-guard.js"></script>
-
-  <!-- ✳️ Kernel + Adapter (new) -->
-  <script defer src="../assets/water-cld.kernel.js"></script>
-  <script defer src="../assets/water-cld.kernel-adapter.js"></script>
-
+  <link rel="stylesheet" href="/assets/dist/water-cld.bundle.css">
+  <script src="/assets/dist/water-cld.bundle.js" defer></script>
+ 
   <!-- Graph owner (singleton) -->
   <script defer src="../assets/graph-store.js"></script>
-
-  <!-- Core app + extras -->
-  <script defer src="../assets/water-cld.js"></script>
-  <script defer src="../assets/water-cld.runtime-guards.js"></script>
   <script defer src="../assets/model-bridge.js"></script>
-  <script defer src="../assets/water-cld.extras-hero.js"></script>
-  <script defer src="../assets/water-cld.aha.js"></script>
-  <script defer src="../assets/water-cld.tour.js"></script>
-  <script defer src="../assets/water-cld.extras-readability.js"></script>
-  <script defer src="../assets/water-cld.extras-controls.js"></script>
-  <script defer src="../assets/water-cld.presets.js"></script>
-  <script defer src="../assets/water-cld.controls-meta.js"></script>
-  <script defer src="../assets/water-cld.scenarios.js"></script>
-  <script defer src="../assets/water-cld.a11y.js"></script>
-  <script defer src="../assets/water-cld.provenance.js"></script>
-  <script defer src="../assets/water-cld.paths.js"></script>
-  <script defer src="../assets/water-cld.fix-hints.js"></script>
-  <script defer src="../assets/water-cld.delta-kpi.js"></script>
-  <script defer src="../assets/water-cld.param-chips.js"></script>
-  <script defer src="../assets/water-cld.quick-preset.js"></script>
-  <script defer src="../assets/water-cld.aha-metrics.js"></script>
-  <script defer src="../assets/water-cld.ghost-delta.js"></script>
-  <script defer src="../assets/water-cld.spotlight.js"></script>
-  <script defer src="../assets/water-cld.explain-10s.js"></script>
+
+  <!-- Legacy CLD includes (kept commented for rollback) -->
+  <!-- Guards: pre-core -->
+  <!-- <script defer src="../assets/water-cld.cy-stub.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.cy-alias.js"></script> -->
+  <!-- Guards after vendors -->
+  <!-- <script defer src="../assets/water-cld.cy-batch-guard.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.cy-safe-add.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.cy-collection-guard.js"></script> -->
+  <!-- ✳️ Kernel + Adapter (new) -->
+  <!-- <script defer src="../assets/water-cld.kernel.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.kernel-adapter.js"></script> -->
+  <!-- Core app + extras -->
+  <!-- <script defer src="../assets/water-cld.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.runtime-guards.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.extras-hero.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.aha.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.tour.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.extras-readability.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.extras-controls.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.presets.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.controls-meta.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.scenarios.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.a11y.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.provenance.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.paths.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.fix-hints.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.delta-kpi.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.param-chips.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.quick-preset.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.aha-metrics.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.ghost-delta.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.spotlight.js"></script> -->
+  <!-- <script defer src="../assets/water-cld.explain-10s.js"></script> -->
 
   <!-- Fixes (additive, idempotent) -->
   <script defer src="../assets/chart.guard.js"></script>


### PR DESCRIPTION
## Summary
- comment and label legacy CLD CSS/JS tags for rollback
- add single bundled CLD assets after vendor scripts before init

## Testing
- `grep -RIn '/assets/dist/water-cld.bundle.css' docs/test/water-cld.html`
- `grep -RIn '/assets/dist/water-cld.bundle.js' docs/test/water-cld.html`
- `grep -RIn 'href="/assets/water-cld' docs/test/water-cld.html || true`
- `grep -RIn 'src="/assets/water-cld' docs/test/water-cld.html || true`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a88d0416808328a6a05ddffc95c3c0