### PR TITLE
refactor: load amaayesh data via fallback helper

### DIFF
--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -1,10 +1,9 @@
 {
   "title": "نقشه تعاملی آمایش خراسان رضوی — انرژی",
-  "baseData": { "combined": "/data/amaayesh/khorasan_razavi_combined.geojson" },
   "themes": [
-    { "key":"electricity", "title":"برق", "type":"line", "file":"/data/amaayesh/electricity_lines.geojson", "style":{"color":"#ffd166","weight":3} },
-    { "key":"water",      "title":"آب",   "type":"line", "file":"/data/amaayesh/water_mains.geojson",      "style":{"color":"#118ab2","weight":3} },
-    { "key":"gas",       "title":"گاز",  "type":"line", "file":"/data/amaayesh/gas_transmission.geojson","style":{"color":"#ef476f","weight":4} },
-    { "key":"oil",       "title":"نفت",  "type":"line", "file":"/data/amaayesh/oil_pipelines.geojson",   "style":{"color":"#073b4c","weight":3} }
+    { "key":"electricity", "title":"برق", "type":"line", "file":"amaayesh/electricity_lines.geojson", "style":{"color":"#ffd166","weight":3} },
+    { "key":"water",      "title":"آب",   "type":"line", "file":"amaayesh/water_mains.geojson",      "style":{"color":"#118ab2","weight":3} },
+    { "key":"gas",       "title":"گاز",  "type":"line", "file":"amaayesh/gas_transmission.geojson","style":{"color":"#ef476f","weight":4} },
+    { "key":"oil",       "title":"نفت",  "type":"line", "file":"amaayesh/oil_pipelines.geojson",   "style":{"color":"#073b4c","weight":3} }
   ]
 }

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -61,13 +61,8 @@
 
   (async () => {
     const cfg = await loadJSON('../layers.config.json');
-    const combinedPath = cfg?.baseData?.combined;
-
-    if(!combinedPath){ return; }
-
-    const combinedRel = combinedPath.replace(/^\//,'').replace(/^data\//,'');
-    const combined = await loadJSON(combinedRel, { layerKey:'province' });
-    if(!combined || !Array.isArray(combined.features) || combined.features.length===0){ return; }
+    const combined = await fetchJSONWithFallback('amaayesh/khorasan_razavi_combined.geojson');
+    if(!combined?.features?.length){ return; }
 
     const damsPath = cfg?.baseData?.dams;
     const damsRel = damsPath ? damsPath.replace(/^\//,'').replace(/^data\//,'') : null;


### PR DESCRIPTION
## Summary
- use `fetchJSONWithFallback` for province boundary data
- simplify amaayesh layers config to use data-relative paths

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b66bf5f0708328b8b6214fba254227