### PR TITLE
Guard Cytoscape selectors from non-string values

### DIFF
--- a/docs/assets/water-cld.cy-collection-guard.js
+++ b/docs/assets/water-cld.cy-collection-guard.js
@@ -103,10 +103,22 @@
       collection: cy.collection.bind(cy)
     };
 
-    cy.elements = function(sel){ return wrapCollection(orig.elements(sel), [''+(sel||'')]); };
-    cy.nodes    = function(sel){ return wrapCollection(orig.nodes(sel),    [''+(sel||'')]); };
-    cy.edges    = function(sel){ return wrapCollection(orig.edges(sel),    [''+(sel||'')]); };
-    cy.$        = function(q){   return wrapCollection(orig.$(q),          [''+(q||'')]); };
+    cy.elements = function(sel){
+      const s = (typeof sel === 'string') ? sel : undefined;
+      return wrapCollection(orig.elements(s), [s || '']);
+    };
+    cy.nodes = function(sel){
+      const s = (typeof sel === 'string') ? sel : undefined;
+      return wrapCollection(orig.nodes(s), [s || '']);
+    };
+    cy.edges = function(sel){
+      const s = (typeof sel === 'string') ? sel : undefined;
+      return wrapCollection(orig.edges(s), [s || '']);
+    };
+    cy.$ = function(q){
+      const s = (typeof q === 'string') ? q : undefined;
+      return wrapCollection(orig.$(s), [s || '']);
+    };
     cy.getElementById = function(id){
       // emulate a selector path that resolves to a single id
       return wrapCollection(orig.getElementById(id), ['[#'+id+']']);

--- a/docs/assets/water-cld.cy-stub.js
+++ b/docs/assets/water-cld.cy-stub.js
@@ -15,13 +15,19 @@
   // ساخت reference انتخاب با نگه‌داری زنجیرهٔ فیلترها
   function makeSelectorRef(base){
     // base: { type:'elements'|'id'|'query', value:any }
-    return { type: base.type, value: base.value, ops: [] }; // ops: [{method:'filter', args:[...]}]
+    var val = base.value;
+    if (base.type === 'id'){
+      val = val != null ? String(val) : undefined;
+    } else if (base.type === 'elements' || base.type === 'query'){
+      val = (typeof val === 'string') ? val : undefined;
+    }
+    return { type: base.type, value: val, ops: [] }; // ops: [{method:'filter', args:[...]}]
   }
 
   function resolveBase(real, ref){
     if (!ref) return real.elements();
-    if (ref.type === 'id')    return real.getElementById(String(ref.value));
-    if (ref.type === 'query') return real.$(String(ref.value));
+    if (ref.type === 'id')    return real.getElementById(ref.value);
+    if (ref.type === 'query') return real.$(ref.value);
     return real.elements(ref.value);
   }
 
@@ -64,7 +70,8 @@
     for (var i=0; i<chainOps.length; i++){
       (function(m){
         api[m] = function(){
-          selectorRef.ops.push({ method: m, args: arguments });
+          var sel = (typeof arguments[0] === 'string') ? arguments[0] : undefined;
+          selectorRef.ops.push({ method: m, args: [sel] });
           return api;
         };
       })(chainOps[i]);
@@ -106,8 +113,8 @@
     elements: function(sel){ return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
     nodes:    function(sel){ return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
     edges:    function(sel){ return makeCollectionProxy(makeSelectorRef({ type:'elements', value: sel })); },
-    getElementById: function(id){ return makeCollectionProxy(makeSelectorRef({ type:'id', value: String(id) })); },
-    $: function(query){ return makeCollectionProxy(makeSelectorRef({ type:'query', value: String(query) })); },
+    getElementById: function(id){ return makeCollectionProxy(makeSelectorRef({ type:'id', value: id })); },
+    $: function(query){ return makeCollectionProxy(makeSelectorRef({ type:'query', value: query })); },
 
     // events & batching
     on: noop, off: noop,


### PR DESCRIPTION
## Summary
- Prevent non-string values from generating invalid selector paths in collection guards
- Sanitize selectors in cy stub and queue to default undefined when inputs aren't strings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa7913e23c8328ab3bfa08dbf512b2