### PR TITLE
chore: load cytoscape vendor script in water cld test page

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -249,6 +249,7 @@
       if (window.cy && window.cy.tagName) { window.cy = undefined; }
     } catch (e) {}
   </script>
+  <script defer src="../assets/vendor/cytoscape.min.js"></script>
   <script defer src="../assets/water-cld.defer.js"></script>
   <script>
     document.addEventListener('cld:bundle:loaded', () => {


### PR DESCRIPTION
## Summary
- ensure water CLD test page loads Cytoscape before deferred script

## Testing
- `npm run check:cld-html`
- `npm test` *(fails: TimeoutError waiting for __WATER_CLD_READY__)*

------
https://chatgpt.com/codex/tasks/task_e_68b3bf7356448328bf22d6ec7db6bff5