### PR TITLE
Add dams and solar data to layer manifest

### DIFF
--- a/docs/data/layers.config.json
+++ b/docs/data/layers.config.json
@@ -4,6 +4,11 @@
     "amaayesh/counties.geojson",
     "amaayesh/wind_sites.geojson",
     "amaayesh/wind_sites_raw.csv",
-    "amaayesh/wind_weights_by_county.csv"
-  ]
+    "amaayesh/wind_weights_by_county.csv",
+    "amaayesh/solar_sites.geojson",
+    "amaayesh/dams.geojson"
+  ],
+  "baseData": {
+    "dams": "amaayesh/dams.geojson"
+  }
 }


### PR DESCRIPTION
## Summary
- include solar site and dam layers in manifest file list
- expose dam layer through `baseData` for map consumption

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `npm run validate:layers`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68bae7f5ec8c832893a460662220ba45