### PR TITLE
Add defensive input checks for water cost calculator

### DIFF
--- a/docs/assets/water-cost.js
+++ b/docs/assets/water-cost.js
@@ -4,6 +4,17 @@
   const num = v => Number(String(v).replace(/[^\d.-]/g,'') || 0);
   const fmt = n => new Intl.NumberFormat('fa-IR').format(Math.round(n));
 
+  function sendInput(id) {
+    const targetInput = document.getElementById(id);
+    const val = targetInput?.value;
+    if (typeof val === 'string') {
+      return val.toLowerCase();
+    } else {
+      console.error('input element not found or has no value');
+      return '';
+    }
+  }
+
   // Bind inputs (number <-> range sync)
   function bindPair(numId, rangeId){
     const n = $('#'+numId), r = $('#'+rangeId);
@@ -118,4 +129,5 @@
     $('#recalc').addEventListener('click', recalc);
     recalc();
   });
+  window.sendInput = sendInput;
 })();

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -105,6 +105,18 @@
         </div>
       </div>
 
+      <div class="card dash-card">
+        <h3>آزمون ورودی‌ها</h3>
+        <div class="group">
+          <label for="chargeinput">شارژ</label>
+          <input id="chargeinput" type="text" />
+        </div>
+        <div class="group">
+          <label for="voteinput">رأی</label>
+          <input id="voteinput" type="text" />
+        </div>
+      </div>
+
       <div class="actions">
         <button id="recalc" class="btn btn-primary" type="button">به‌روزرسانی محاسبات</button>
         <a class="btn" href="../index.html">بازگشت</a>


### PR DESCRIPTION
## Summary
- add charge and vote input fields to water cost calculator
- guard sendInput with type check before toLowerCase to avoid runtime errors

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68aa7c41628883289c8b2bab2ddbf525