### PR TITLE
fix cld bundle path resolution

### DIFF
--- a/docs/assets/water-cld.defer.js
+++ b/docs/assets/water-cld.defer.js
@@ -1,10 +1,10 @@
 function loadBundle(){
   if (window.__CLD_BUNDLE_INJECTED__) { console.debug('[CLD defer] bundle already injected'); return; }
-  if ([...document.scripts].some(s => (s.src||'').endsWith('/assets/dist/water-cld.bundle.js'))){
+  if ([...document.scripts].some(s => (s.src||'').endsWith('assets/dist/water-cld.bundle.js'))){
     window.__CLD_BUNDLE_INJECTED__ = true; console.debug('[CLD defer] bundle present by src'); return;
   }
   const s = document.createElement('script');
-  s.src = '/assets/dist/water-cld.bundle.js';
+  s.src = '../assets/dist/water-cld.bundle.js';
   s.defer = true;
   s.id = 'cld-bundle-loader';
   s.addEventListener('load', () => { window.__CLD_BUNDLE_INJECTED__ = true; console.debug('[CLD defer] bundle loaded'); });


### PR DESCRIPTION
## Summary
- load `water-cld.bundle.js` via relative path so docs/test resolves correctly
- relax existing bundle detection to match relative asset path

## Testing
- `node tests/mapper.test.js`
- `npm test` *(fails: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f66d98d48328aaf993392578ed28