### PR TITLE
fix: stabilize amaayesh map data source and no-data handling

### DIFF
--- a/docs/amaayesh/data/README.md
+++ b/docs/amaayesh/data/README.md
@@ -1,0 +1,1 @@
+Deprecated. Do not use. Source of Truth: docs/data/amaayesh/

--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -1,4 +1,4 @@
 {
   "title": "مانیفست لایه‌های آمایش — خراسان رضوی",
-  "files": ["counties.geojson", "wind_sites.geojson"]
+  "files": ["counties.geojson", "wind_sites.geojson", "khorasan_razavi_combined.geojson"]
 }

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -3,7 +3,7 @@ window.__AMA_BUILD_ID = document.querySelector('meta[name="build-id"]')?.content
 
 ;(function(){
   window.__AMA_UI_VERSION = 'dock-probe-v1';
-  console.info('[AMA:UI]', window.__AMA_UI_VERSION, 'build=', window.__AMA_BUILD_ID, 'path=', location.pathname);
+  console.log('[AMA:UI]', window.__AMA_UI_VERSION, 'build=', window.__AMA_BUILD_ID, 'path=', location.pathname);
   // tiny top-left badge for visual confirmation (removable later)
   try {
     const el = document.createElement('div');
@@ -25,14 +25,51 @@ window.legendCtl = window.legendCtl || null;
 window.renderLegend = window.renderLegend || function(){};
 window.__AMA_renderTop10 = window.__AMA_renderTop10 || function(){};
 
+function keyOf(s=''){
+  return String(s)
+    .replace(/\u200c/g,'')
+    .replace(/[ي]/g,'ی')
+    .replace(/[ك]/g,'ک')
+    .replace(/\s+/g,' ')
+    .trim()
+    .toLowerCase();
+}
+const sameCounty = (a,b)=> keyOf(a) === keyOf(b);
 function normalizeFaName(s){
   if(!s) return '';
-  return String(s).replace(/\u200c/g,' ')
-    .replace(/ي/g,'ی').replace(/ك/g,'ک')
-    .replace(/[^\p{L}\p{N}\s]/gu,'')
-    .replace(/\s+/g,' ').trim();
+  return keyOf(s);
 }
-const keyOf = s => normalizeFaName(s).replace(/\s+/g,'');
+// alias map for common Persian variations / city-to-county mappings (extendable)
+const __AMA_ALIAS = {
+  // spacing / ZWNJ / spelling
+  'مهولات': 'مه ولات',
+  'مه‌ولات': 'مه ولات',
+  'تربتجام': 'تربت جام',
+  'تربت‌جام': 'تربت جام',
+  'طرقبه شاندیز': 'طرقبه و شاندیز',
+  'طرقبه‌ شاندیز': 'طرقبه و شاندیز',
+  // capitals occasionally used instead of county name
+  'فیض آباد': 'مه ولات',
+  'طرقبه': 'طرقبه و شاندیز',
+  'شاندیز': 'طرقبه و شاندیز',
+  // --- fixes for remaining onlyInIdx case(s) ---
+  // Normalize Torbat Heydariyeh variants -> "تربت حیدریه"
+  'تربتحیدریه': 'تربت حیدریه',
+  'تربت‌حیدریه': 'تربت حیدریه',
+  'تربت حیدریه': 'تربت حیدریه',
+  'تربت-حیدریه': 'تربت حیدریه',
+  // Arabic Ye/spacing/ZWNJ variants
+  'تربت حيدريه': 'تربت حیدریه',
+  'تربت‌حيدريه': 'تربت حیدریه',
+  'تربت حیدریه‌': 'تربت حیدریه'
+};
+function canonicalCountyName(name=''){
+  const k = keyOf(name);
+  for(const [raw,to] of Object.entries(__AMA_ALIAS)){
+    if(keyOf(raw) === k) return to;
+  }
+  return name;
+}
 function showToast(msg){
   try{
     const host = document.querySelector('#ama-map, .ama-map, .leaflet-container') || document.body;
@@ -87,14 +124,14 @@ async function tryLoadVendorScript(relPath){
         s.onerror = () => reject(new Error('load-failed'));
         document.head.appendChild(s);
       });
-      if (window.AMA_DEBUG) console.info('[vendor]', 'loaded', url);
+      if (window.AMA_DEBUG) console.log('[vendor]', 'loaded', url);
       return true;
     } catch (e) {
-      if (window.AMA_DEBUG) console.info('[vendor]', 'miss', url, e?.message || 'error');
+      if (window.AMA_DEBUG) console.log('[vendor]', 'miss', url, e?.message || 'error');
       // try next base
     }
   }
-  if (window.AMA_DEBUG) console.info('[vendor]', 'not-found', relPath);
+  if (window.AMA_DEBUG) console.log('[vendor]', 'not-found', relPath);
   return false;
 }
 
@@ -131,7 +168,7 @@ function pickBestCountiesLayer(map){
 function ensureCountiesLayer(map){
   if(!window.__countiesLayer){
     const best = pickBestCountiesLayer(map);
-    if(best){ window.__countiesLayer = best; if(window.AMA_DEBUG){ let n=0; best.eachLayer(l=>{ if(l.feature&&isPolyFeature(l.feature)) n++; }); console.info('[counties pick] features:', n); } }
+    if(best){ window.__countiesLayer = best; if(window.AMA_DEBUG){ let n=0; best.eachLayer(l=>{ if(l.feature&&isPolyFeature(l.feature)) n++; }); console.log('[counties pick] features:', n); } }
   }
 }
 function eachPolyFeatureLayer(root, fn){
@@ -208,8 +245,8 @@ function parseCSV(text){
 function styleForCounty(feature){
   const p = feature.properties||{};
   const k = window.__activeWindKPI || 'wind_wDensity';
-  const has = !!p.__hasWindData;
   const v = Number(p[k] ?? 0);
+  const has = !!p.__hasWindData;
   if(!has) return {fillOpacity:.15, color:'#7a7a7a', weight:.8, dashArray:'3', fillColor:'#e5e7eb'};
   if(v===0) return {fillOpacity:.88, color:'#6b7280', weight:.9, fillColor:'#f3f4f6'};
   const ramp = ['#e0f2fe','#bae6fd','#7dd3fc','#38bdf8','#0ea5e9'];
@@ -218,21 +255,95 @@ function styleForCounty(feature){
   return {fillOpacity:.9, color:'#475569', weight:.9, fillColor:ramp[i]};
 }
 
-window.runWindSelfCheck = function(){
+window.runWindSelfCheck = function(opts){
+  const log = opts?.log !== false;
+  if (log) console.log('[AMA] self-check started');
   try{
-    if(!window.__countiesLayer){ if(window.AMA_DEBUG) console.warn('no countiesLayer'); return; }
-    const rows=[]; let has=0, nod=0;
-    eachPolyFeatureLayer(window.__countiesLayer, l=>{
-      const f=l.feature||{}; const p=f.properties||{};
-      const nm = deriveCountyFromProps(p);
+    const rows=[]; let has=0, nod=0; const uniq = new Set();
+    const namesMap = new Set();             // normalized names present on map (union)
+    const seen = new Set();                 // to dedupe rows by normalized name
+    const addRow = (p, src)=>{
+      const rawName = (p?.county || p?.name_fa || p?.name || p?.NAME_2 || p?.NAME_1 || p?.shahrestan || p?.['نام'] || p?.['نام_شهرستان'] || '');
+      const name = canonicalCountyName(rawName);
+      const k = keyOf(name);
+      if(!k || seen.has(k)) return;
+      seen.add(k);
+      namesMap.add(k);
       const hd = !!p.__hasWindData;
+      rows.push({ county:name, hasData:hd, N:+(p.wind_N||0), sumW:+(p.wind_sumW||0), avgW:+(p.wind_avgW||0), _src:src });
+      uniq.add(k);
       if(hd) has++; else nod++;
-      rows.push({name:nm, has:hd, N:p.wind_N, sumW:p.wind_sumW, wD:p.wind_wDensity, dN:p.wind_density, avgW:p.wind_avgW});
+    };
+
+    // source counters
+    const srcCount = { countiesLayer:0, choropleth:0, boundary:0, polysFC:0, countiesGeo:0 };
+
+    // 1) Leaflet layers (if present)
+    const layers=[];
+    if (window.__countiesLayer && typeof window.__countiesLayer.eachLayer==='function') layers.push(['countiesLayer', window.__countiesLayer]);
+    if (window.windChoroplethLayer && typeof window.windChoroplethLayer.eachLayer==='function') layers.push(['choropleth', window.windChoroplethLayer]);
+    if (window.boundary && typeof window.boundary.eachLayer==='function') layers.push(['boundary', window.boundary]);
+    layers.forEach(([name,L])=>{
+      eachPolyFeatureLayer(L, l=>{ addRow((l.feature||{}).properties||{}, name); srcCount[name]++; });
     });
-    window.__WIND_SELF_CHECK = window.__WIND_SELF_CHECK || {};
-    Object.assign(window.__WIND_SELF_CHECK, { mapCount:rows.length, hasData:has, noData:nod });
-    if(window.AMA_DEBUG){ console.group('WIND SELF-CHECK'); console.table(rows.slice(0,12)); console.log(window.__WIND_SELF_CHECK); console.groupEnd(); }
+
+    // 2) polysFC union (not fallback-only)
+    if (window.polysFC?.features?.length){
+      window.polysFC.features.forEach(f=>{
+        const p = f?.properties || {};
+        if (typeof p.__hasWindData === 'undefined'){
+          const n=+(p.wind_N||0), s=+(p.wind_sumW||0), avg=+(p.wind_avgW||0);
+          p.__hasWindData = (n>0)||(s>0)||(avg>0);
+        }
+        addRow(p, 'polysFC'); srcCount.polysFC++;
+      });
+    }
+
+    // 3) countiesGeo union (not fallback-only)
+    if (window.countiesGeo?.features?.length){
+      window.countiesGeo.features.forEach(f=>{
+        const p = f?.properties || {};
+        if (typeof p.__hasWindData === 'undefined'){
+          const n=+(p.wind_N||0), s=+(p.wind_sumW||0), avg=+(p.wind_avgW||0);
+          p.__hasWindData = (n>0)||(s>0)||(avg>0);
+        }
+        addRow(p, 'countiesGeo'); srcCount.countiesGeo++;
+      });
+    }
+
+    // Build namesIdx from weights CSV index (if available)
+    const namesIdx = new Set();
+    if (window.__AMA_windIdx && typeof window.__AMA_windIdx === 'object'){
+      Object.keys(window.__AMA_windIdx).forEach(k => namesIdx.add(keyOf(canonicalCountyName(k))));
+    }
+    // Mismatch diagnostics
+    const onlyInMap = [];
+    const onlyInIdx = [];
+    if (namesMap.size){
+      namesMap.forEach(k => { if(!namesIdx.has(k)) onlyInMap.push(k); });
+    }
+    if (namesIdx.size){
+      namesIdx.forEach(k => { if(!namesMap.has(k)) onlyInIdx.push(k); });
+    }
+
+    const summary = {
+      mapCount: rows.length, uniqueCountyCount: uniq.size, hasData:has, noData:nod,
+      onlyInMap, onlyInIdx,
+      sourcesCount: srcCount
+    };
+    window.__WIND_SELF_CHECK = summary;
+    window.__WIND_SELF_CHECK_ROWS = rows;
+    if (log && window.AMA_DEBUG){
+      console.group('WIND SELF-CHECK');
+      console.table(rows.slice(0,12));
+      console.log('[AMA] summary', summary);
+      if (onlyInMap.length) console.warn('[AMA] onlyInMap', onlyInMap.slice(0,20), '… total:', onlyInMap.length);
+      if (onlyInIdx.length) console.warn('[AMA] onlyInIdx', onlyInIdx.slice(0,20), '… total:', onlyInIdx.length);
+      console.groupEnd();
+    }
   }catch(e){ if(window.AMA_DEBUG) console.error('runWindSelfCheck', e); }
+  if (log) console.log('[AMA] self-check done');
+  return window.__WIND_SELF_CHECK;
 };
 
 // Debug flag and fetch logger
@@ -279,7 +390,7 @@ const __jsonCache = new Map();
 function setManifestBase(fromUrl){
   try {
     __LAYER_MANIFEST_BASE = new URL('.', fromUrl).pathname.replace(/\/{2,}/g,'/'); // e.g. '/data/'
-    if (AMA_DEBUG) console.info('[ama:manifest] base', __LAYER_MANIFEST_BASE);
+    if (AMA_DEBUG) console.log('[ama:manifest] base', __LAYER_MANIFEST_BASE);
   } catch {}
 }
 
@@ -295,7 +406,7 @@ async function fetchJSONFromManifest(rel){
   const url = absFromManifest(rel);
   if (__jsonCache.has(url)) return __jsonCache.get(url);
   const res = await fetch(url, { cache: 'no-store' });
-  if (AMA_DEBUG) console.info('[ama:data]', 'GET', url, '->', res.status);
+  if (AMA_DEBUG) console.log('[ama:data]', 'GET', url, '->', res.status);
   if (!res.ok) throw new Error('data-not-found: ' + url);
   const j = await res.json();
   __jsonCache.set(url, j);
@@ -311,7 +422,7 @@ async function fetchTextFromManifest(rel){
   const cleanRel = String(rel || '').replace(/^\.?\//,'');
   const url = new URL(cleanRel, location.origin + base).pathname + qs;
   const res = await fetch(url, { cache:'no-store' });
-  if (AMA_DEBUG) console.info('[ama:data:text] GET', url, '->', res.status);
+  if (AMA_DEBUG) console.log('[ama:data:text] GET', url, '->', res.status);
   if (!res.ok) throw new Error('data-not-found: ' + url);
   return await res.text();
 }
@@ -332,16 +443,22 @@ async function joinWindWeightsOnAll(){
   lines.forEach(line=>{
     const cols=line.split(',');
     const row={}; headers.forEach((h,i)=>row[h]=(cols[i]||'').trim());
-    const raw=row['county']||''; idx[keyOf(raw)]=row;
+    const raw=row['county']||'';
+    const canon = canonicalCountyName(raw);
+    row.county = canon;
+    idx[keyOf(canon)]=row;
   });
   window.__weightsIdx = idx;
+  // Expose weight index for diagnostics
+  try { window.__AMA_windIdx = idx; } catch(_) {}
 
   if(!window.__countiesLayer){ if(AMA_DEBUG) console.warn('[join] no counties layer'); return; }
 
   let mapCount=0, hasData=0, noData=0; const onlyInMap=[], mapKeys=[];
   eachPolyFeatureLayer(window.__countiesLayer, leaf=>{
     const f=leaf.feature, p=f.properties||(f.properties={}); mapCount++;
-    const county = deriveCountyFromProps(p);
+    const county = canonicalCountyName(p.county || deriveCountyFromProps(p));
+    p.county = county;
     const k = keyOf(county);
     mapKeys.push(k);
 
@@ -351,10 +468,12 @@ async function joinWindWeightsOnAll(){
       p.wind_N=n; p.wind_sumW=s; p.wind_avgW=avg;
       const a = p.area_km2>0 ? p.area_km2 : 0;
       p.wind_density = a? (n/a):0; p.wind_wDensity = a? (s/a):0;
-      p.__hasWindData=true; hasData++;
+      const hasKPI = (n>0) || (s>0) || (avg>0);
+      p.__hasWindData = !!hasKPI;
+      if(hasKPI) hasData++; else noData++;
     }else{
       p.wind_N=p.wind_sumW=p.wind_avgW=0; p.wind_density=p.wind_wDensity=0;
-      p.__hasWindData=false; noData++; onlyInMap.push(p.name_fa||p.name||county||'؟');
+      p.__hasWindData=false; noData++; onlyInMap.push(p.county||p.name_fa||p.name||county||'؟');
     }
     if(typeof styleForCounty==='function') leaf.setStyle(styleForCounty(f));
   });
@@ -395,7 +514,7 @@ async function joinWindWeightsOnAll(){
           const b = e.target.closest('button'); if(!b) return;
           const act = b.dataset.act;
           if(act==='reset' && window.__countiesLayer && window.__mapBounds){ map.fitBounds(window.__mapBounds); }
-          if(window.AMA_DEBUG) console.info('[dock]', act);
+          if(window.AMA_DEBUG) console.log('[dock]', act);
         });
         return c;
       }
@@ -484,14 +603,14 @@ async function actuallyLoadManifest(){
     const url = b + 'layers.config.json' + qs;
     try{
       const res = await fetch(url, { cache:'no-store' });
-      if (AMA_DEBUG) console.info('[ama:fetch]', 'GET', url, '->', res.status);
+      if (AMA_DEBUG) console.log('[ama:fetch]', 'GET', url, '->', res.status);
       if (res.ok){
         const json = await res.json();
-        if (AMA_DEBUG) console.info('[ama:manifest] loaded from', url);
+        if (AMA_DEBUG) console.log('[ama:manifest] loaded from', url);
         return { json, url };
       }
     }catch(e){
-      if (AMA_DEBUG) console.info('[ama:fetch]', 'ERR', url, e?.message);
+      if (AMA_DEBUG) console.log('[ama:fetch]', 'ERR', url, e?.message);
     }
   }
   throw new Error('manifest-not-found');
@@ -503,28 +622,100 @@ async function actuallyLoadManifest(){
     window.__LAYER_MANIFEST = new Set(json.files || []);
     window.__LAYER_MANIFEST_URL = url;
     window.__LAYER_MANIFEST_JSON = json;
+    if (AMA_DEBUG) console.log('[ama:manifest] using', url);
   } catch (e) {
     if (window.showToast) window.showToast('عدم دسترسی به داده‌ها (layers.config.json).');
     if (AMA_DEBUG) console.warn(e);
   }
 
   window.__dumpAmaState = function(){
-    if (!window.AMA_DEBUG) return;
-    const manifest = Array.from(window.__LAYER_MANIFEST || []);
-    const scriptEl = document.querySelector('script[type="module"][src*="amaayesh-map"]') || document.currentScript;
-    const scriptSrc = scriptEl ? scriptEl.src : '';
-    const servedFromAma = /\/amaayesh\//.test(new URL(scriptSrc, location.href).pathname);
-    console.group('[ama-dump]');
-    console.log('pathname:', window.location.pathname);
-    console.log('__LAYER_MANIFEST size:', manifest.length);
-    console.log('__LAYER_MANIFEST list:', manifest);
-    console.log('inManifest("amaayesh/counties.geojson"):', inManifest('amaayesh/counties.geojson'));
-    console.log('inManifest("amaayesh/wind_sites.geojson"):', inManifest('amaayesh/wind_sites.geojson'));
-    console.log('AMA_DATA_BASE:', window.AMA_DATA_BASE);
-    console.log('script src:', scriptSrc);
-    console.log('served from /amaayesh/?', servedFromAma);
-    console.groupEnd();
+    const arr = Array.isArray(window.__LAYER_MANIFEST) ? window.__LAYER_MANIFEST : Array.from(window.__LAYER_MANIFEST||[]);
+    const inManifest = (k)=> arr.includes(k);
+    const info = {
+      manifestUrl: window.__LAYER_MANIFEST_URL,
+      manifestSize: arr.length,
+      manifestSample: arr.slice(0,5),
+      inManifest: {
+        'amaayesh/counties.geojson': inManifest('amaayesh/counties.geojson'),
+        'amaayesh/wind_sites.geojson': inManifest('amaayesh/wind_sites.geojson')
+      },
+      dataBase: '/data/amaayesh/',
+      activeKPI: window.__activeWindKPI,
+      hasCountyLayer: !!(window.__countiesLayer || window.windChoroplethLayer || window.boundary),
+      polysFC_features: window.polysFC?.features?.length || 0,
+      countiesGeo_features: window.countiesGeo?.features?.length || 0,
+      countySource: window.__AMA_countySource || 'unknown'
+    };
+    console.log('[AMA] dump', info);
+    return info;
   };
+
+  // --- helpers for robust county name matching ---
+  function __AMA_candidateNames(p){
+    if(!p) return [];
+    const keys = ['county','name_fa','name','NAME_2','NAME_1','shahrestan','نام','نام_شهرستان'];
+    const vals = [];
+    for(const k of keys){ if(p[k]!=null) vals.push(String(p[k])); }
+    return vals;
+  }
+  function __AMA_matchPropsByName(p, normTarget){
+    return __AMA_candidateNames(p).some(v => keyOf(v) === normTarget);
+  }
+
+  // helper: find a county by (normalized) Persian name in the live datasets
+  window.__AMA_whereCounty = function(name){
+    const target = keyOf(name||'');
+    let found = null, source = null;
+    // 1) live Leaflet layers first
+    if (!found && window.__countiesLayer && typeof window.__countiesLayer.eachLayer==='function'){
+      eachPolyFeatureLayer(window.__countiesLayer, l=>{
+        const p=(l.feature||{}).properties||{};
+        if(!found && __AMA_matchPropsByName(p, target)){ found=p; source='__countiesLayer'; }
+      });
+    }
+    if (!found && window.windChoroplethLayer && typeof window.windChoroplethLayer.eachLayer==='function'){
+      eachPolyFeatureLayer(window.windChoroplethLayer, l=>{
+        const p=(l.feature||{}).properties||{};
+        if(!found && __AMA_matchPropsByName(p, target)){ found=p; source='windChoroplethLayer'; }
+      });
+    }
+    // 2) FC used to build the choropleth
+    if (!found && window.polysFC?.features?.length){
+      const f = window.polysFC.features.find(f=> __AMA_matchPropsByName((f||{}).properties||{}, target));
+      if (f){ found=f.properties||null; source='polysFC'; }
+    }
+    // 3) raw GeoJSON fallback
+    if (!found && window.countiesGeo?.features?.length){
+      const f = window.countiesGeo.features.find(f=> __AMA_matchPropsByName((f||{}).properties||{}, target));
+      if (f){ found=f.properties||null; source='countiesGeo'; }
+    }
+    console.log('[AMA] whereCounty', name, '-> source:', source, 'props:', found);
+    return found;
+  };
+
+  // helper: list all available county names (for debugging)
+  window.__AMA_listCountyNames = function(){
+    const seen = new Set(); const out = [];
+    const push = (nm, src) => { const k=keyOf(nm||''); if(!k || seen.has(k)) return; seen.add(k); out.push({name:nm, source:src}); };
+    const collectFromLayer = (L, src)=>{
+      if(!L || typeof L.eachLayer!=='function') return;
+      eachPolyFeatureLayer(L, l=>{
+        const p=(l.feature||{}).properties||{};
+        for(const nm of __AMA_candidateNames(p)) push(nm, src);
+      });
+    };
+    collectFromLayer(window.__countiesLayer, 'countiesLayer');
+    collectFromLayer(window.windChoroplethLayer, 'choropleth');
+    if (window.polysFC?.features?.length){
+      window.polysFC.features.forEach(f=> __AMA_candidateNames(f.properties||{}).forEach(nm=> push(nm, 'polysFC')));
+    }
+    if (window.countiesGeo?.features?.length){
+      window.countiesGeo.features.forEach(f=> __AMA_candidateNames(f.properties||{}).forEach(nm=> push(nm, 'countiesGeo')));
+    }
+    console.log('[AMA] county names', out.slice(0,20), '… total:', out.length);
+    return out;
+  };
+
   if (window.AMA_DEBUG) {
     window.__dumpAmaState();
   }
@@ -532,7 +723,7 @@ async function actuallyLoadManifest(){
   // load a GeoJSON file only if manifest allows it
   async function optionalGeoJSONFile(file, opts = {}) {
     if (!inManifest(file)) {
-      if (window.AMA_DEBUG) console.info('[ama-layer] skip (not in manifest):', file);
+      if (window.AMA_DEBUG) console.log('[ama-layer] skip (not in manifest):', file);
       return null;
     }
     let geo = null;
@@ -561,7 +752,7 @@ async function actuallyLoadManifest(){
     }
     if (layerKey) disableLayerToggle(layerKey);
     if (window.showToast) showToast('عدم دسترسی به داده‌ها: ' + rels[0]);
-    if (window.AMA_DEBUG) console.info('⛔️ Dataset not found:', rels[0], '→ tried:', rels.concat(fallbacks));
+    if (window.AMA_DEBUG) console.log('⛔️ Dataset not found:', rels[0], '→ tried:', rels.concat(fallbacks));
     return null;
   }
 
@@ -612,7 +803,7 @@ async function actuallyLoadManifest(){
         <div>Σw/km²</div><div>${p.wind_wDensity!=null?__AMA_fmtNumberFa(p.wind_wDensity,{digits:3}):'—'}</div>
         <div>avgW</div><div>${p.wind_avgW!=null?__AMA_fmtNumberFa(p.wind_avgW,{digits:3}):'—'}</div>
       </div>`;
-    const sites = (windSitesRaw||[]).filter(r=> (r.county||'')===name).slice(0,8);
+    const sites = (windSitesRaw||[]).filter(r=> sameCounty(r.county, name)).slice(0,8);
     const list = sites.map(s=>`<li>${s.name_fa||'—'} <small>(${(+s.lon).toFixed(2)},${(+s.lat).toFixed(2)})</small> <span>${s.source||''}</span> <button data-lat="${s.lat}" data-lon="${s.lon}" data-name="${s.name_fa}">نمایش روی نقشه</button></li>`).join('');
     body.innerHTML = `${kpiHtml}${sites.length?`<div><b>سایت‌های این شهرستان:</b><ul class="sp-sites">${list}</ul></div>`:''}<div style="margin-top:8px"><button id="ama-sp-dl">دانلود CSV شهرستان</button></div>`;
     sidepanelEl.querySelector('#ama-sp-name').textContent = name;
@@ -647,7 +838,7 @@ async function actuallyLoadManifest(){
 
   function focusCountyByName(name){
     let targetLayer=null;
-    (windChoroplethLayer||boundary)?.eachLayer?.(l=>{ if((l.feature?.properties?.county||'')===name) targetLayer=l; });
+    (windChoroplethLayer||boundary)?.eachLayer?.(l=>{ if(sameCounty(l.feature?.properties?.county||'', name)) targetLayer=l; });
     if(targetLayer){
       map.fitBounds(targetLayer.getBounds(), {maxZoom:11});
       targetLayer.fire('click');
@@ -824,15 +1015,118 @@ async function actuallyLoadManifest(){
       const fmt = (x, d=1) => (x==null || isNaN(x)) ? '—' : Number(x).toFixed(d);
       const radiusFromMW = mw => Math.max(5, 1.6*Math.sqrt(Math.max(0, mw||0)));
 
-        // counties
-        let polysFC = null;
-        try {
-          polysFC = await fetchJSONFromManifest('amaayesh/counties.geojson');
-        } catch (e) {
-          try { polysFC = await fetchJSONFromManifest('amaayesh/khorasan_razavi_combined.geojson'); } catch(_) {}
+        // counties (select central districts as county representatives)
+        async function __ama_loadCentralDistrictCounties(){
+          let combined=null;
+          try { combined = await fetchJSONFromManifest('amaayesh/khorasan_razavi_combined.geojson'); } catch(_){ }
+          const feats = [];
+          const re = /^بخش مرکزی شهرستان\s+(.+)\s*$/;
+          for (const f of (combined?.features||[])) {
+            const p = Object.assign({}, f.properties||{});
+            const nm = String(p.name||'');
+            const m = nm.match(re);
+            if (!m) continue;
+            const county = canonicalCountyName(m[1].trim());
+            p.county = county;
+            feats.push({ type:'Feature', geometry:f.geometry, properties:p });
+          }
+          return { type:'FeatureCollection', features:feats, __combined:combined };
         }
-        if (window.AMA_DEBUG) console.log('[ama-data] counties features =', Array.isArray(polysFC?.features) ? polysFC.features.length : 0);
-        countiesGeo = polysFC;
+        let polysFC = await __ama_loadCentralDistrictCounties();
+
+        // --- CSV-guided fallback: add representatives for CSV counties not matched yet ---
+        async function __ama_loadCSVCountyNames(){
+          // Prefer existing index if available; else fetch CSV directly
+          const names = new Set();
+          if (window.__AMA_windIdx && typeof window.__AMA_windIdx==='object'){
+            Object.keys(window.__AMA_windIdx).forEach(n=> names.add(canonicalCountyName(n)));
+            return Array.from(names);
+          }
+          try{
+            const csvUrl = (window.AMA_DATA_BASE||'/data/amaayesh/') + 'wind_weights_by_county.csv';
+            const res = await fetch(csvUrl, {cache:'no-store'});
+            if(!res.ok) return [];
+            const text = await res.text();
+            const lines = text.split(/\r?\n/).filter(Boolean);
+            if(lines.length < 2) return [];
+            const hdr = lines[0].split(',').map(h=>h.trim());
+            const iCounty = hdr.findIndex(h=> /^(county|شهرستان)$/i.test(h));
+            for(let i=1;i<lines.length;i++){
+              const cols = lines[i].split(',');
+              const nm = canonicalCountyName((cols[iCounty]||'').trim());
+              if(nm) names.add(nm);
+            }
+            return Array.from(names);
+          }catch(_){ return []; }
+        }
+
+        try{
+          const csvCountyNames = await __ama_loadCSVCountyNames();
+          const have = new Set((polysFC.features||[]).map(f=> keyOf(canonicalCountyName(f.properties?.county||''))));
+          const combinedL6 = (polysFC.__combined?.features||[]).filter(f=> String(f?.properties?.admin_level||'')==='6');
+          const candProps = ['county','name_fa','name','NAME_2','NAME_1','shahrestan','نام','نام_شهرستان'];
+          let addedL6=0, addedCountyFile=0;
+
+          // Stage 2: admin_level=6 guided by CSV
+          for(const rawName0 of csvCountyNames){
+            const rawName = canonicalCountyName(rawName0);
+            const k = keyOf(rawName);
+            if(!k || have.has(k)) continue;
+            let hit = combinedL6.find(f=>{
+              const p=f.properties||{};
+              return candProps.some(prop=> sameCounty(canonicalCountyName(p[prop]), rawName));
+            });
+            if(!hit){
+              hit = combinedL6.find(f=>{
+                const p=f.properties||{};
+                return candProps.some(prop=> p[prop] && keyOf(String(canonicalCountyName(p[prop]))).includes(k));
+              });
+            }
+            if(hit){
+              const p = Object.assign({}, hit.properties||{});
+              p.county = rawName.trim();
+              polysFC.features.push({ type:'Feature', geometry: hit.geometry, properties: p });
+              have.add(k); addedL6++;
+            }
+          }
+
+          // Stage 3: fallback to counties.geojson (if present) for remaining names
+          const remaining = csvCountyNames
+            .map(canonicalCountyName)
+            .filter(n => !have.has(keyOf(n)));
+          let countiesFile=null;
+          try { countiesFile = await fetchJSONFromManifest('amaayesh/counties.geojson'); } catch(_){ }
+          if (countiesFile && Array.isArray(countiesFile.features) && remaining.length){
+            for(const rawName of remaining){
+              const k = keyOf(rawName);
+              let hit = countiesFile.features.find(f=>{
+                const p=f.properties||{};
+                return candProps.some(prop=> sameCounty(canonicalCountyName(p[prop]), rawName));
+              });
+              if(!hit){
+                hit = countiesFile.features.find(f=>{
+                  const p=f.properties||{};
+                  return candProps.some(prop=> p[prop] && keyOf(String(canonicalCountyName(p[prop]))).includes(k));
+                });
+              }
+              if(hit){
+                const p = Object.assign({}, hit.properties||{});
+                p.county = rawName.trim();
+                polysFC.features.push({ type:'Feature', geometry: hit.geometry, properties: p });
+                have.add(k); addedCountyFile++;
+              }
+            }
+          }
+
+          window.__AMA_countySource = 'combined/central-districts+guided-fallback' + (addedCountyFile?'+county-fallback':'');
+          if (window.AMA_DEBUG) console.warn('[ama-data] county source:', window.__AMA_countySource,
+            'addedL6=', addedL6, 'addedCountyFile=', addedCountyFile,
+            'unmatchedAfterAll=', csvCountyNames.filter(n=> !have.has(keyOf(canonicalCountyName(n)))).length);
+        }catch(e){
+          window.__AMA_countySource = 'combined/central-districts-as-county';
+          if (window.AMA_DEBUG) console.warn('[ama-data] fallback skipped', e?.message);
+        }
+        countiesGeo = polysFC; window.countiesGeo = countiesGeo; window.polysFC = polysFC;
         if (polysFC?.features?.length) {
           createSidepanel();
 
@@ -848,7 +1142,7 @@ async function actuallyLoadManifest(){
           windChoroplethLayer = L.geoJSON(polysFC, {
             pane:'polygons',
             style: f => styleForCounty(f),
-            onEachFeature:(f,l)=> l.bindTooltip((f.properties?.county || f.properties?.name || '—'), {sticky:true, direction:'auto', className:'label'})
+            onEachFeature:(f,l)=> l.bindTooltip((f.properties?.county || '—'), {sticky:true, direction:'auto', className:'label'})
           }).addTo(map);
           window.__countiesLayer = windChoroplethLayer;
           map.removeLayer(windLayer);
@@ -867,7 +1161,7 @@ async function actuallyLoadManifest(){
             l.on('mouseover', ()=>{
               const p=l.feature.properties||{};
               if(__focused!==l) l.setStyle({...styleForCounty(l.feature), color:'#22d3ee', weight:1.2, fillOpacity:0.65});
-              const name=p.county||p.name||'—';
+              const name=p.county||p.name_fa||p.name||'—';
               if(!p.__hasWindData){ showInfo(`<b>${name}</b><div>بدون داده</div>`); }
               else {
                 showInfo(`<b>${name}</b><div>N: ${__AMA_fmtNumberFa(p.wind_N,{digits:0})}</div><div>Σw: ${__AMA_fmtNumberFa(p.wind_sumW,{digits:3})}</div><div>N/km²: ${__AMA_fmtNumberFa(p.wind_density,{digits:3})}</div><div>Σw/km²: ${__AMA_fmtNumberFa(p.wind_wDensity,{digits:3})}</div><div>avgW: ${__AMA_fmtNumberFa(p.wind_avgW,{digits:3})}</div>`);
@@ -930,7 +1224,7 @@ async function actuallyLoadManifest(){
             const top=rows.slice(0,10);
             el.innerHTML = top.map((p,i)=>`<div class="ama-row" data-county="${p.county||''}"><div class="c">${__AMA_fmtNumberFa(i+1)}</div><div class="n">${p.county||'—'}</div><div class="m">${__AMA_fmtNumberFa(p[windKpiKey]||0,{digits:3})}</div></div>`).join('');
             el.querySelectorAll('.ama-row').forEach(r=>{
-              r.addEventListener('click',()=>{ const n=r.getAttribute('data-county'); focusCountyByName(n); openSidepanel(polysFC.features.find(f=>f.properties.county===n)?.properties||{}); });
+              r.addEventListener('click',()=>{ const n=r.getAttribute('data-county'); focusCountyByName(n); openSidepanel(polysFC.features.find(f=>sameCounty(f.properties.county, n))?.properties||{}); });
             });
           };
           window.__AMA_topPanel.addTo(map);
@@ -1110,8 +1404,9 @@ async function actuallyLoadManifest(){
         sugg.innerHTML=''; idx=-1;
         if(!q){ sugg.style.display='none'; return; }
         const list=[];
-        if(countiesGeo?.features) countiesGeo.features.forEach(f=>{ const n=f.properties?.county||f.properties?.name||''; if(n.includes(q)) list.push({type:'county',name:n}); });
-        if(windSitesGeo?.features) windSitesGeo.features.forEach(f=>{ const n=f.properties?.name_fa||''; if(n.includes(q)) list.push({type:'site',name:n,latlng:f.geometry?.coordinates?.slice().reverse(),props:f.properties}); });
+        const kq = keyOf(q);
+        if(countiesGeo?.features) countiesGeo.features.forEach(f=>{ const n=f.properties?.county||f.properties?.name||''; if(keyOf(n).includes(kq)) list.push({type:'county',name:n}); });
+        if(windSitesGeo?.features) windSitesGeo.features.forEach(f=>{ const n=f.properties?.name_fa||''; if(keyOf(n).includes(kq)) list.push({type:'site',name:n,latlng:f.geometry?.coordinates?.slice().reverse(),props:f.properties}); });
         if(!list.length){ sugg.innerHTML='<div>داده‌ای برای جستجو موجود نیست.</div>'; sugg.style.display='block'; return; }
         items = list.slice(0,10);
         sugg.innerHTML = items.map((it,i)=>`<div data-i="${i}" data-type="${it.type}">${it.name}</div>`).join('');


### PR DESCRIPTION
## Summary
- use central districts from combined geojson as county stand-ins and expose source info
- enrich diagnostics with county source and unique counts for self-check
- add CSV-guided fallback to append missing counties from weights CSV
- canonicalize county names using alias mapping to eliminate index mismatches
- ensure self-check canonicalizes county names from all sources
- extend county fallback with counties.geojson to resolve any remaining CSV counties
- canonicalize Torbat Heydariyeh name variants to remove final mismatch

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run validate:layers`


------
https://chatgpt.com/codex/tasks/task_e_68b8566fee9483288822574234318907