### PR TITLE
docs: add local bundle check instructions

### DIFF
--- a/docs/debug/ADDME.md
+++ b/docs/debug/ADDME.md
@@ -1,0 +1,7 @@
+- نحوه‌ی تست محلی: `npm run serve-docs` و آدرس `http://localhost:5173/test/water-cld.html`
+- چک Network برای water-cld.bundle.js با status 200
+- اسنیپت کنسولی زیر برای تایید init:
+  ```js
+  console.log('CLD_SAFE?', !!window.CLD_SAFE, 'cy?', !!window.cy,
+    'nodes=', window.cy?.nodes()?.length, 'edges=', window.cy?.edges()?.length);
+  ```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "build:agri": "babel docs/agrivoltaics/app.jsx --presets @babel/preset-react -o docs/agrivoltaics/app.js",
     "prepare:agri": "mkdir -p docs/agrivoltaics/vendor && cp node_modules/react/umd/react.production.min.js docs/agrivoltaics/vendor/ && cp node_modules/react-dom/umd/react-dom.production.min.js docs/agrivoltaics/vendor/ && cp node_modules/qrcode-generator/dist/qrcode.js docs/agrivoltaics/vendor/ && cp node_modules/jspdf/dist/jspdf.umd.min.js docs/agrivoltaics/vendor/",
     "build:cld": "node scripts/build-cld.js",
-    "check:cld-html": "bash tools/check-cld-html.sh"
+    "check:cld-html": "bash tools/check-cld-html.sh",
+    "serve-docs": "npx http-server docs -p 5173"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add `serve-docs` script for quick HTTP server
- document quick bundle verification in `docs/debug/ADDME.md`

## Testing
- `npm test` *(fails: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b303d48d38832882355e6741e36576