### PR TITLE
Normalize Amaayesh data paths and add publish checks

### DIFF
--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -1,4 +1,4 @@
 {
   "title": "مانیفست لایه‌های آمایش — خراسان رضوی",
-  "files": ["data/counties.geojson", "data/wind_sites.geojson"]
+  "files": ["counties.geojson", "wind_sites.geojson"]
 }

--- a/tools/audit_amaayesh.js
+++ b/tools/audit_amaayesh.js
@@ -12,7 +12,7 @@ const htmlPath     = p.join(root, 'docs/amaayesh/index.html');
 // 1) Manifest
 const manifest = readJSON(manifestPath);
 const files = Array.isArray(manifest?.files) ? manifest.files : [];
-const repoFiles = files.map(f => p.join(root, 'docs/amaayesh', f.replace(/^data\//,'data/')));
+const repoFiles = files.map(f => p.join(root, 'docs/amaayesh', f.includes('/') ? f : `data/${f}`));
 
 // 2) JS references (inManifest('...') و fetch ... .geojson)
 const js = fs.existsSync(jsPath) ? fs.readFileSync(jsPath,'utf8') : '';

--- a/tools/validate_layers.js
+++ b/tools/validate_layers.js
@@ -1,14 +1,18 @@
 const fs = require('fs'), path = require('path');
 const root = path.join(__dirname, '..');
-const dataDir = path.join(root, 'docs', 'data');
+const dataDir = path.join(root, 'docs', 'amaayesh');
 const manPath = path.join(dataDir, 'layers.config.json');
 if (!fs.existsSync(manPath)) { console.error('[validate] no layers.config.json'); process.exit(2); }
 const man = JSON.parse(fs.readFileSync(manPath, 'utf-8'));
 const files = man.files || [];
+
+const withSlash = files.filter(f => f.includes('/'));
+if (withSlash.length) console.warn('[validate] files should be bare names:', withSlash);
+
 let missing = [];
 for (const f of files) {
   const p1 = path.join(dataDir, f);
-  const p2 = path.join(dataDir, 'amaayesh', f);
+  const p2 = path.join(dataDir, 'data', f);
   if (!fs.existsSync(p1) && !fs.existsSync(p2)) missing.push(f);
 }
 if (missing.length) { console.error('[validate] missing:', missing); process.exit(2); }

--- a/tools/verify_publish_paths.js
+++ b/tools/verify_publish_paths.js
@@ -1,16 +1,23 @@
-const fs = require('fs');
 const paths = [
-  'docs/amaayesh/layers.config.json',
-  'docs/amaayesh/data/counties.geojson',
-  'docs/amaayesh/data/wind_sites.geojson',
-  'docs/data/amaayesh/khorasan_razavi_combined.geojson'
+  '/amaayesh/layers.config.json',
+  '/data/amaayesh/counties.geojson',
+  '/data/amaayesh/wind_sites.geojson'
 ];
 
-const rows = paths.map(filePath => {
-  const exists = fs.existsSync(filePath);
-  const size = exists ? fs.statSync(filePath).size : 0;
-  const urlExpected = filePath.startsWith('docs/') ? '/' + filePath.slice(5) : '';
-  return { filePath, exists, size, urlExpected };
-});
+const base = process.env.VERIFY_BASE || 'http://localhost:8888';
 
-console.table(rows);
+async function check(url){
+  const full = base.replace(/\/$/, '') + url;
+  try{
+    const res = await fetch(full, { method:'HEAD' });
+    return { url: full, status: res.status, ok: res.ok };
+  }catch(e){
+    return { url: full, status: 'ERR', ok: false };
+  }
+}
+
+(async () => {
+  const rows = [];
+  for(const p of paths){ rows.push(await check(p)); }
+  console.table(rows);
+})();


### PR DESCRIPTION
## Summary
- make `layers.config.json` list bare filenames and warn on slashes
- centralize data path resolution with normalization, debug-only probes, and manifest-aware fetches
- add publish verifier that HEAD-checks critical Amaayesh assets

## Testing
- ❌ `npm test` (missing libatk-1.0.so.0)
- ✅ `npm run validate:layers`
- ⚠️ `npm run verify:publish` (ERR for localhost paths)
- ✅ `npm run audit:ama`


------
https://chatgpt.com/codex/tasks/task_e_68b6bd1c72a08328ab2f3a101f45bd09