### PR TITLE
feat: harden CLD bundle loader

### DIFF
--- a/docs/assets/water-cld.defer.js
+++ b/docs/assets/water-cld.defer.js
@@ -1,18 +1,42 @@
-function loadBundle(){
-  if (window.__CLD_BUNDLE_INJECTED__) { console.debug('[CLD defer] bundle already injected'); return; }
-  if ([...document.scripts].some(s => (s.src||'').endsWith('assets/dist/water-cld.bundle.js'))){
-    window.__CLD_BUNDLE_INJECTED__ = true; console.debug('[CLD defer] bundle present by src'); return;
+(function () {
+  var existing = document.querySelector('script[data-cld-bundle]');
+  if (existing) {
+    console.log('[CLD defer] bundle tag already in DOM:', existing.src);
+    return;
   }
-  const s = document.createElement('script');
-  s.src = '../assets/dist/water-cld.bundle.js';
-  s.defer = true;
-  s.id = 'cld-bundle-loader';
-  s.addEventListener('load', () => { window.__CLD_BUNDLE_INJECTED__ = true; console.debug('[CLD defer] bundle loaded'); });
-  document.head.appendChild(s);
-  console.debug('[CLD defer] bundle injected');
-}
-document.addEventListener('DOMContentLoaded', function(){
-  if (window.__CLD_BUNDLE_INJECTED__) return;
-  window.__CLD_BUNDLE_INJECTED__ = true;
-  loadBundle();
-}, { once:true });
+  if (window.CLD_SAFE && !existing) {
+    console.warn('[CLD defer] CLD_SAFE present but bundle tag missing; injecting anyway');
+  }
+
+  var candidates = (Array.isArray(window.CLD_BUNDLE_URLS) && window.CLD_BUNDLE_URLS.length)
+    ? window.CLD_BUNDLE_URLS
+    : [
+        '../assets/dist/water-cld.bundle.js?v=3',
+        './assets/dist/water-cld.bundle.js?v=3',
+        '/assets/dist/water-cld.bundle.js?v=3'
+      ];
+
+  function tryLoad(i) {
+    if (i >= candidates.length) {
+      console.error('[CLD defer] failed to load bundle from all candidates:', candidates);
+      return;
+    }
+    var url = new URL(candidates[i], window.location.href).href;
+    var s = document.createElement('script');
+    s.src = url;
+    s.async = true;
+    s.setAttribute('data-cld-bundle', 'true');
+    s.onload = function () {
+      console.log('[CLD defer] bundle loaded OK:', url, 'CLD_SAFE=', !!window.CLD_SAFE);
+      document.dispatchEvent(new CustomEvent('cld:bundle:loaded', { detail: { url: url } }));
+    };
+    s.onerror = function () {
+      console.warn('[CLD defer] bundle load failed:', url, '→ trying next…');
+      tryLoad(i + 1);
+    };
+    document.head.appendChild(s);
+    console.debug('[CLD defer] trying URL:', url);
+  }
+  tryLoad(0);
+})();
+


### PR DESCRIPTION
## Summary
- replace `water-cld.defer.js` to inject bundle tag only once
- add fallback URL list and sequential loading with logging
- emit `cld:bundle:loaded` event when bundle loads

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fd1605b08328bb9103285e122d46