### PR TITLE
fix(amaayesh): link gas effects to overlay visibility

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -60,31 +60,45 @@
     L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
 
     // اگر لایه گاز موجود است، جلوه‌های اضافه اعمال شود
-    const gasLayer = overlays['گاز'];
+    const gasLayer = overlays && overlays['گاز'];
     if (gasLayer) {
+      const gasEffects = L.layerGroup();
+
       // هاله
-      const halo = L.geoJSON(gasLayer.toGeoJSON(), { style:{ color:'#ffe0d6', weight:8, opacity:1 } }).addTo(map);
-      gasLayer.bringToFront();
+      const gasFC = gasLayer.toGeoJSON();
+      L.geoJSON(gasFC, { style:{ color:'#ffe0d6', weight:8, opacity:1 } }).addTo(gasEffects);
 
-      // فلِش جهت
-      L.polylineDecorator(gasLayer, {
-        patterns: [{ offset: 0, repeat: '80px',
-          symbol: L.Symbol.arrowHead({ pixelSize: 8, pathOptions: { color: '#ef476f', weight: 1 }})
-        }]
-      }).addTo(map);
+      // فلِش جهت (اگر پلاگین Decorator موجود بود)
+      if (typeof L !== 'undefined' && L.polylineDecorator && L.Symbol && L.Symbol.arrowHead) {
+        const segs = [];
+        gasLayer.eachLayer(l => { if (l && typeof l.getLatLngs === 'function') segs.push(l); });
+        if (segs.length) {
+          L.polylineDecorator(segs, {
+            patterns: [{ offset:0, repeat:'80px',
+              symbol: L.Symbol.arrowHead({ pixelSize:8, pathOptions:{ color:'#ef476f', weight:1 }})
+            }]
+          }).addTo(gasEffects);
+        }
+      }
 
-      // بافر فاصله (اختیاری)
-      try{
-        const unioned = gasLayer.toGeoJSON().features.reduce((acc,f)=> acc? turf.union(acc,f) : f, null);
+      // بافر فاصله (اگر Turf موجود بود)
+      if (typeof turf !== 'undefined') {
         const distancesKm = [10,30,50];
         let prev = null;
-        distancesKm.forEach((km,i)=>{
-          const b = turf.buffer(unioned, km, {units:'kilometers'});
-          const ring = prev ? turf.difference(b, prev) : b;
-          prev = b;
-          if(ring) L.geoJSON(ring, { style:{ fillColor:'#ffd0cc', fillOpacity:0.25, color:'#e06b5f', weight:1 } }).addTo(map);
-        });
-      }catch(e){ /* اگر Turf در دسترس نبود یا داده نبود، سکوت */ }
+        for (let i=0; i<distancesKm.length; i++) {
+          const b = turf.buffer(gasFC, distancesKm[i], { units:'kilometers' });
+          const ring = prev ? turf.difference(b, prev) : b; prev = b;
+          if (ring) L.geoJSON(ring, {
+            style:{ fillColor:['#fff5ef','#ffe3d6','#ffc2a4'][i]||'#ffd0cc', fillOpacity:.25, color:'#e06b5f', weight:1 }
+          }).addTo(gasEffects);
+        }
+      }
+
+      // هم‌زمان‌سازی با کنترل لایه‌ها
+      map.on('overlayadd',   e => { if (e.layer === gasLayer) { gasEffects.addTo(map); gasLayer.bringToFront(); } });
+      map.on('overlayremove',e => { if (e.layer === gasLayer) map.removeLayer(gasEffects); });
+
+      if (map.hasLayer(gasLayer)) { gasEffects.addTo(map); gasLayer.bringToFront(); }
     }
 
     document.getElementById('info').innerHTML = missing.length


### PR DESCRIPTION
## Summary
- group gas halo, arrows and buffers in a layer group tied to the 'گاز' overlay

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b29a4f20f483288649aea19b003497