### PR TITLE
Enhance AMA data debugging and path verification

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -18,6 +18,21 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
   };
 }
 
+window.addEventListener('unhandledrejection', e => {
+  const msg = e?.reason?.message || e?.reason || '';
+  if (/message channel closed/i.test(String(msg))) {
+    console.warn('[ama-ignore-ext]', msg);
+    e.preventDefault();
+  }
+});
+window.addEventListener('error', e => {
+  const msg = e?.message || e?.error?.message || '';
+  if (/message channel closed/i.test(String(msg))) {
+    console.warn('[ama-ignore-ext]', msg);
+    e.preventDefault();
+  }
+});
+
 // (IIFE wrapper) — must be async to allow top-level await inside
 (async function(){
   const labelFa = p => (p?.['name:fa'] || p?.['alt_name:fa'] || p?.name || '—');
@@ -40,6 +55,9 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
   function uniq(arr){ return [...new Set(arr.filter(Boolean))]; }
 
   async function fetchJSONWithFallback(name){
+    if (window.AMA_DEBUG) {
+      console.log('[ama:probe] pathname:', window.location.pathname, 'base:', window.AMA_DATA_BASE, 'name:', name);
+    }
     const isAbs = name.startsWith('/');
     const candidates = uniq([
       isAbs ? name : `/data/${name}`,
@@ -49,18 +67,60 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
       isAbs ? null : `/amaayesh/${name}`,
       isAbs ? null : `/amaayesh/data/${name}`,
     ]);
+    if (window.AMA_DEBUG) {
+      console.table(candidates.map((url, idx) => ({ idx, url })));
+    }
 
     let lastErr;
     for (const url of candidates){
       try{
         const r = await fetch(url, {cache:'no-cache'});
+        if (window.AMA_DEBUG) console.log(`[ama:probe] GET ${url} → ${r.status}`);
         if (r.ok) return await r.json();
-      }catch(e){ lastErr = e; }
+      }catch(e){
+        lastErr = e;
+        if (window.AMA_DEBUG) console.log(`[ama:probe] GET ${url} → err ${e?.message}`);
+      }
     }
-    console.error('[ama-data] failed to load:', name, 'candidates tried:', candidates);
-    if (lastErr) console.error(lastErr);
+    console.warn('[ama-data] failed to load:', name, 'candidates tried:', candidates);
+    if (lastErr) console.warn(lastErr);
     return null;
   }
+
+  window.__inspectDataPath = async function(name){
+    const candidates = uniq([
+      name,
+      '/' + name,
+      `/amaayesh/${name}`,
+      `amaayesh/${name}`,
+      `/data/${name}`,
+      `data/${name}`,
+      `../${name}`,
+      `../../${name}`,
+    ]);
+    const rows = [];
+    for (const url of candidates){
+      let method = 'HEAD';
+      let res = null;
+      try {
+        res = await fetch(url, { method:'HEAD', cache:'no-store' });
+        if (res.status === 405) throw new Error('HEAD not allowed');
+      } catch (_) {
+        method = 'GET';
+        try {
+          res = await fetch(url, { method:'GET', cache:'no-store' });
+        } catch (_) { }
+      }
+      rows.push({
+        url,
+        method,
+        status: res ? res.status : 'ERR',
+        ok: res ? res.ok : false,
+        redirected: res ? res.redirected : false,
+      });
+    }
+    console.table(rows);
+  };
 
   // --- manifest ---
   let __LAYER_MANIFEST = window.__LAYER_MANIFEST = (window.__LAYER_MANIFEST instanceof Set ? window.__LAYER_MANIFEST : new Set());
@@ -95,6 +155,28 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
     }
   }
   await loadLayerManifest();
+
+  window.__dumpAmaState = function(){
+    const manifest = Array.from(window.__LAYER_MANIFEST || []);
+    const scriptEl = document.querySelector('script[type="module"][src*="amaayesh-map"]') || document.currentScript;
+    const scriptSrc = scriptEl ? scriptEl.src : '';
+    const servedFromAma = /\/amaayesh\//.test(new URL(scriptSrc, location.href).pathname);
+    console.group('[ama-dump]');
+    console.log('pathname:', window.location.pathname);
+    console.log('__LAYER_MANIFEST size:', manifest.length);
+    console.log('__LAYER_MANIFEST list:', manifest);
+    console.log('inManifest("data/counties.geojson"):', inManifest('data/counties.geojson'));
+    console.log('inManifest("data/wind_sites.geojson"):', inManifest('data/wind_sites.geojson'));
+    console.log('AMA_DATA_BASE:', window.AMA_DATA_BASE);
+    console.log('script src:', scriptSrc);
+    console.log('served from /amaayesh/?', servedFromAma);
+    console.groupEnd();
+  };
+  if (window.AMA_DEBUG) {
+    window.__dumpAmaState();
+    window.__inspectDataPath('data/counties.geojson');
+    window.__inspectDataPath('data/wind_sites.geojson');
+  }
 
   // load a GeoJSON file only if manifest allows it
   async function optionalGeoJSONFile(file, opts = {}) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "serve-docs": "npx http-server docs -p 5173",
     "build:wind": "python3 tools/build_wind_geojson.py",
     "vendor:supercluster": "node tools/vendorize_supercluster.js",
-    "audit:ama": "node tools/audit_amaayesh.js"
+    "audit:ama": "node tools/audit_amaayesh.js",
+    "verify:publish": "node tools/verify_publish_paths.js"
   },
   "keywords": [],
   "author": "",

--- a/tools/verify_publish_paths.js
+++ b/tools/verify_publish_paths.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const paths = [
+  'docs/amaayesh/layers.config.json',
+  'docs/amaayesh/data/counties.geojson',
+  'docs/amaayesh/data/wind_sites.geojson',
+  'docs/data/amaayesh/khorasan_razavi_combined.geojson'
+];
+
+const rows = paths.map(filePath => {
+  const exists = fs.existsSync(filePath);
+  const size = exists ? fs.statSync(filePath).size : 0;
+  const urlExpected = filePath.startsWith('docs/') ? '/' + filePath.slice(5) : '';
+  return { filePath, exists, size, urlExpected };
+});
+
+console.table(rows);


### PR DESCRIPTION
## Summary
- log and filter extension-related errors in AMA map
- expose `__inspectDataPath` and detailed `fetchJSONWithFallback` probes
- add `__dumpAmaState` and a CLI to verify publish paths

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run verify:publish`


------
https://chatgpt.com/codex/tasks/task_e_68b6b1dccdfc832896f53607bde3fb8c