### PR TITLE
fix(cld): guarantee Cytoscape init even after DOMContentLoaded, hard-sync graphStore→cy, normalize elements, and emit phases only after success

### DIFF
--- a/docs/assets/water-cld.kernel-adapter.js
+++ b/docs/assets/water-cld.kernel-adapter.js
@@ -16,14 +16,16 @@
     });
   }
 
-  window.waterKernel.onceReady('cy', (cy) => {
+  window.waterKernel.onReady('GRAPH_READY', () => {
+    const cy = window.__cy;
+    if (!cy || !cy.nodes || cy.nodes().length === 0) return;
     const el = document.getElementById('cy');
     if (el && 'ResizeObserver' in window){
       const ro = new ResizeObserver(() => safeLayout(cy));
       ro.observe(el);
     }
-    window.waterKernel.onReady('MODEL_LOADED', () => safeLayout(cy));
-    window.waterKernel.onReady('GRAPH_READY', () => safeLayout(cy));
+    console.log('[kernel-adapter] cy ready, running layout');
+    safeLayout(cy);
   });
 })();
 


### PR DESCRIPTION
## Summary
- initialize Cytoscape via `initCytoscape` regardless of `DOMContentLoaded`, expose the instance globally, and dispatch a `cy:ready` event
- normalize model data and hard-sync the graph store into Cytoscape, emitting `MODEL_LOADED`/`GRAPH_READY` only when node counts match
- run the layout adapter only after `GRAPH_READY` with a populated Cytoscape instance

## Testing
- `npm test`
- `npm run check:cld-html`


------
https://chatgpt.com/codex/tasks/task_e_68aa99b2280c8328b59ad216f092810c