### PR TITLE
feat: wait for DOM before loading CLD bundle

### DIFF
--- a/docs/assets/water-cld.defer.js
+++ b/docs/assets/water-cld.defer.js
@@ -1,5 +1,11 @@
 // Loads the CLD bundle only when kernel graph is ready (no inline, CSP-safe).
-(function () {
+(async function () {
+  function whenDomReady() {
+    if (document.readyState !== 'loading') return Promise.resolve();
+    return new Promise((resolve) => {
+      document.addEventListener('DOMContentLoaded', resolve, { once: true });
+    });
+  }
   function loadBundle() {
     if (document.getElementById('cld-bundle-loader')) return;
     const s = document.createElement('script');
@@ -9,8 +15,13 @@
     document.head.appendChild(s);
   }
   const g = (typeof window !== 'undefined') ? window : globalThis;
+  await whenDomReady();
+  if (g.CLD_SAFE && typeof g.CLD_SAFE.domGateReady === 'function') {
+    try { g.CLD_SAFE.domGateReady(); } catch (_) {}
+  }
   if (g.kernelReady && typeof g.kernelReady.then === 'function') {
-    g.kernelReady.then(loadBundle);
+    await g.kernelReady;
+    loadBundle();
   } else {
     // very defensive fallback
     const iv = setInterval(() => {


### PR DESCRIPTION
## Summary
- ensure DOM is ready before loading CLD bundle
- optionally signal DOM readiness via CLD_SAFE.domGateReady
- load bundle after kernelReady resolves

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68aa6d0979b88328bf87a3effff674d7