### PR TITLE
feat: add map reset control

### DIFF
--- a/docs/assets/css/amaayesh.css
+++ b/docs/assets/css/amaayesh.css
@@ -9,6 +9,7 @@
 .legend-dock ul.swatches{list-style:none;margin:0;padding:0}
 .legend-dock ul.swatches li{display:flex;align-items:center;gap:8px;padding:6px;border-radius:8px;cursor:pointer}
 .legend-dock ul.swatches li:hover{background:rgba(255,255,255,.06)}
+.legend-dock ul.swatches li.active{background:rgba(255,255,255,.12)}
 .legend-dock .sw{width:28px;height:14px;border-radius:4px;display:inline-block;border:1px solid rgba(255,255,255,.25)}
 .legend-dock .bubbles{display:grid;grid-template-columns:auto 1fr;gap:10px;align-items:center;margin-top:6px}
 .legend-dock .bubble{display:inline-block;border-radius:999px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.35)}
@@ -68,3 +69,7 @@
 .ama-suggestions{position:absolute;right:0;left:0;top:100%;background:#fff;color:#111;max-height:200px;overflow:auto;border:1px solid #ccc;border-top:none;z-index:1002;}
 .ama-suggestions div{padding:6px;cursor:pointer;}
 .ama-suggestions div.active,.ama-suggestions div:hover{background:#e5e7eb;}
+
+/* === Reset control === */
+.ama-reset{background:rgba(10,15,28,.88);color:#e5e7eb;border:1px solid #324155;border-radius:8px;box-shadow:0 2px 8px rgba(0,0,0,.2);cursor:pointer;height:44px;padding:0 10px;margin:4px;display:flex;align-items:center;justify-content:center;}
+.ama-reset:hover{background:#0ea5e9;color:#04121f;border-color:#0ea5e9}


### PR DESCRIPTION
## Summary
- add reset control to return viewport and layers to defaults
- expose legend.reset() to clear swatch filters
- style reset button and active legend swatches

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f2f867708328a68676eebe0a6a93