### PR TITLE
refactor: rebuild wind weights

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "doc": "docs"
   },
   "scripts": {
-    "prebuild": "node tools/build-wind-weights.mjs",
+    "build:wind-weights": "node tools/build-wind-weights.mjs",
+    "prebuild": "npm run build:wind-weights",
     "build:css": "tailwindcss -i docs/assets/tailwind.input.css -o docs/assets/tailwind.css --minify",
     "build": "npm run build:css && npm run build:agri && npm run prepare:agri",
     "test": "node tests/mapper.test.js && node tests/e2e-cld.test.js",

--- a/tools/build-wind-weights.mjs
+++ b/tools/build-wind-weights.mjs
@@ -1,4 +1,4 @@
-import { readFile, writeFile, copyFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, copyFile } from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -14,8 +14,8 @@ function toEnDigits(s = '') {
     .replace(/[\u06F0-\u06F9]/g, d => String(d.charCodeAt(0) - 0x06f0))
     .replace(/[\u0660-\u0669]/g, d => String(d.charCodeAt(0) - 0x0660))
     .replace(/\u066B/g, '.')
-    .replace(/[\u066C\u060C]/g, '')
-    .replace(/\s+/g, ' ');
+    .replace(/[\u060C\u066C]/g, '')
+    .replace(/\s+/g, '');
 }
 
 function normalizeFa(s = '') {
@@ -27,31 +27,31 @@ function normalizeFa(s = '') {
     .trim();
 }
 
-function parseNumber(s) {
+function parseNum(s) {
   if (s == null) return null;
-  const t = toEnDigits(String(s)).replace(/[,\s]/g, '');
+  const t = toEnDigits(String(s));
   if (t === '') return null;
-  const n = parseFloat(t);
+  const n = Number(t);
   return Number.isNaN(n) ? null : n;
 }
 
 function parseClasses(text = '', defaultN = 0) {
   const res = { c1: 0, c2: 0, c3: 0 };
   if (!text) return res;
-  const clean = normalizeFa(toEnDigits(text.replace(/<br\s*\/?>/gi, '\n')));
-  const parts = clean.split(/\n|,|؛/).map(p => p.trim()).filter(Boolean);
+  const normalized = normalizeFa(text.replace(/<br\s*\/?>/gi, '\n'));
+  const parts = normalized.split(/\n|,|؛/).map(p => toEnDigits(p.trim())).filter(Boolean);
   for (const part of parts) {
-    let m = part.match(/(\d+)\s*سایت\s*کلاس\s*(\d)/);
+    let m = part.match(/(\d+)سایتکلاس(\d)/);
     if (m) {
-      const cls = Number(m[2]);
       const cnt = Number(m[1]);
+      const cls = Number(m[2]);
       if (cls >= 1 && cls <= 3) res[`c${cls}`] += cnt;
       continue;
     }
-    m = part.match(/کلاس\s*(\d)/);
+    m = part.match(/کلاس(\d)/);
     if (m) {
       const cls = Number(m[1]);
-      const cnt = defaultN || 1;
+      const cnt = defaultN || 0;
       if (cls >= 1 && cls <= 3) res[`c${cls}`] += cnt;
     }
   }
@@ -100,7 +100,7 @@ function csvParse(text) {
   return { headers, rows };
 }
 
-function indexOfHeader(headers, aliases) {
+function findIndex(headers, aliases) {
   const normHeaders = headers.map(h => normalizeFa(h).replace(/\s+/g, '').toLowerCase());
   for (const alias of aliases) {
     const normAlias = normalizeFa(alias).replace(/\s+/g, '').toLowerCase();
@@ -111,56 +111,54 @@ function indexOfHeader(headers, aliases) {
 }
 
 async function main() {
-  const t8Text = stripBOM(await readFile(path.join(root, 'data', 'table8_counties.csv'), 'utf8'));
-  const rawText = stripBOM(await readFile(path.join(root, 'data', 'wind_sites_raw.csv'), 'utf8'));
+  const tablePath = path.join(root, 'data', 'table8_counties.csv');
+  const rawPath = path.join(root, 'data', 'wind_sites_raw.csv');
+  const t8Text = stripBOM(await readFile(tablePath, 'utf8'));
+  const rawText = stripBOM(await readFile(rawPath, 'utf8'));
 
   const t8 = csvParse(t8Text);
   const raw = csvParse(rawText);
 
   const aliases = {
-    county: ['county', 'شهرستان', 'name_std', 'name_fa'],
-    nSites: ['n_sites', 'sites_count', 'تعداد سایت', 'تعدادسایت'],
-    areaHa: ['site_area_ha', 'area_ha', 'مساحت سایت (هکتار)', 'مساحت سایت', 'مساحت(هکتار)'],
-    capMw: ['capacity_mw', 'ظرفیت تخمینی انرژی بادی (مگاوات)', 'ظرفیت (مگاوات)', 'ظرفیت'],
-    classes: ['کلاس بادی', 'classes', 'ترکیب کلاس', 'wind_class']
+    county: ['county', 'شهرستان', 'name_fa', 'name_std', 'دستگاه پیشنهادی'],
+    n_sites: ['n_sites', 'sites_count', 'تعداد سایت', 'تعدادسایت', 'تعداد‌سایت'],
+    area_ha: ['site_area_ha', 'area_ha', 'مساحت سایت (هکتار)', 'مساحت سایت', 'مساحت‌سایت (هکتار)'],
+    cap_mw: ['capacity_mw', 'ظرفیت تخمینی انرژی بادی (مگاوات)', 'ظرفیت (مگاوات)', 'ظرفیت'],
+    classes: ['کلاس بادی', 'classes', 'ترکیب کلاس']
   };
 
-  const idxCounty = indexOfHeader(t8.headers, aliases.county);
-  const idxNSites = indexOfHeader(t8.headers, aliases.nSites);
-  const idxAreaHa = indexOfHeader(t8.headers, aliases.areaHa);
-  const idxCapMw = indexOfHeader(t8.headers, aliases.capMw);
-  const idxClasses = indexOfHeader(t8.headers, aliases.classes);
+  const idx = {
+    county: findIndex(t8.headers, aliases.county),
+    n_sites: findIndex(t8.headers, aliases.n_sites),
+    area_ha: findIndex(t8.headers, aliases.area_ha),
+    cap_mw: findIndex(t8.headers, aliases.cap_mw),
+    classes: findIndex(t8.headers, aliases.classes)
+  };
 
-  if ([idxCounty, idxNSites, idxAreaHa, idxCapMw, idxClasses].some(i => i < 0)) {
-    throw new Error('Required columns not found in table8_counties.csv');
-  }
-
-  const idxRawCounty = indexOfHeader(raw.headers, aliases.county);
-  if (idxRawCounty < 0) throw new Error('county column not found in wind_sites_raw.csv');
-
-  const countByCounty = {};
-  for (const r of raw.rows) {
-    const c = normalizeFa(r[idxRawCounty] || '');
-    if (!c) continue;
-    countByCounty[c] = (countByCounty[c] || 0) + 1;
+  const idxRawCounty = findIndex(raw.headers, aliases.county);
+  const countSitesByCounty = {};
+  if (idxRawCounty >= 0) {
+    for (const r of raw.rows) {
+      const c = normalizeFa(r[idxRawCounty] || '');
+      if (!c) continue;
+      countSitesByCounty[c] = (countSitesByCounty[c] || 0) + 1;
+    }
   }
 
   const rows = [];
   for (const cols of t8.rows) {
-    if (!cols || cols.every(c => !c)) continue;
-    const county = normalizeFa(cols[idxCounty] || '');
-    if (!county) continue;
-    const nSitesRaw = parseNumber(cols[idxNSites]);
-    let n_sites = nSitesRaw != null ? Math.round(nSitesRaw) : null;
-    const site_area_ha = parseNumber(cols[idxAreaHa]);
-    const capacity_mw = parseNumber(cols[idxCapMw]);
-    const cls = parseClasses(cols[idxClasses] || '', n_sites || 0);
-    const sumCls = cls.c1 + cls.c2 + cls.c3;
-    if ((n_sites == null || Number.isNaN(n_sites)) && sumCls > 0) n_sites = sumCls;
-    if (n_sites == null) n_sites = 0;
+    if (!cols || cols.every(c => !c || String(c).trim() === '')) continue;
+    const county = normalizeFa(cols[idx.county] || '');
+    if (!county || county === 'مجموع' || county.includes('مجموع')) continue;
+    const nSitesRaw = idx.n_sites >= 0 ? parseNum(cols[idx.n_sites]) : null;
+    const cls = parseClasses(idx.classes >= 0 ? cols[idx.classes] : '', nSitesRaw || 0);
+    let n_sites = nSitesRaw != null ? Math.round(nSitesRaw) : cls.c1 + cls.c2 + cls.c3;
+    if (!n_sites) n_sites = 0;
+    const site_area_ha = idx.area_ha >= 0 ? parseNum(cols[idx.area_ha]) : null;
+    const capacity_mw = idx.cap_mw >= 0 ? parseNum(cols[idx.cap_mw]) : null;
     const suitability_avg = n_sites > 0 ? (cls.c1 * 1 + cls.c2 * 0.8 + cls.c3 * 0.6) / n_sites : 0;
     const cap_per_site = capacity_mw != null && n_sites > 0 ? capacity_mw / n_sites : null;
-    const mw_per_ha = capacity_mw != null && site_area_ha > 0 ? capacity_mw / site_area_ha : null;
+    const mw_per_ha = capacity_mw != null && site_area_ha ? capacity_mw / site_area_ha : null;
     rows.push({
       county,
       n_sites,
@@ -175,57 +173,86 @@ async function main() {
     });
   }
 
+  if (process.env.AMA_CI_DEBUG === '1') {
+    console.log('headers', idx);
+    console.log('sample', rows.slice(0, 2).map(r => ({ county: r.county, n_sites: r.n_sites, capacity_mw: r.capacity_mw })));
+  }
+
   if (rows.length === 0) throw new Error('No rows parsed from table8_counties.csv');
 
-  let empty = 0;
-  for (const row of rows) {
-    const rawCount = countByCounty[row.county] || 0;
-    if (Math.abs(rawCount - row.n_sites) > 1) {
-      console.warn(`WARN ${row.county}: table8=${row.n_sites} raw=${rawCount}`);
+  let emptyCount = 0;
+  for (const r of rows) {
+    const rawCount = countSitesByCounty[r.county] || 0;
+    if (Math.abs(rawCount - r.n_sites) > 1) {
+      console.warn(`WARN ${r.county}: table8=${r.n_sites} raw=${rawCount}`);
     }
-    if (row.n_sites === 0 && row.capacity_mw == null) empty++;
+    if (r.n_sites === 0 && r.capacity_mw == null) emptyCount++;
   }
-  if (empty / rows.length > 0.8) {
-    throw new Error('Input columns not detected; check headers/encoding.');
+  if (emptyCount / rows.length > 0.8) {
+    throw new Error('Header aliasing failed; check input headers/encoding.');
   }
 
   const capVals = rows.map(r => r.capacity_mw).filter(v => v != null);
-  const mwhaVals = rows.map(r => r.mw_per_ha).filter(v => v != null);
-  const capMin = Math.min(...capVals);
-  const capMax = Math.max(...capVals);
-  const mwhaMin = Math.min(...mwhaVals);
-  const mwhaMax = Math.max(...mwhaVals);
+  const capMin = capVals.length ? Math.min(...capVals) : 0;
+  const capMax = capVals.length ? Math.max(...capVals) : 0;
   const capRange = capMax - capMin;
+
+  const mwhaVals = rows.map(r => r.mw_per_ha).filter(v => v != null);
+  const mwhaMin = mwhaVals.length ? Math.min(...mwhaVals) : 0;
+  const mwhaMax = mwhaVals.length ? Math.max(...mwhaVals) : 0;
   const mwhaRange = mwhaMax - mwhaMin;
 
   for (const r of rows) {
     r.cap_norm = r.capacity_mw != null && capRange > 0 ? (r.capacity_mw - capMin) / capRange : 0;
     r.mwha_norm = r.mw_per_ha != null && mwhaRange > 0 ? (r.mw_per_ha - mwhaMin) / mwhaRange : 0;
-    r.w_avg = 0.6 * r.cap_norm + 0.3 * r.suitability_avg + 0.1 * r.mwha_norm;
+    r.w_avg = 0.6 * (r.cap_norm || 0) + 0.3 * (r.suitability_avg || 0) + 0.1 * (r.mwha_norm || 0);
     r.sum_w = r.w_avg * r.n_sites;
   }
 
-  if (rows.some(r => r.capacity_mw != null) && rows.every(r => r.w_avg === 0)) {
-    throw new Error('Normalization failed. Check decimal normalization.');
+  if (capVals.length && rows.every(r => r.w_avg === 0)) {
+    throw new Error('Normalization failed; check Persian digit/decimal parsing.');
+  }
+
+  const checks = {
+    'خواف': { w_avg: 0.8842, sum_w: 8.8420, n_sites: 10 },
+    'زیرنجفام': { w_avg: 0.7315, sum_w: 2.9260, n_sites: 4 },
+    'تایباد': { w_avg: 0.4492, sum_w: 1.3475, n_sites: 3 },
+    'مشهد': { w_avg: 0.4211, sum_w: 0.4211, n_sites: 1 },
+    'زاوه': { w_avg: 0.2400, sum_w: 0.4800, n_sites: 2 }
+  };
+  for (const [name, exp] of Object.entries(checks)) {
+    const normName = normalizeFa(name);
+    const r = rows.find(rr => rr.county === normName);
+    if (!r) {
+      console.warn(`WARN missing regression county ${name}`);
+      continue;
+    }
+    const wDiff = Math.abs(r.w_avg - exp.w_avg);
+    const sDiff = Math.abs(r.sum_w - exp.sum_w);
+    if (r.n_sites !== exp.n_sites || wDiff > 0.05 || sDiff > 0.05) {
+      throw new Error(`Regression failed for ${name}: expected n_sites=${exp.n_sites}, w_avg≈${exp.w_avg}, sum_w≈${exp.sum_w}; got n_sites=${r.n_sites}, w_avg=${r.w_avg.toFixed(4)}, sum_w=${r.sum_w.toFixed(4)}`);
+    } else if (wDiff > 0.02 || sDiff > 0.02) {
+      console.warn(`WARN regression drift for ${name}: w_avg diff=${wDiff.toFixed(4)}, sum_w diff=${sDiff.toFixed(4)}`);
+    }
   }
 
   const outDir = path.join(root, 'docs', 'amaayesh', 'data');
   await mkdir(outDir, { recursive: true });
 
-  const fmt = v => (v == null ? '' : String(Math.round(v * 1e4) / 1e4));
-  const fmt4 = v => (v == null ? '' : (Math.round(v * 1e4) / 1e4).toFixed(4));
+  const fmtInt = n => (n == null ? '' : String(Math.round(n)));
+  const fmt4 = n => (n == null ? '' : (Math.round(n * 1e4) / 1e4).toFixed(4));
 
   const header = 'county,n_sites,class1,class2,class3,site_area_ha,capacity_mw,cap_per_site,mw_per_ha,suitability_avg,cap_norm,mwha_norm,w_avg,sum_w';
   const lines = [header];
   for (const r of rows) {
     lines.push([
       r.county,
-      r.n_sites,
-      r.class1,
-      r.class2,
-      r.class3,
-      fmt(r.site_area_ha),
-      fmt(r.capacity_mw),
+      fmtInt(r.n_sites),
+      fmtInt(r.class1),
+      fmtInt(r.class2),
+      fmtInt(r.class3),
+      fmt4(r.site_area_ha),
+      fmt4(r.capacity_mw),
       fmt4(r.cap_per_site),
       fmt4(r.mw_per_ha),
       fmt4(r.suitability_avg),
@@ -236,10 +263,11 @@ async function main() {
     ].join(','));
   }
   lines.push('');
-  await writeFile(path.join(outDir, 'wind_weights_by_county.csv'), lines.join('\n'), 'utf8');
-  await copyFile(path.join(root, 'data', 'wind_sites_raw.csv'), path.join(outDir, 'wind_sites_raw.csv'));
 
-  console.log(`wind_weights_by_county.csv: ${rows.length} rows \u2713  (copied wind_sites_raw.csv)`);
+  await writeFile(path.join(outDir, 'wind_weights_by_county.csv'), lines.join('\n'), 'utf8');
+  await copyFile(rawPath, path.join(outDir, 'wind_sites_raw.csv'));
+
+  console.log(`wind_weights_by_county.csv: ${rows.length} rows ✓  | with weights: ${rows.filter(r => r.w_avg > 0).length} rows`);
 }
 
 main().catch(err => {


### PR DESCRIPTION
## Summary
- expand header aliases and add totals-row skip in wind weight builder
- normalize Persian numerals and expose debug header/row dumps

## Testing
- `npm run build` *(fails: Regression failed for خواف: expected n_sites=10, w_avg≈0.8842, sum_w≈8.842; got n_sites=2, w_avg=0.1000, sum_w=0.2000)*
- `npm test` *(fails: Error: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b70f69b58c83289b57408b324e296e