### PR TITLE
Normalize Chart.js asset path across docs

### DIFF
--- a/docs/electricity/peak.html
+++ b/docs/electricity/peak.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="/assets/global-footer.css">
     <link rel="stylesheet" href="/assets/unified-badge.css">
     <link rel="stylesheet" href="../assets/site-overrides.css">
-    <script src="/vendor/chart.umd.min.js"></script>
+    <script src="/assets/vendor/chart.umd.min.js"></script>
     <script src="../assets/electricity-management.js"></script>
     <script defer src="/assets/unified-badge.js"></script>
     <script defer src="/assets/global-footer.js"></script>

--- a/docs/electricity/quality.html
+++ b/docs/electricity/quality.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="../assets/tailwind.css">
 
     <!-- Chart.js: نسخه محلی پروژه -->
-    <script src="/vendor/chart.umd.min.js"></script>
+    <script src="/assets/vendor/chart.umd.min.js"></script>
 
     <!-- فونت محلی Vazirmatn -->
   <link rel="stylesheet" href="../assets/fonts.css">

--- a/docs/gas/energy.html
+++ b/docs/gas/energy.html
@@ -138,7 +138,7 @@
   </div>
 
   <!-- کتابخانه‌ها و اسکریپت‌ها (محلی) -->
-  <script defer src="/vendor/chart.umd.min.js"></script>
+  <script defer src="/assets/vendor/chart.umd.min.js"></script>
   <script defer src="../assets/numfmt.js"></script>
   <script defer src="./energy.js"></script>
   <script defer src="../assets/badge-updated.js"></script>

--- a/docs/gas/fuel-carbon.html
+++ b/docs/gas/fuel-carbon.html
@@ -199,7 +199,7 @@
   </div>
 
   <!-- اسکریپت اختصاصی این صفحه (JS جداگانه) -->
-  <script src="../vendor/chart.js/chart.umd.js" defer></script>
+  <script src="/assets/vendor/chart.umd.min.js" defer></script>
   <script src="../vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js" defer></script>
   <script src="../assets/js/gas-fuel-carbon.js?v=1" defer></script>
 </body>

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -249,11 +249,11 @@
   <script defer src="/assets/graph-store.js"></script>
   <script defer src="/assets/model-bridge.js"></script>
 
-  <!-- Sentinel (debug) -->
-  <script defer src="/assets/debug/sentinel.js"></script>
-
   <!-- Bundled CLD -->
   <script defer src="/assets/dist/water-cld.bundle.js"></script>
+
+  <!-- Sentinel (debug) -->
+  <script defer src="/assets/debug/sentinel.js"></script>
 
   <!-- SHIM + DEFER (no inline) -->
   <script defer src="/assets/water-cld.kernel-shim.js"></script>

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -116,7 +116,7 @@
   <div class="footer-note">با هر تغییر در ورودی‌ها، نتایج به‌صورت زنده محاسبه می‌شوند.</div>
 </main>
 
-  <script src="/vendor/chart.umd.min.js"></script>
+  <script src="/assets/vendor/chart.umd.min.js"></script>
   <script defer src="../assets/water-cost.js"></script>
   <script defer src="../assets/water-init.js"></script>
 </body>

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -214,7 +214,7 @@
     
     
 
-    <script defer src="/vendor/chart.umd.min.js"></script>
+    <script defer src="/assets/vendor/chart.umd.min.js"></script>
     <script defer src="../assets/water-init.js"></script>
     <script type="module" src="../assets/ai.js"></script>
     <script defer src="../assets/app.js"></script>


### PR DESCRIPTION
## Summary
- point all dashboards to `/assets/vendor/chart.umd.min.js`
- keep a single Chart.js include per page and fix CLD sentinel load order

## Testing
- `npm test`
- `npm run check:cld-html`
- `rg -c '/assets/vendor/chart.umd.min.js' docs/**/*.html`


------
https://chatgpt.com/codex/tasks/task_e_68aa74ee14e48328bfc738537c342417