### PR TITLE
Add dams and solar data to layer manifest

### DIFF
--- a/docs/data/layers.config.json
+++ b/docs/data/layers.config.json
@@ -4,6 +4,11 @@
     "amaayesh/counties.geojson",
     "amaayesh/wind_sites.geojson",
     "amaayesh/wind_sites_raw.csv",
-    "amaayesh/wind_weights_by_county.csv"
-  ]
+    "amaayesh/wind_weights_by_county.csv",
+    "amaayesh/solar_sites.geojson",
+    "amaayesh/dams.geojson"
+  ],
+  "baseData": {
+    "dams": "amaayesh/dams.geojson"
+  }
 }


### PR DESCRIPTION
## Summary
- fetch dam data using manifest path with fallback to normalized name
- normalize manifest file list and expose solar sites overlay layer
- keep dams, wind sites and solar overlays off until user toggles

## Testing
- `npm test` *(fails: TimeoutError Waiting failed: 15000ms exceeded)*
- `npm run validate:layers`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68bae7f5ec8c832893a460662220ba45