### PR TITLE
feat(amaayesh): wire thematic energy layers via config with graceful missing-state

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -46,9 +46,18 @@
       onEachFeature: (f,l)=> l.bindPopup(`<b>${labelFa(f.properties)}</b>`)
     }).addTo(map);
 
-    L.control.layers({'OpenStreetMap':base}, {
-      'مرز شهرستان‌ها': boundary, 'پُرشدگی شهرستان‌ها': polyFill, 'شهرها/نقاط': pointLayer
-    }, {collapsed:false}).addTo(map);
-    document.getElementById('info').textContent = 'پایه نقشه بارگذاری شد.';
+    const overlays = { 'مرز شهرستان‌ها': boundary, 'پُرشدگی شهرستان‌ها': polyFill, 'شهرها/نقاط': pointLayer };
+    const missing = [];
+    for(const th of (cfg?.themes || [])){
+      try{
+        const data = await loadJSON(th.file);
+        const layer = L.geoJSON(data,{ pane:'polygons', style: th.style || {color:'#ef4444',weight:3} });
+        overlays[th.title] = layer; layer.addTo(map);
+      }catch(e){ missing.push(th.title); }
+    }
+    L.control.layers({'OpenStreetMap':base}, overlays, {collapsed:false}).addTo(map);
+    document.getElementById('info').innerHTML = missing.length
+      ? `لایه‌های در صف بارگذاری: ${missing.join('، ')}`
+      : 'همه‌ی لایه‌ها بارگذاری شدند.';
   })().catch(()=>{ /* بدون خطا روی UI */ });
 })();


### PR DESCRIPTION
## Summary
- load themed energy layers from `layers.config.json` and overlay on the map
- gracefully report missing thematic layers without failing

## Testing
- `npm run build`
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b28fff29a483289288f70c551e6c89