### PR TITLE
fix: use relative paths for water-cld test assets

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -5,14 +5,14 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>مدل پویایی بهره‌وری آب در کشاورزی</title>
 
-  <link rel="icon" type="image/webp" href="/page/landing/logo2.webp" />
+  <link rel="icon" type="image/webp" href="../page/landing/logo2.webp" />
 
   <!-- Base styles -->
-  <link rel="stylesheet" href="/assets/tailwind.css" />
-  <link rel="stylesheet" href="/assets/chart.autofix.css" />
+  <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="../assets/chart.autofix.css" />
 
   <!-- Bundled CLD styles -->
-  <link rel="stylesheet" href="/assets/dist/water-cld.bundle.css" />
+  <link rel="stylesheet" href="../assets/dist/water-cld.bundle.css" />
 
   <style>
     #system-graph, #cy { min-height: 480px; height: 100%; }
@@ -185,8 +185,8 @@
         </label><span class="hint" data-tippy-content="نمایش روابط دارای تأخیر زمانی">❔</span>
 
         <select id="model-switch" aria-label="انتخاب مدل">
-          <option value="/data/water-cld.json?v=2">Simple</option>
-          <option value="/data/water-cld-poster.json?v=1" selected>Poster</option>
+          <option value="../data/water-cld.json?v=2">Simple</option>
+          <option value="../data/water-cld-poster.json?v=1" selected>Poster</option>
         </select>
 
         <select id="layout" class="btn outline">
@@ -236,6 +236,6 @@
   </div>
 
   <!-- فقط لودر باندل CLD را نگه می‌داریم -->
-  <script defer src="/assets/water-cld.defer.js"></script>
+  <script defer src="../assets/water-cld.defer.js"></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- fix test HTML to load assets, data, and icon using relative paths

## Testing
- `npm test` (fails: Error: Failed to launch the browser process - missing libatk-1.0.so.0)
- `npm run check:cld-html`


------
https://chatgpt.com/codex/tasks/task_e_68b2f544872c8328a99ae70cef18af32