### PR TITLE
Add Supercluster clustering for wind sites

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -60,6 +60,7 @@
   <script src="../assets/vendor/leaflet/leaflet.js"></script>
   <script src="../assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script src="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
+  <script src="https://unpkg.com/supercluster@7.1.5/dist/supercluster.min.js"></script>
   <script src="../assets/js/amaayesh-map.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Load Supercluster from CDN and integrate clustering for wind site markers
- Build Supercluster index and render clusters when zoomed out
- Sync cluster visibility with zoom level

## Testing
- `npm test` *(fails: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b6779a38948328a7a3dac3bc4d057b