### PR TITLE
feat: add tool dock control

### DIFF
--- a/docs/assets/css/amaayesh.css
+++ b/docs/assets/css/amaayesh.css
@@ -95,3 +95,8 @@
 
 /* site labels */
 .site-label{background:transparent;border:none;color:#e5e7eb;font-size:12px;text-shadow:0 0 2px #000;}
+
+.ama-dock { display:flex; flex-direction:column; gap:8px; background:#0b1220cc; padding:10px; border-radius:14px; box-shadow:0 8px 24px rgba(0,0,0,.25); }
+.ama-dock .btn { width:44px; height:44px; border-radius:10px; background:#111827; color:#e5e7eb; border:1px solid #374151; font-size:18px; display:grid; place-items:center; cursor:pointer; }
+.ama-dock .btn:hover { background:#1f2937; }
+.ama-dock .btn:active { transform: translateY(1px); }

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -179,6 +179,33 @@ window.addEventListener('error', e => {
     }
     map.setView([36.3, 59.6], 7);
 
+    const ToolDock = L.Control.extend({
+      options:{ position:'topleft' },
+      onAdd: function(){
+        const c = L.DomUtil.create('div','ama-dock');
+        c.innerHTML = `
+        <button class="btn" aria-label="لایه‌ها"    data-act="layers">🗂</button>
+        <button class="btn" aria-label="ابزارها"    data-act="tools">🛠</button>
+        <button class="btn" aria-label="جستجو"     data-act="search">🔎</button>
+        <button class="btn" aria-label="دانلود"    data-act="download">⬇️</button>
+        <button class="btn" aria-label="بازنشانی"  data-act="reset">↺</button>
+        `;
+        // stop map drag
+        L.DomEvent.disableClickPropagation(c); L.DomEvent.disableScrollPropagation(c);
+        // temp handlers
+        c.addEventListener('click',(e)=>{
+          const b = e.target.closest('button'); if(!b) return;
+          const act = b.dataset.act;
+          if(act==='reset' && window.__countiesLayer && window.__mapBounds){ map.fitBounds(window.__mapBounds); }
+          if(window.AMA_DEBUG) console.info('[dock]', act);
+        });
+        return c;
+      }
+    });
+    // remember map bounds once (to use with reset)
+    if(!window.__mapBounds) setTimeout(()=>{ try{ window.__mapBounds = map.getBounds(); }catch{} }, 500);
+    map.addControl(new ToolDock());
+
     if (window.AMA_DEBUG && map) {
       map.on('zoomend', () => console.log('[ama:event] zoomend =>', map.getZoom()));
       map.on('moveend', () => console.log('[ama:event] moveend =>', map.getCenter()));


### PR DESCRIPTION
## Summary
- add custom ToolDock control with layers, tools, search, download, and reset actions
- style dock with dark vertical layout and interactive button states

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b727ac21b48328a7357cbab4b75b0c