### PR TITLE
refactor: improve CLD bundle loading

### DIFF
--- a/docs/assets/water-cld.defer.js
+++ b/docs/assets/water-cld.defer.js
@@ -1,46 +1,32 @@
 (function () {
-  // اگر اسکریپت باندل واقعاً در DOM هست، دوباره تزریق نکن
   var existing = document.querySelector('script[data-cld-bundle]');
-  if (existing) {
-    console.log('[CLD defer] bundle tag already in DOM:', existing.src);
-    return;
-  }
+  if (existing) { console.log('[CLD defer] bundle tag already in DOM:', existing.src); return; }
 
-  // حتی اگر CLD_SAFE روی window هست ولی تگ نیست، باز تزریق کن
-  if (window.CLD_SAFE && !existing) {
-    console.warn('[CLD defer] CLD_SAFE present but bundle tag missing; injecting anyway');
-  }
-
-  // کاندیدهای URL (نسبی) + شکستِ کش
-  var defaultCandidates = [
-    ['..', 'assets', 'dist', 'water-cld.bundle.js?v=3'].join('/'),
-    ['.', 'assets', 'dist', 'water-cld.bundle.js?v=3'].join('/')
-  ];
   var candidates = (Array.isArray(window.CLD_BUNDLE_URLS) && window.CLD_BUNDLE_URLS.length)
     ? window.CLD_BUNDLE_URLS
-    : defaultCandidates;
+    : ['../assets/dist/water-cld.bundle.js?v=3', './assets/dist/water-cld.bundle.js?v=3'];
 
   function tryLoad(i) {
     if (i >= candidates.length) {
-      console.error('[CLD defer] failed to load bundle from all candidates:', candidates);
+      console.error('[CLD defer] failed from all candidates:', candidates);
       return;
     }
-    var url = new URL(candidates[i], window.location.href).href;
+    var url = new URL(candidates[i], location.href).href;
     var s = document.createElement('script');
-    s.src = url;
-    s.async = true;
     s.setAttribute('data-cld-bundle', 'true');
+    s.async = true;
+    s.src = url;
     s.onload = function () {
       console.log('[CLD defer] bundle loaded OK:', url, 'CLD_SAFE=', !!window.CLD_SAFE);
-      document.dispatchEvent(new CustomEvent('cld:bundle:loaded', { detail: { url: url } }));
+      document.dispatchEvent(new CustomEvent('cld:bundle:loaded', { detail: { url } }));
     };
     s.onerror = function () {
-      console.warn('[CLD defer] bundle load failed:', url, '→ trying next…');
+      console.warn('[CLD defer] bundle load failed:', url, '→ next…');
       tryLoad(i + 1);
     };
+    console.debug('[CLD defer] trying:', url);
     document.head.appendChild(s);
-    console.debug('[CLD defer] trying URL:', url);
   }
-
   tryLoad(0);
 })();
+


### PR DESCRIPTION
## Summary
- rewrite deferred loader to inject bundle once, log candidate attempts, and signal `cld:bundle:loaded`

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b304daa7cc832886c6e9dd8f565214