### PR TITLE
fix: stabilize amaayesh map data source and no-data handling

### DIFF
--- a/docs/amaayesh/data/README.md
+++ b/docs/amaayesh/data/README.md
@@ -1,0 +1,1 @@
+Deprecated. Do not use. Source of Truth: docs/data/amaayesh/


### PR DESCRIPTION
## Summary
- unify layer manifest to use docs/data and expose debug hooks
- normalize Persian county names for joins, filters, and search
- treat zero KPI counties as no-data and color gray
- render zero KPI values with light bucket styling instead of "No Data"
- harden self-check and dumpAmaState diagnostics to handle missing layers and show manifest details

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run validate:layers`


------
https://chatgpt.com/codex/tasks/task_e_68b8566fee9483288822574234318907