### PR TITLE
fix: stabilize amaayesh map data source and no-data handling

### DIFF
--- a/docs/amaayesh/data/README.md
+++ b/docs/amaayesh/data/README.md
@@ -1,0 +1,1 @@
+Deprecated. Do not use. Source of Truth: docs/data/amaayesh/


### PR DESCRIPTION
## Summary
- expose wind weight index as `__AMA_windIdx` and add richer self-check diagnostics
- load county polygons from `khorasan_razavi_combined.geojson` (admin_level=6) with cleaned `county` names, ignoring district-level data
- standardize county joins and lookups on `properties.county`

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run validate:layers`


------
https://chatgpt.com/codex/tasks/task_e_68b8566fee9483288822574234318907