### PR TITLE
fix: enable async data loading for amaayesh map

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -60,6 +60,6 @@
   <script src="../assets/vendor/leaflet/leaflet.js"></script>
   <script src="../assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script src="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
-  <script src="../assets/js/amaayesh-map.js"></script>
+  <script type="module" src="../assets/js/amaayesh-map.js"></script>
 </body>
 </html>

--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -5,5 +5,9 @@
     { "key":"water",      "title":"آب",   "type":"line", "file":"amaayesh/water_mains.geojson",      "style":{"color":"#118ab2","weight":3} },
     { "key":"gas",       "title":"گاز",  "type":"line", "file":"amaayesh/gas_transmission.geojson","style":{"color":"#ef476f","weight":4} },
     { "key":"oil",       "title":"نفت",  "type":"line", "file":"amaayesh/oil_pipelines.geojson",   "style":{"color":"#073b4c","weight":3} }
+  ],
+  "files": [
+    "counties.geojson",
+    "wind_sites.geojson"
   ]
 }

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -1,4 +1,5 @@
-(function(){
+// (IIFE wrapper) — must be async to allow top-level await inside
+(async function(){
   const labelFa = p => (p?.['name:fa'] || p?.['alt_name:fa'] || p?.name || '—');
 
   const map = L.map('map', { preferCanvas:true, zoomControl:true });
@@ -9,14 +10,15 @@
   let boundary;
 
   // === AMAAYESH DATA LOADER (path-robust) ===
-  const AMA_DATA_BASE = "/data/"; // سایتت ریشه‌اش docs/ است، پس /data/ درست است
+  const AMA_DATA_BASE = "/data/";
   async function fetchJSONWithFallback(name) {
     const candidates = [
-      name.startsWith("/") ? name : AMA_DATA_BASE + name,           // ✅ اول از ریشه /data/
-      name,                                                         // هرچه کد قبلی داده (نسبی)
+      name.startsWith("/") ? name : AMA_DATA_BASE + name, // /data/first
+      name,                                               // as given
       "./" + name,
       "../data/" + name,
-      "/amaayesh/data/" + name                                      // آخرین شانس (قدیمی)
+      "/amaayesh/" + name,                                // ✅ manifest or assets under /amaayesh
+      "/amaayesh/data/" + name                            // legacy fallback
     ];
     for (const url of candidates) {
       try {
@@ -39,7 +41,8 @@
   async function loadLayerManifest() {
     __LAYER_MANIFEST = null;
     try {
-      const man = await fetchJSONWithFallback('layers.config.json');
+      // ✅ ابتدا به‌طور صریح مسیر /amaayesh/ را امتحان کن؛ سپس fallbackهای لودر فعال‌اند
+      const man = await fetchJSONWithFallback('amaayesh/layers.config.json');
       if (man && Array.isArray(man.files)) {
         __LAYER_MANIFEST = new Set(man.files);
         console.log('[ama-data] manifest loaded with', __LAYER_MANIFEST.size, 'files');


### PR DESCRIPTION
## Summary
- allow top-level `await` by wrapping amaayesh-map script in an async IIFE
- extend data loader fallbacks to search `/amaayesh/` and explicitly load `/amaayesh/layers.config.json`
- mark amaayesh HTML script as an ES module for future-proof async usage
- ensure file manifest lists available GeoJSON datasets

## Testing
- `rg -n "await" docs/assets/js/amaayesh-map.js`
- `npm test` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b6787c448c8328a8305d4fa64edf50