### PR TITLE
Tone down wind map boundaries and strokes

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -205,7 +205,7 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
     const windLayer = L.geoJSON(polys, {
       pane:'polygons',
       style: f => ({ fillColor: ({1:'#bdbdbd',2:'#f6c945',3:'#29cc7a'})[f.properties.wind_class_num] || '#9e9e9e',
-                      fillOpacity:0.22, color:'rgba(39,48,63,.85)', weight:.8 }),
+                      fillOpacity:0.35, color:'rgba(39,48,63,.4)', weight:.8 }),
       onEachFeature: (f,l)=> l.bindTooltip(labelFa(f.properties), {sticky:true, direction:'auto', className:'label'})
       }).addTo(map);
     windLayer.eachLayer(l=>l.feature.properties.__legend_value = l.feature.properties.wind_class_num);
@@ -230,7 +230,7 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
       tabs.push(damsLegendCfg);
     }
 
-    boundary = L.geoJSON(polys, { pane:'boundary', style:{ color:'#111827', weight:2.4, fill:false } }).addTo(map);
+    boundary = L.geoJSON(polys, { pane:'boundary', style:{ color:'rgba(31,41,55,.6)', weight:1.2, fill:false } }).addTo(map);
     map.fitBounds(boundary.getBounds(), { padding:[12,12] });
 
     // === Province focus & toggle ===
@@ -282,7 +282,7 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
             pane: 'polygons',
             style: f => ({
               fillColor: classColors[ +f.properties?.wind_class ] || '#9e9e9e',
-              fillOpacity: 0.22, color:'rgba(39,48,63,.85)', weight:.8
+              fillOpacity: 0.45, color:'rgba(39,48,63,.4)', weight:.8
             }),
             onEachFeature: (f,l)=> l.bindTooltip(
               (f.properties?.county || f.properties?.name || '—'),
@@ -294,7 +294,7 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
           window.windChoroplethLayer = windChoroplethLayer;
 
           if (boundary) map.removeLayer(boundary);
-          boundary = L.geoJSON(polysFC, { pane:'boundary', style:{ color:'#111827', weight:2.4, fill:false } }).addTo(map);
+          boundary = L.geoJSON(polysFC, { pane:'boundary', style:{ color:'rgba(31,41,55,.6)', weight:1.2, fill:false } }).addTo(map);
           map.fitBounds(boundary.getBounds(), { padding:[12,12] });
           map.setMaxBounds(boundary.getBounds().pad(0.25));
           boundary.setStyle({ className: 'neon-edge' });
@@ -304,14 +304,14 @@ if (window.AMA_DEBUG && typeof window.fetch === 'function') {
             l.on('click', ()=>{
               __focused = l;
               window.windChoroplethLayer.eachLayer(x=>{
-                x.setStyle({ fillOpacity:(x===l?0.35:0.08), color:(x===l?'#22d3ee':'rgba(39,48,63,.4)') });
+                x.setStyle({ fillOpacity:(x===l?0.65:0.08), color:(x===l?'#22d3ee':'rgba(39,48,63,.4)') });
               });
             });
           });
           map.on('click keydown', (e)=>{
             if (e.key && e.key !== 'Escape') return;
             if (__focused){
-              window.windChoroplethLayer.eachLayer(x=> x.setStyle({ fillOpacity:0.22, color:'rgba(39,48,63,.85)' }));
+              window.windChoroplethLayer.eachLayer(x=> x.setStyle({ fillOpacity:0.45, color:'rgba(39,48,63,.4)' }));
               __focused = null;
             }
           });


### PR DESCRIPTION
## Summary
- soften county boundary stroke with lighter color and thinner weight
- lighten wind class polygons, increasing fill opacity and reducing border contrast
- adjust highlight logic for wind choropleth

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b3b10d3c8328872e96fd5978df38