### PR TITLE
feat: gate supercluster vendor and robust manifest loader

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -6,7 +6,8 @@
   <title>نقشه آمایش انرژی — خراسان رضوی | WESH360</title>
   <link rel="icon" href="../page/landing/favicon.ico"/>
   <link rel="stylesheet" href="../assets/tailwind.css"/>
-  <link rel="stylesheet" href="../assets/vendor/leaflet/leaflet.css"/>
+  <link rel="stylesheet" href="../assets/vendor/leaflet/leaflet.css" />
+  <link rel="stylesheet" href="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.css" />
   <link rel="stylesheet" href="../assets/legend.css"/>
   <style>
     html, body { height:100% }
@@ -31,10 +32,10 @@
 
   <footer class="mt-6 py-6 text-center text-slate-400 text-xs">WESH360 • Energy Spatial Planning • Leaflet</footer>
 
-  <link rel="stylesheet" href="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.css"/>
-  <script src="../assets/vendor/leaflet/leaflet.js"></script>
-  <script src="../assets/vendor/leaflet.polylineDecorator.min.js"></script>
-  <script src="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
+  <script defer src="../assets/vendor/leaflet/leaflet.js"></script>
+  <script defer src="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
+  <script defer src="../assets/vendor/leaflet.polylineDecorator.min.js"></script>
+  <!-- supercluster optional (CDN removed due to CSP). Use local vendor if added. -->
   <script type="module" src="../assets/js/amaayesh-map.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove supercluster CDN in favor of local/optional vendor
- gate clustering behind feature detection with graceful fallback
- probe data manifest bases until a 200 response is found

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b7eaae01f88328bb4023b5082bd350