### PR TITLE
feat: robust map data loading

### DIFF
--- a/docs/assets/css/amaayesh.css
+++ b/docs/assets/css/amaayesh.css
@@ -12,3 +12,5 @@
 .legend-dock .bubble{display:inline-block; border-radius:999px; background:rgba(255,255,255,.15); border:1px solid rgba(255,255,255,.35)}
 .legend-dock .legend-meta{display:flex; justify-content:space-between; margin-top:8px; font-size:12px; opacity:.8}
 .legend-dock .subhead{font-size:12px; opacity:.9; margin:2px 0 6px}
+
+.is-disabled{opacity:.5; pointer-events:none}

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -7,49 +7,61 @@
 
   let searchLayer = L.layerGroup().addTo(map);
 
-  // base path = پوشه‌ای که index.html در آن است
-  const BASE_PATH = (()=>{
+  // کشف base path از مسیر صفحه (مثلاً /amaayesh/ یا /deploy-preview-XXX/amaayesh/)
+  const BASE_PATH = (() => {
     const p = location.pathname;
     return p.endsWith('/') ? p : p.replace(/\/[^\/]*$/, '/');
   })();
-  // ساخت URL دیتا با توجه به BASE_PATH
-  const dataUrl = rel => `${BASE_PATH}data/${rel}`;
 
-  // لودر مقاوم با fallback و هندل خطا
-  async function loadJSON(rel, {fallbacks=[]}={}){
-    const urls = [ dataUrl(rel), ...fallbacks ];
-    for (const u of urls){
-      try{
-        const res = await fetch(u, {cache:'no-cache'});
-        if(res.ok) return await res.json();
-        if(res.status===404) continue;
-      }catch(e){ /* ignore and try next */ }
+  // پاک‌سازی ورودی و ساخت مسیر نهایی: /<base>/data/<rel-clean>
+  function dataUrl(rel) {
+    // حذف هر / اول، و هر data/ اول، و هر ./ اول
+    const clean = String(rel).replace(/^(\/+|\.\/)/, '').replace(/^data\//, '');
+    return `${BASE_PATH}data/${clean}`;
+  }
+
+  // لودر مقاوم با هندل 404 و فهرست fallbackها
+  async function loadJSON(relOrList, { layerKey, fallbacks = [] } = {}) {
+    const rels = Array.isArray(relOrList) ? relOrList : [relOrList];
+    const urls = [...rels.map(dataUrl), ...fallbacks];
+    for (const u of urls) {
+      try {
+        const res = await fetch(u, { cache: 'no-cache' });
+        if (res.ok) return await res.json();
+        if (res.status === 404) continue;
+      } catch (e) { /* try next */ }
     }
-    console.info('Layer not available:', rel);
+    if (layerKey) disableLayerToggle(layerKey);
+    console.info('⛔️ Dataset not found:', rels[0], '→ tried:', urls);
     return null;
   }
-  // ابزار غیرفعال‌کردن سوییچ UI لایه در صورت نبودن دیتا
-  function disableLayerToggle(layerKey){
+
+  function disableLayerToggle(layerKey) {
     const el = document.querySelector(`[data-layer-key="${layerKey}"]`);
-    if(el){ el.disabled = true; el.title = 'داده در این دیپلوی موجود نیست'; el.checked = false; }
+    if (el) {
+      el.disabled = true;
+      el.checked = false;
+      el.title = 'فایل داده در این دیپلوی موجود نیست';
+      el.closest('label')?.classList.add('is-disabled');
+    }
   }
 
   // لایه‌ها در پن‌های جدا برای کنترل z-index
   map.createPane('polygons'); map.createPane('boundary'); map.createPane('points');
 
   (async () => {
-    const cfg = await loadJSON('../layers.config.json', {fallbacks:['layers.config.json']});
+    const cfg = await loadJSON('../layers.config.json');
     const combinedPath = cfg?.baseData?.combined;
 
     if(!combinedPath){ return; }
 
-    const combinedRel = combinedPath.replace(/^\//,'');
-    const combined = await loadJSON(combinedRel.startsWith('data/') ? combinedRel.replace(/^data\//,'') : combinedRel);
+    const combinedRel = combinedPath.replace(/^\//,'').replace(/^data\//,'');
+    const combined = await loadJSON(combinedRel, { layerKey:'province' });
     if(!combined || !Array.isArray(combined.features) || combined.features.length===0){ return; }
 
     const damsPath = cfg?.baseData?.dams;
-    const damsRel = damsPath ? damsPath.replace(/^\//,'') : null;
-    const damsGeojson = damsRel ? await loadJSON(damsRel.startsWith('data/') ? damsRel.replace(/^data\//,'') : damsRel) : null;
+    const damsRel = damsPath ? damsPath.replace(/^\//,'').replace(/^data\//,'') : null;
+    const damsGeojson = damsRel ? await loadJSON(damsRel, { layerKey:'dams' }) : null;
 
     const polys = { type:'FeatureCollection', features:[] }, points = { type:'FeatureCollection', features:[] };
     for(const f of combined.features){
@@ -242,9 +254,9 @@
       'شهرها/نقاط': pointLayer };
     const missing = [];
     for(const th of (cfg?.themes || [])){
-      const rel = th.file.replace(/^\//,'');
-      const j = await loadJSON(rel.startsWith('data/') ? rel.replace(/^data\//,'') : rel);
-      if(!j){ disableLayerToggle(th.key); missing.push(th.title); continue; }
+      const rel = th.file.replace(/^\//,'').replace(/^data\//,'');
+      const j = await loadJSON(rel, { layerKey: th.key });
+      if(!j){ missing.push(th.title); continue; }
       const layer = L.geoJSON(j,{ pane:'polygons', style: th.style || {color:'#ef4444',weight:3} });
       overlays[th.title] = layer; layer.addTo(map);
     }


### PR DESCRIPTION
## Summary
- normalize data paths and use resilient JSON loader with graceful 404 handling
- disable missing layer toggles and add style for disabled state

## Testing
- `npm test` *(fails: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cacf84e48328be153a8c4b6eaea6