### PR TITLE
Add collapsible infrastructure overlay drawer

### DIFF
--- a/docs/assets/legend.css
+++ b/docs/assets/legend.css
@@ -90,3 +90,6 @@
   #ama-top10 .ama-row:hover { background:#111827; }
 }
 
+.ama-infra .box { background:rgba(255,255,255,.95); padding:8px 10px; margin-top:6px; border-radius:12px; box-shadow:0 6px 24px rgba(0,0,0,.15); direction:rtl; }
+.ama-infra label { display:block; font-size:13px; margin:6px 0; }
+


### PR DESCRIPTION
## Summary
- add a compact "زیرساخت" drawer to toggle electricity, water, gas and oil overlays
- drop infrastructure layers from the default layer switcher and wire gas effects to new control
- style new infra drawer in `legend.css`

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b678fa995083289ce6edfe9b489100