### PR TITLE
feat: use safe addClass wrapper

### DIFF
--- a/docs/assets/debug/sentinel.js
+++ b/docs/assets/debug/sentinel.js
@@ -1,13 +1,17 @@
-(function(){
-  function safeAddClass(node, cls){
+(function(g){
+  g = g || (typeof window !== 'undefined' ? window : globalThis);
+  g.CLD_SAFE = g.CLD_SAFE || {};
+  g.CLD_SAFE.safeAddClass = g.CLD_SAFE.safeAddClass || function(node, cls){
     try{
-      if (node && node.classList && cls){ node.classList.add(cls); return true; }
+      if (node?.addClass){ node.addClass(cls); return true; }
+      if (node?.classList?.add){ node.classList.add(cls); return true; }
     }catch(_){ }
+    console.warn('CLD_SAFE.safeAddClass fallback');
     return false;
-  }
+  };
   function mark(cls){
     var el = (document && (document.documentElement || document.body));
-    if (el) safeAddClass(el, cls);
+    if (el) g.CLD_SAFE.safeAddClass(el, cls);
   }
   function detect(){
     if (!document || !document.createElement){ return; }
@@ -20,4 +24,4 @@
   } else {
     detect();
   }
-})();
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/docs/assets/water-cld.kernel-adapter.js
+++ b/docs/assets/water-cld.kernel-adapter.js
@@ -61,7 +61,7 @@
     }catch(_){ }
   });
 
-  // 3) API کمکی برای ماژول‌ها: اجرای امن بر اساس فاز
-  // مثال استفاده: waterKernel.queue('graph', () => cy.$('#x').addClass('on'));
+    // 3) API کمکی برای ماژول‌ها: اجرای امن بر اساس فاز
+    // مثال استفاده: waterKernel.queue('graph', () => CLD_SAFE.safeAddClass(cy.$('#x'), 'on'));
   // (در کنار graphStore.run نیز قابل استفاده است)
 })();

--- a/docs/assets/water-cld.paths.js
+++ b/docs/assets/water-cld.paths.js
@@ -104,7 +104,15 @@
       const q = $('#node-search')?.value?.trim(); const n = findNodeByLabel(q);
       if (!n) return;
       cy.animate({ fit: { eles: n, padding: 60 }, duration: 240 });
-      n.flashClass = (cls, ms=700)=>{ n.addClass(cls); setTimeout(()=> n.removeClass(cls), ms); };
+      n.flashClass = (cls, ms=700)=>{ 
+        if (CLD_SAFE?.safeAddClass) {
+          CLD_SAFE.safeAddClass(n, cls);
+        } else {
+          console.warn('CLD_SAFE.safeAddClass missing');
+          n?.addClass?.(cls) ?? n?.classList?.add(cls);
+        }
+        setTimeout(()=> n.removeClass(cls), ms); 
+      };
       n.flashClass('cy-path-active', 800);
     });
 
@@ -120,9 +128,20 @@
     function highlightSet(eles, cls='cy-path-active'){
       const set = eles.union ? eles : cy.collection(eles);
       cy.batch(()=>{
-        cy.elements().not(set).addClass('cy-dim');
+        const others = cy.elements().not(set);
+        if (CLD_SAFE?.safeAddClass) {
+          CLD_SAFE.safeAddClass(others, 'cy-dim');
+        } else {
+          console.warn('CLD_SAFE.safeAddClass missing');
+          others?.addClass?.('cy-dim') ?? others?.classList?.add('cy-dim');
+        }
         set.removeClass('cy-dim');
-        set.addClass(cls);
+        if (CLD_SAFE?.safeAddClass) {
+          CLD_SAFE.safeAddClass(set, cls);
+        } else {
+          console.warn('CLD_SAFE.safeAddClass missing');
+          set?.addClass?.(cls) ?? set?.classList?.add(cls);
+        }
       });
     }
 

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -252,6 +252,9 @@
   <!-- Sentinel (debug) -->
   <script defer src="/assets/debug/sentinel.js"></script>
 
+  <!-- Bundled CLD -->
+  <script defer src="/assets/dist/water-cld.bundle.js"></script>
+
   <!-- SHIM + DEFER (no inline) -->
   <script defer src="/assets/water-cld.kernel-shim.js"></script>
   <script defer src="/assets/water-cld.defer.js"></script>

--- a/tools/check-cld-html.sh
+++ b/tools/check-cld-html.sh
@@ -84,9 +84,9 @@ if [[ -z "$GLINE" || -z "$BLINE" || "$GLINE" -le "$BLINE" ]]; then
 fi
 
 # --- مسیر قدیمی Chart.js نباید در مخزن باشد
-if git grep -n "assets/libs/chart.umd.min.js" -- ':!node_modules' >/dev/null 2>&1; then
+if git grep -n "assets/libs/chart.umd.min.js" -- ':!node_modules' ':!tools/check-cld-html.sh' >/dev/null 2>&1; then
   red "❌ Found legacy Chart path: assets/libs/chart.umd.min.js (replace with /assets/vendor/chart.umd.min.js)"
-  git grep -n "assets/libs/chart.umd.min.js" -- ':!node_modules' || true
+  git grep -n "assets/libs/chart.umd.min.js" -- ':!node_modules' ':!tools/check-cld-html.sh' || true
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- add global `CLD_SAFE.safeAddClass` with fallback implementation
- replace direct `.addClass` calls with guarded `CLD_SAFE.safeAddClass`
- document safe wrapper usage in kernel adapter example
- include bundled script in CLD test HTML and update check to ignore legacy Chart path false positives

## Testing
- `npm test`
- `npm run flag:test` *(fails: Failed to launch the browser process: error while loading shared libraries: libatk-1.0.so.0)*
- `npm run check:no-binary`
- `npm run check:cld-html`

------
https://chatgpt.com/codex/tasks/task_e_68aa6ea12ffc8328ad2ed80541d28b8f