### PR TITLE
fix: enable async data loading for amaayesh map

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -60,6 +60,7 @@
   <script src="../assets/vendor/leaflet/leaflet.js"></script>
   <script src="../assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script src="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
-  <script src="../assets/js/amaayesh-map.js"></script>
+  <script src="https://unpkg.com/supercluster@7.1.5/dist/supercluster.min.js"></script>
+  <script type="module" src="../assets/js/amaayesh-map.js"></script>
 </body>
 </html>

--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -5,5 +5,9 @@
     { "key":"water",      "title":"آب",   "type":"line", "file":"amaayesh/water_mains.geojson",      "style":{"color":"#118ab2","weight":3} },
     { "key":"gas",       "title":"گاز",  "type":"line", "file":"amaayesh/gas_transmission.geojson","style":{"color":"#ef476f","weight":4} },
     { "key":"oil",       "title":"نفت",  "type":"line", "file":"amaayesh/oil_pipelines.geojson",   "style":{"color":"#073b4c","weight":3} }
+  ],
+  "files": [
+    "counties.geojson",
+    "wind_sites.geojson"
   ]
 }


### PR DESCRIPTION
## Summary
- allow top-level `await` by wrapping amaayesh-map script in an async IIFE
- extend data loader fallbacks to search `/amaayesh/` and explicitly load `/amaayesh/layers.config.json`
- mark amaayesh HTML script as an ES module for future-proof async usage
- ensure file manifest lists available GeoJSON datasets
- load Supercluster CDN before the map script and guard clustering when the library is missing

## Testing
- `rg -n "await" docs/assets/js/amaayesh-map.js`
- `rg -n '<<<<<<< ' || true`
- `rg -n '>>>>>>> ' || true`
- `rg -n '^=======$' || true`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6787c448c8328a8305d4fa64edf50