### PR TITLE
fix: skip falsy names in dataset fallback resolution

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -69,10 +69,12 @@ const DEFAULT_FILES = {
 };
 
 // یک کمک‌تابع fallback برای داده‌های مهم:
+// attempt to resolve the first available dataset name; skips falsy entries
 async function resolveWithFallback(nameList){
-  for(const name of nameList){
+  for (const name of nameList) {
+    if (!name) continue; // allow callers to pass conditional names
     const u = await resolveDataUrl(name);
-    if(u) return u;
+    if (u) return u;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- ignore falsy entries when resolving dataset fallback lists to avoid erroneous fetch attempts

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68b7da57f7608328859e9a15a0b85b27