### PR TITLE
feat(amaayesh): add energy map skeleton and homepage link

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width, initial-scale=1"/>
+  <title>نقشه آمایش انرژی — خراسان رضوی | WESH360</title>
+  <link rel="stylesheet" href="../assets/tailwind.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"/>
+  <style>
+    html, body { height:100% }
+    .label{ font-family: Vazirmatn, sans-serif; font-size:12px; text-shadow:0 0 6px #fff }
+    .map-wrap{ height:calc(100vh - 140px) }
+  </style>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100 flex flex-col">
+  <header class="w-full px-4 py-3 flex items-center justify-between">
+    <h1 class="text-lg md:text-2xl font-bold">نقشه تعاملی آمایش انرژی — خراسان رضوی</h1>
+    <nav class="text-sm md:text-base"><a href="../index.html" class="underline decoration-dotted">صفحه اصلی</a></nav>
+  </header>
+
+  <main id="main" class="container mx-auto px-4 grow">
+    <div id="info" class="mb-2 text-slate-300 text-sm">در انتظار داده…</div>
+    <div class="map-wrap rounded-2xl overflow-hidden ring-1 ring-slate-700">
+      <div id="map" class="h-full w-full"></div>
+    </div>
+  </main>
+
+  <footer class="mt-6 py-6 text-center text-slate-400 text-xs">WESH360 • Energy Spatial Planning • Leaflet</footer>
+
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="../assets/js/amaayesh-map.js"></script>
+</body>
+</html>

--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -1,0 +1,10 @@
+{
+  "title": "نقشه تعاملی آمایش خراسان رضوی — انرژی",
+  "baseData": { "combined": "/data/amaayesh/khorasan_razavi_combined.geojson" },
+  "themes": [
+    { "key":"electricity", "title":"برق", "type":"line", "file":"/data/amaayesh/electricity_lines.geojson", "style":{"color":"#ffd166","weight":3} },
+    { "key":"water",      "title":"آب",   "type":"line", "file":"/data/amaayesh/water_mains.geojson",      "style":{"color":"#118ab2","weight":3} },
+    { "key":"gas",       "title":"گاز",  "type":"line", "file":"/data/amaayesh/gas_transmission.geojson","style":{"color":"#ef476f","weight":4} },
+    { "key":"oil",       "title":"نفت",  "type":"line", "file":"/data/amaayesh/oil_pipelines.geojson",   "style":{"color":"#073b4c","weight":3} }
+  ]
+}

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -1,0 +1,11 @@
+(function(){
+  const map = L.map('map', { preferCanvas:true, zoomControl:true });
+  const base = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{
+    attribution:'© OpenStreetMap'
+  }).addTo(map);
+
+  // fallback view (Mashhad region)
+  map.setView([36.3, 59.6], 7);
+
+  // اگر بعداً config اضافه شد، همین فایل بعداً ارتقاء می‌یابد.
+})();

--- a/docs/index.html
+++ b/docs/index.html
@@ -54,6 +54,10 @@
       </div>
     </section>
   <main id="main" class="flex-grow">
+    <a href="./amaayesh/index.html"
+       class="inline-flex items-center gap-2 px-4 py-2 my-4 rounded-xl bg-sky-600/90 hover:bg-sky-500 text-white">
+      نقشه آمایش انرژی خراسان رضوی
+    </a>
     <section id="entry-cards" class="cards-section" aria-label="navigation cards">
       <a href="/water/hub" class="card water" aria-label="ورود به داشبورد آب">
         <span class="icon" aria-hidden="true">💧</span>


### PR DESCRIPTION
## Summary
- add energy map skeleton page under `docs/amaayesh/`
- include minimal Leaflet map script and layer config
- link new energy map from homepage

## Testing
- `npm run build`
- `npm test` *(fails: TimeoutError waiting for page load)*

------
https://chatgpt.com/codex/tasks/task_e_68b28b11ced48328960b766f49c96df7