### PR TITLE
Add layers manifest validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "node tests/mapper.test.js && node tests/e2e-cld.test.js",
     "flag:test": "node scripts/check-flag.js",
     "check:no-binary": "node tools/check-no-binary.js",
+    "validate:layers": "node tools/validate_layers.js",
     "build:agri": "babel docs/agrivoltaics/app.jsx --presets @babel/preset-react -o docs/agrivoltaics/app.js",
     "prepare:agri": "mkdir -p docs/agrivoltaics/vendor && cp node_modules/react/umd/react.production.min.js docs/agrivoltaics/vendor/ && cp node_modules/react-dom/umd/react-dom.production.min.js docs/agrivoltaics/vendor/ && cp node_modules/qrcode-generator/dist/qrcode.js docs/agrivoltaics/vendor/ && cp node_modules/jspdf/dist/jspdf.umd.min.js docs/agrivoltaics/vendor/",
     "build:cld": "node scripts/build-cld.js",

--- a/tools/validate_layers.js
+++ b/tools/validate_layers.js
@@ -1,0 +1,15 @@
+const fs = require('fs'), path = require('path');
+const root = path.join(__dirname, '..');
+const dataDir = path.join(root, 'docs', 'data');
+const manPath = path.join(dataDir, 'layers.config.json');
+if (!fs.existsSync(manPath)) { console.error('[validate] no layers.config.json'); process.exit(2); }
+const man = JSON.parse(fs.readFileSync(manPath, 'utf-8'));
+const files = man.files || [];
+let missing = [];
+for (const f of files) {
+  const p1 = path.join(dataDir, f);
+  const p2 = path.join(dataDir, 'amaayesh', f);
+  if (!fs.existsSync(p1) && !fs.existsSync(p2)) missing.push(f);
+}
+if (missing.length) { console.error('[validate] missing:', missing); process.exit(2); }
+console.log('[validate] ok:', files.length, 'files');


### PR DESCRIPTION
## Summary
- add validate_layers.js to verify files in docs/data/layers.config.json
- expose npm script `validate:layers`

## Testing
- `npm run validate:layers`
- `npm test` *(fails: Error: Failed to launch the browser process! libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b674512f108328a5e9defce1d92eb3