### PR TITLE
fix: guard undefined metadata and badge update

### DIFF
--- a/docs/assets/unified-badge.js
+++ b/docs/assets/unified-badge.js
@@ -27,6 +27,22 @@
     });
   }
 
+  function updateTimes(){
+    const els = document.querySelectorAll('[data-last-updated]');
+    for (const el of els) {
+      const iso = el.getAttribute('data-last-updated');
+      if (!iso) continue;
+      const dt = new Date(iso);
+      const formatted = new Intl.DateTimeFormat('fa-IR', { dateStyle: 'medium' }).format(dt);
+      const timeEl = el.querySelector('.updated-time');
+      if (timeEl) {
+        timeEl.textContent = formatted;
+      } else {
+        console.warn('Element with [data-last-updated] is missing a child with class ".updated-time"', el);
+      }
+    }
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     const html = document.documentElement;
     if (!html.getAttribute('data-theme')) {
@@ -37,5 +53,6 @@
         p.startsWith('/gas')         ? 'gas'     : 'electric');
     }
     installBadges();
+    updateTimes();
   });
 })();

--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -75,15 +75,25 @@ function cldGetCy(){
 }
 
 function findSynonyms(id){
-  const meta = (window?.cy?.graph?.meta) ?? { synonymToId: new Map(), nodes: new Map(), edges: new Map() };
-  const syn = meta.synonymToId instanceof Map ? meta.synonymToId : new Map();
-  return (syn.get(id) || []).map(function(x){ return x; }).filter(Boolean);
+  const meta = window?.cy?.graph?.meta;
+  if (!meta || !meta.synonymToId) {
+    return [];
+  }
+  const synonymsOfN = meta.nodes?.get?.(id)?.synonyms;
+  if (!synonymsOfN) {
+    return [];
+  }
+  const synonymIds = synonymsOfN.map(function (s) { return meta.synonymToId.get(s); });
+  return synonymIds.filter(Boolean);
 }
 
 function findSynonymNodes(id){
-  const meta = (window?.cy?.graph?.meta) ?? { synonymToId: new Map(), nodes: new Map(), edges: new Map() };
-  const syn = meta.synonymToId instanceof Map ? meta.synonymToId : new Map();
-  return (syn.get(id) || []).map(function(x){ return meta.nodes?.get?.(x); }).filter(Boolean);
+  const meta = window?.cy?.graph?.meta;
+  if (!meta || !meta.synonymToId) {
+    return [];
+  }
+  const synonymIds = findSynonyms(id);
+  return synonymIds.map(function(x){ return meta.nodes?.get?.(x); }).filter(Boolean);
 }
 window.findSynonyms = findSynonyms;
 window.findSynonymNodes = findSynonymNodes;


### PR DESCRIPTION
## Summary
- prevent crash when synonyms metadata not ready
- avoid null textContent updates for last-updated badge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aaf427190083289a00038b3955ee72