### PR TITLE
Add debug sentinel script for CLD test

### DIFF
--- a/docs/assets/debug/sentinel.js
+++ b/docs/assets/debug/sentinel.js
@@ -1,0 +1,23 @@
+(function(){
+  function safeAddClass(node, cls){
+    try{
+      if (node && node.classList && cls){ node.classList.add(cls); return true; }
+    }catch(_){ }
+    return false;
+  }
+  function mark(cls){
+    var el = (document && (document.documentElement || document.body));
+    if (el) safeAddClass(el, cls);
+  }
+  function detect(){
+    if (!document || !document.createElement){ return; }
+    var ok = !!(window.cytoscape && window.elk && window.dagre && window.Chart && window.exprEval && window.tippy && window.Popper);
+    mark(ok ? 'vendor-ok' : 'vendor-missing');
+  }
+  if (typeof document === 'undefined'){ return; }
+  if (document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', detect, { once:true });
+  } else {
+    detect();
+  }
+})();

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -249,6 +249,9 @@
   <script defer src="/assets/graph-store.js"></script>
   <script defer src="/assets/model-bridge.js"></script>
 
+  <!-- Sentinel (debug) -->
+  <script defer src="/assets/debug/sentinel.js"></script>
+
   <!-- SHIM + DEFER (no inline) -->
   <script defer src="/assets/water-cld.kernel-shim.js"></script>
   <script defer src="/assets/water-cld.defer.js"></script>


### PR DESCRIPTION
## Summary
- Add debug sentinel script to verify vendor availability and DOM readiness
- Insert sentinel in CLD test HTML to run before kernel shim

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run check:cld-html` *(fails: Required pattern not found in docs/test/water-cld.html: /assets/dist/water-cld.bundle.js)*

------
https://chatgpt.com/codex/tasks/task_e_68aa06382bf083289de579ee4f5404bf