### PR TITLE
Guard event listeners against missing elements

### DIFF
--- a/docs/assets/power-tariff.js
+++ b/docs/assets/power-tariff.js
@@ -163,9 +163,14 @@ document.addEventListener('DOMContentLoaded', () => {
   console.clear();
   populateTariffTable(ETariffConfig);
   initTabs();
-  document.getElementById('etf-check-tier-btn').addEventListener('click', checkUserTier);
-  document.getElementById('etf-calculate-btn').addEventListener('click', handleCalculate);
-  document.getElementById('etf-savings-slider').addEventListener('input', updateSavings);
-  document.getElementById('etf-analyze-btn').addEventListener('click', analyzeConsumption);
-  document.getElementById('etf-download-pdf-btn').addEventListener('click', downloadBillAsPDF);
+  const addListener = (id, evt, handler) => {
+    const el = document.getElementById(id);
+    if (el) el.addEventListener(evt, handler);
+    else console.warn(`Element #${id} not found`);
+  };
+  addListener('etf-check-tier-btn', 'click', checkUserTier);
+  addListener('etf-calculate-btn', 'click', handleCalculate);
+  addListener('etf-savings-slider', 'input', updateSavings);
+  addListener('etf-analyze-btn', 'click', analyzeConsumption);
+  addListener('etf-download-pdf-btn', 'click', downloadBillAsPDF);
 });

--- a/docs/assets/water-cld.quick-preset.js
+++ b/docs/assets/water-cld.quick-preset.js
@@ -13,7 +13,9 @@ function boot(){
   const bar=document.createElement('div'); bar.className='quick-cta'; bar.id='quick-cta';
   bar.innerHTML=`<button id="cta-see-effect" class="btn">\u0627\u062b\u0631 \u0633\u06cc\u0627\u0633\u062a \u0646\u0645\u0648\u0646\u0647 \u0631\u0627 \u0628\u0628\u06cc\u0646</button><span class="hint">\u06f2 \u06a9\u0644\u06cc\u06a9 \u062a\u0627 \u062f\u06cc\u062f\u0646 \u0627\u062b\u0631 \u0631\u0648\u06cc KPI\u0647\u0627</span>`;
   const anchor=document.getElementById('hero-kpi')||document.body; anchor.parentElement.insertBefore(bar,anchor);
-  bar.querySelector('#cta-see-effect').addEventListener('click',()=>{ applyPresetLeakage20(); try{LS.setItem('seenAha','1')}catch(_){} });
+  const btn = bar.querySelector('#cta-see-effect');
+  if (btn) btn.addEventListener('click',()=>{ applyPresetLeakage20(); try{LS.setItem('seenAha','1')}catch(_){} });
+  else console.warn('Element #cta-see-effect not found');
 }
 document.readyState!=='loading'?boot():window.addEventListener('DOMContentLoaded',boot,{once:true});
 })();


### PR DESCRIPTION
## Summary
- Avoid runtime errors in power tariff script by checking element existence before binding handlers
- Safely bind quick preset button only when present and warn otherwise

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68aa75858618832887dcfc9f1aee56ad