### PR TITLE
fix(cld): ensure Cytoscape init after DOM and sync graph

### DIFF
--- a/docs/assets/water-cld.kernel-adapter.js
+++ b/docs/assets/water-cld.kernel-adapter.js
@@ -22,8 +22,10 @@
       const ro = new ResizeObserver(() => safeLayout(cy));
       ro.observe(el);
     }
-    window.waterKernel.onReady('MODEL_LOADED', () => safeLayout(cy));
-    window.waterKernel.onReady('GRAPH_READY', () => safeLayout(cy));
+    window.waterKernel.onReady('GRAPH_READY', () => {
+      console.debug('[kernel-adapter] cy ready, running layout');
+      safeLayout(cy);
+    });
   });
 })();
 


### PR DESCRIPTION
## Summary
- initialize Cytoscape immediately when DOM is ready and dispatch `cy:ready`
- defer graph restoration until `CY_READY` and emit `MODEL_LOADED`/`GRAPH_READY`
- run layout only after `GRAPH_READY` on real Cytoscape instance

## Testing
- `npm test`
- `npm run check:cld-html`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68aa9744f9b0832897ca24fd1b2ed739