### PR TITLE
Add fallback for province boundary data path

### DIFF
--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -1,13 +1,4 @@
 {
-  "title": "نقشه تعاملی آمایش خراسان رضوی — انرژی",
-  "themes": [
-    { "key":"electricity", "title":"برق", "type":"line", "file":"amaayesh/electricity_lines.geojson", "style":{"color":"#ffd166","weight":3} },
-    { "key":"water",      "title":"آب",   "type":"line", "file":"amaayesh/water_mains.geojson",      "style":{"color":"#118ab2","weight":3} },
-    { "key":"gas",       "title":"گاز",  "type":"line", "file":"amaayesh/gas_transmission.geojson","style":{"color":"#ef476f","weight":4} },
-    { "key":"oil",       "title":"نفت",  "type":"line", "file":"amaayesh/oil_pipelines.geojson",   "style":{"color":"#073b4c","weight":3} }
-  ],
-  "files": [
-    "counties.geojson",
-    "wind_sites.geojson"
-  ]
+  "title": "مانیفست لایه‌های آمایش — خراسان رضوی",
+  "files": ["data/counties.geojson", "data/wind_sites.geojson"]
 }


### PR DESCRIPTION
## Summary
- replace const with let for combined boundary fetch to allow fallback reassignment
- load layer manifest via absolute `/amaayesh/` path and provide minimal manifest listing required data files
- align manifest layer checks with `data/` paths and use helper for conditional loading

## Testing
- `npm test` *(fails: error while loading shared libraries: libXdamage.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6965e49ac8328a3fbcb3537b7b01d