### PR TITLE
feat(cld): harden meta access & fix stub to prevent null Map race in synonym lookup

### DIFF
--- a/docs/assets/water-cld.cy-stub.js
+++ b/docs/assets/water-cld.cy-stub.js
@@ -1,4 +1,4 @@
-(function(){
+(typeof window !== 'undefined' && !window.cy) && (function(){
   if (window.__CY_STUB__) return; window.__CY_STUB__ = true;
   'use strict';
 
@@ -131,6 +131,7 @@
     reset:       function(){ enqueue('cy','reset',       arguments); },
     layout:      function(){ enqueue('cy','layout',      arguments); }
   };
+  cyStub.graph = { meta: { synonymToId: new Map(), nodes: new Map(), edges: new Map() } };
 
   // Getter/Setter روی window.cy + flush
   try{


### PR DESCRIPTION
## Summary
- Prevent early access to `window.cy` by guarding the stub and seeding its graph meta with Maps.
- Add CLD readiness promise, safe meta lookups, and synonym helper functions.
- Register Cytoscape event listeners only after the graph and metadata are ready.

## Testing
- `npm test`
- `npm run check:no-binary`
- `npm run check:cld-html`


------
https://chatgpt.com/codex/tasks/task_e_68aaeec82aa48328a2cb36e9d2a63441