### PR TITLE
refactor: centralize data fetch resolution

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -35,34 +35,31 @@ function normalizeFaName(s){
     .replace(/\s+/g,' ').trim();
 }
 const keyOf = s => normalizeFaName(s).replace(/\s+/g,'');
-function dataBases() {
-  // بدون 'amaayesh/data/' نسبی تا دوبل نشود
+function dataBases(){
   const here = new URL(location.href);
-  return [
-    new URL('./data/', here).pathname,      // ./data/
-    new URL('data/', here).pathname,        // data/
-    '/amaayesh/data/',                       // abs
-    '/data/amaayesh/'                        // abs legacy
+  // ترتیب مناسب Netlify (Publish=docs). بدون تکرار amaayesh/amaayesh
+  const cand = [
+    new URL('./data/', here).pathname,  // ./data/
+    new URL('data/',  here).pathname,   // data/
+    '/amaayesh/data/',                  // abs
+    '/data/amaayesh/'                   // abs legacy
   ];
+  // de-dupe while keeping order
+  return [...new Set(cand)];
 }
-async function resolveDataUrl(file) {
+async function resolveDataUrl(file){
   const qs = `?v=${window.__AMA_BUILD_ID}`;
-  for (const b of dataBases()) {
+  for(const b of dataBases()){
     const url = b + file + qs;
-    try {
-      const r = await fetch(url, { method:'GET', cache:'no-store' });
-      if (r.ok) {
-        (window.__AMA_RESOLVED ||= {})[file] = url;
-        if (window.AMA_DEBUG) console.info('[resolve]', file, '→', url);
-        return url;
-      }
+    try { const r = await fetch(url, {method:'GET', cache:'no-store'});
+      if (r.ok) { (window.__AMA_RESOLVED ||= {})[file]=url; if(AMA_DEBUG) console.info('[resolve]',file,'→',url); return url; }
     } catch {}
   }
-  if (window.AMA_DEBUG) console.warn('[resolve] NOT FOUND:', file);
+  if (AMA_DEBUG) console.warn('[resolve] NOT FOUND:', file);
   return null;
 }
-async function fetchJSONResolved(file) { const u = await resolveDataUrl(file); if(!u) return null; const r = await fetch(u,{cache:'no-store'}); return r.ok ? r.json() : null; }
-async function fetchCSVResolved (file) { const u = await resolveDataUrl(file); if(!u) return null; const r = await fetch(u,{cache:'no-store'}); return r.ok ? r.text() : null; }
+async function fetchJSONResolved(f){ const u=await resolveDataUrl(f); if(!u) return null; const r=await fetch(u,{cache:'no-store'}); return r.ok? r.json(): null; }
+async function fetchCSVResolved (f){ const u=await resolveDataUrl(f); if(!u) return null; const r=await fetch(u,{cache:'no-store'}); return r.ok? r.text(): null; }
 
 // ===== ارجاع پیش‌فرض برای فایل‌ها وقتی manifest نیست =====
 const DEFAULT_FILES = {


### PR DESCRIPTION
## Summary
- de-dupe candidate data base paths and log resolution with `AMA_DEBUG`
- replace hardcoded water-cld worker fetch with `fetchJSONResolved`

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68b7d7531a2883289f85e33f097252b0