### PR TITLE
Include edge sign when deriving polarity in sanitizeGraph

### DIFF
--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -103,7 +103,8 @@ function sanitizeGraph(graph){
     let t = String(e?.target || '').trim();
     if (syn){ s = String(syn.get(s) || s); t = String(syn.get(t) || t); }
     if (!s || !t || !nodeSet.has(s) || !nodeSet.has(t)) continue;
-    const p = (e?.polarity === '-' || e?.polarity === '+') ? e.polarity : (e?.p || '');
+    const p = (e?.polarity === '-' || e?.polarity === '+') ? e.polarity :
+              (e?.p || e?.sign || '');
     const key = `${s}->${t}:${p}`;
     if (seenEdges.has(key)) continue;
     seenEdges.add(key);


### PR DESCRIPTION
## Summary
- ensure sanitizeGraph considers `e.sign` along with `polarity` and `p` to preserve edge sign metadata

## Testing
- `npm test` *(fails: error while loading shared libraries: libXcomposite.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f828c2a883288576e9da2b7bcce8