### PR TITLE
fix: prevent map control overlap

### DIFF
--- a/docs/assets/css/amaayesh.css
+++ b/docs/assets/css/amaayesh.css
@@ -14,3 +14,11 @@
 .legend-dock .subhead{font-size:12px;opacity:.9;margin:2px 0 6px}
 
 .is-disabled{opacity:.5;pointer-events:none}
+
+/* Avoid control overlap: stack with gaps per corner */
+.leaflet-top.leaflet-right,
+.leaflet-top.leaflet-left,
+.leaflet-bottom.leaflet-right,
+.leaflet-bottom.leaflet-left{display:flex;flex-direction:column;gap:10px;align-items:flex-end}
+.leaflet-top.leaflet-left,
+.leaflet-bottom.leaflet-left{align-items:flex-start}

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -24,6 +24,10 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
 
     const map = L.map('map', { preferCanvas:true, zoomControl:true });
     const base = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(map);
+    // move attribution to bottom-left to avoid colliding with legend
+    if (map.attributionControl && typeof map.attributionControl.setPosition === 'function') {
+      map.attributionControl.setPosition('bottomleft');
+    }
     map.setView([36.3, 59.6], 7);
 
     if (window.AMA_DEBUG && map) {
@@ -557,7 +561,7 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
         }
       }
       const overlays = Object.fromEntries(overlayEntries.filter(([_, layer]) => !!layer));
-      L.control.layers({'OpenStreetMap':base}, overlays, {collapsed:false}).addTo(map);
+      L.control.layers({'OpenStreetMap':base}, overlays, { position:'topleft', collapsed:false }).addTo(map);
       L.control.scale({ metric:true, imperial:false }).addTo(map);
 
       if (L.Control && L.Control.geocoder) {


### PR DESCRIPTION
## Summary
- avoid legend collision by moving attribution to bottom-left
- place layer switcher in top-left and stack map controls with CSS gaps

## Testing
- `npm test` *(fails: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b22c8ed083288c4bbbd16bee7626