### PR TITLE
feat: add custom layers dock

### DIFF
--- a/docs/assets/css/amaayesh.css
+++ b/docs/assets/css/amaayesh.css
@@ -24,6 +24,16 @@
 
 .is-disabled{opacity:.5;pointer-events:none}
 
+/* === Layers Dock === */
+.layers-dock{background:rgba(10,15,28,.88);color:#fff;padding:12px;border-radius:14px;box-shadow:0 2px 8px rgba(0,0,0,.2);max-width:320px;font-size:14px}
+.layers-dock .ld-tabs{display:flex;gap:6px}
+.layers-dock .ld-tabs button{flex:1;background:#0b1220;color:#e5e7eb;border:1px solid #324155;border-radius:10px;padding:6px 10px;cursor:pointer}
+.layers-dock .ld-tabs button.active{background:#0ea5e9;color:#04121f;border-color:#0ea5e9}
+.layers-dock .ld-body{margin-top:8px}
+.layers-dock .ld-pane label{display:flex;align-items:center;gap:8px;padding:8px;border-radius:8px;cursor:pointer;min-height:44px}
+.layers-dock .ld-pane label:hover{background:rgba(255,255,255,.06)}
+.layers-dock .ld-pane label.is-disabled{cursor:not-allowed;pointer-events:auto}
+
 /* Avoid control overlap: stack with gaps per corner */
 .leaflet-top.leaflet-right,
 .leaflet-top.leaflet-left,


### PR DESCRIPTION
## Summary
- replace default Leaflet layers control with custom tabbed LayersDock
- style LayersDock with card UI and RTL tabbed layout

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f191320083288b2ad033fc9e35b6