### PR TITLE
fix: prevent console crashes in findSynonyms and unified-badge (defensive guards)

### DIFF
--- a/docs/assets/unified-badge.js
+++ b/docs/assets/unified-badge.js
@@ -27,6 +27,21 @@
     });
   }
 
+  function updateBadgeTimes(){
+    const els = document.querySelectorAll('[data-last-updated]');
+    for (const el of els) {
+      const ts = el.getAttribute('data-last-updated');
+      const d = ts ? new Date(ts) : null;
+      const formatted = (d && !isNaN(d)) ? d.toISOString().slice(0,10) : (ts || '');
+      const timeEl = el.querySelector('.updated-time');
+      if (timeEl) {
+        timeEl.textContent = formatted;
+      } else {
+        console.warn('Element with [data-last-updated] is missing a child ".updated-time"', el);
+      }
+    }
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     const html = document.documentElement;
     if (!html.getAttribute('data-theme')) {
@@ -37,5 +52,6 @@
         p.startsWith('/gas')         ? 'gas'     : 'electric');
     }
     installBadges();
+    updateBadgeTimes();
   });
-})();
+  })();

--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -75,9 +75,19 @@ function cldGetCy(){
 }
 
 function findSynonyms(id){
-  const meta = (window?.cy?.graph?.meta) ?? { synonymToId: new Map(), nodes: new Map(), edges: new Map() };
-  const syn = meta.synonymToId instanceof Map ? meta.synonymToId : new Map();
-  return (syn.get(id) || []).map(function(x){ return x; }).filter(Boolean);
+  const graph = (typeof window !== 'undefined' && window.cy && window.cy.graph) ? window.cy.graph : {};
+  const meta = graph.meta || {};
+  // اگر هنوز آماده نیست، آرایهٔ خالی برگردان
+  if (!meta || !meta.synonymToId) return [];
+
+  const node = (meta.nodes instanceof Map) ? meta.nodes.get(id) : undefined;
+  const synonymsOfN = Array.isArray(node?.synonyms) ? node.synonyms : [];
+  if (!synonymsOfN.length) return [];
+
+  const synonymIds = synonymsOfN
+    .map((s) => meta.synonymToId.get(s))
+    .filter(Boolean);
+  return synonymIds;
 }
 
 function findSynonymNodes(id){


### PR DESCRIPTION
## Summary
- add defensive guards around graph meta lookups in `findSynonyms`
- guard `.updated-time` query in unified badge script to warn instead of crash

## Testing
- `npm test`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68aaf65248b483288608251042bb5af2