### PR TITLE
feat: lazy load vendor scripts

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -35,7 +35,6 @@
   <script src="../assets/vendor/leaflet/leaflet.js"></script>
   <script src="../assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script src="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
-  <script src="../assets/vendor/supercluster/supercluster.min.js"></script>
   <script type="module" src="../assets/js/amaayesh-map.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- avoid 404s by dropping static supercluster vendor reference
- add helper to optionally load vendor scripts at runtime
- lazily request supercluster when wind sites are shown

## Testing
- `npm test` *(fails: error while loading shared libraries: libXdamage.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68b7cd733ba88328aee1d7c5e6c9316f