### PR TITLE
feat: refresh amaayesh map layout

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -10,24 +10,115 @@
   <link rel="stylesheet" href="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.css" />
   <link rel="stylesheet" href="../assets/legend.css"/>
   <style>
-    html, body { height:100% }
     .label{ font-family: Vazirmatn, sans-serif; font-size:12px; text-shadow:0 0 6px #fff }
-    .map-wrap{ height:calc(100vh - 110px) }
+    body{ font-family: Vazirmatn, system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif; background-color:#f8fafc; }
+    .material-icons{ font-family:'Material Icons'; font-weight:normal; font-style:normal; font-size:24px; line-height:1; letter-spacing:normal; text-transform:none; display:inline-block; white-space:nowrap; word-wrap:normal; direction:ltr; -webkit-font-feature-settings:'liga'; -webkit-font-smoothing:antialiased; }
   </style>
 </head>
-<body class="min-h-screen bg-slate-950 text-slate-100 flex flex-col">
+<body class="min-h-screen flex flex-col">
   <header class="w-full px-4 py-3 flex items-center justify-between">
     <h1 class="text-lg md:text-2xl font-bold">نقشه تعاملی آمایش انرژی — خراسان رضوی</h1>
     <nav class="text-sm md:text-base"><a href="../index.html" class="underline decoration-dotted">صفحه اصلی</a></nav>
   </header>
+  <main class="flex-grow flex relative">
+    <!-- نقشه (تمام‌صفحه) -->
+    <div id="ama-map" class="map-wrap w-full h-full" style="min-height:calc(100vh - 110px)"></div>
 
-  <main id="main" class="px-4 grow w-full">
-    <div id="info" class="mb-2 text-slate-300 text-sm">در انتظار داده…</div>
-    <div class="map-wrap rounded-2xl overflow-hidden ring-1 ring-slate-700">
-      <div id="map" class="h-full w-full"></div>
-      <!-- removed static legend; dynamic LegendDock handles legend -->
+    <!-- پنل راست (Layers/Search/Scale) -->
+    <div id="ama-layer-dock" class="absolute top-4 right-4 w-80 bg-white/90 backdrop-blur-sm rounded-xl shadow-lg flex flex-col space-y-4 p-4 z-10">
+      <div class="flex justify-between items-center pb-2 border-b">
+        <h2 class="text-lg font-semibold text-gray-800">لایه ها</h2>
+        <button class="p-1 rounded-full hover:bg-gray-200">
+          <span class="material-icons text-gray-600">tune</span>
+        </button>
+      </div>
+
+      <div class="flex space-x-2 space-x-reverse">
+        <button data-layer="wind" id="tab-wind" class="flex items-center space-x-2 space-x-reverse px-4 py-2 bg-blue-600 text-white rounded-lg shadow-md hover:bg-blue-700 transition-colors w-full justify-center">
+          <span class="material-icons">air</span><span>باد</span>
+        </button>
+        <button data-layer="solar" id="tab-solar" class="flex items-center space-x-2 space-x-reverse px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors w-full justify-center">
+          <span class="material-icons">wb_sunny</span><span>خورشیدی</span>
+        </button>
+        <button data-layer="dams" id="tab-dams" class="flex items-center space-x-2 space-x-reverse px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors w-full justify-center">
+          <span class="material-icons">water_drop</span><span>آب</span>
+        </button>
+      </div>
+
+      <div class="relative">
+        <span class="material-icons absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">search</span>
+        <input id="ama-search" type="text" placeholder="جستجوی شهرستان..." class="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"/>
+      </div>
+
+      <div class="space-y-3 pt-2">
+        <div class="flex items-center">
+          <input id="chk-wind-sites" type="checkbox" class="w-5 h-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"/>
+          <label for="chk-wind-sites" class="mr-3 text-sm font-medium text-gray-700">سایت‌های بادی (انرژی)</label>
+        </div>
+        <div class="flex items-center">
+          <input id="chk-solar-sites" type="checkbox" class="w-5 h-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"/>
+          <label for="chk-solar-sites" class="mr-3 text-sm font-medium text-gray-700">سایت‌های خورشیدی</label>
+        </div>
+        <div class="flex items-center">
+          <input id="chk-dam-sites" type="checkbox" class="w-5 h-5 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"/>
+          <label for="chk-dam-sites" class="mr-3 text-sm font-medium text-gray-700">سد</label>
+        </div>
+      </div>
+
+      <div class="pt-4 border-t">
+        <p class="text-sm text-gray-600 mb-2">مقیاس نقشه</p>
+        <div class="w-full bg-gray-200 rounded-full h-1.5">
+          <div class="bg-blue-600 h-1.5 rounded-full" style="width:45%"></div>
+        </div>
+        <div class="flex justify-between text-xs text-gray-500 mt-1"><span>0 km</span><span>50 km</span></div>
+      </div>
     </div>
-    <div id="ama-sidepanel-root"></div>
+
+    <!-- پنل چپ (Top10/Legend) -->
+    <div id="ama-top-dock" class="absolute top-4 left-4 w-72 bg-white/90 backdrop-blur-sm rounded-xl shadow-lg flex flex-col space-y-4 p-4 z-10">
+      <div class="flex justify-between items-center pb-2 border-b">
+        <h2 class="text-lg font-semibold text-gray-800">برترین‌ها</h2>
+        <button class="px-3 py-1 bg-blue-100 text-blue-800 text-sm font-semibold rounded-full">Top 10</button>
+      </div>
+
+      <div class="space-y-2">
+        <table class="w-full text-sm text-right text-gray-500">
+          <thead class="text-xs text-gray-700 uppercase bg-gray-50">
+            <tr><th class="px-4 py-2">رتبه</th><th class="px-4 py-2">شهرستان</th><th class="px-4 py-2">پتانسیل (MW)</th></tr>
+          </thead>
+          <tbody id="ama-top10">
+            <!-- با JS پر می‌شود -->
+          </tbody>
+        </table>
+      </div>
+
+      <div class="pt-4 border-t">
+        <div class="flex justify-between items-center pb-2">
+          <h2 class="text-lg font-semibold text-gray-800">راهنمای رنگ‌ها</h2>
+        </div>
+        <div id="ama-legend" class="space-y-2">
+          <!-- با JS پر می‌شود؛ نمونه‌ی رنگ‌ها: -->
+          <div class="flex items-center justify-between text-sm">
+            <span class="text-gray-600">کم</span>
+            <div class="flex items-center space-x-1 space-x-reverse">
+              <div class="w-6 h-4 rounded bg-teal-100 border border-teal-200"></div>
+              <div class="w-6 h-4 rounded bg-teal-200 border border-teal-300"></div>
+              <div class="w-6 h-4 rounded bg-teal-300 border border-teal-400"></div>
+              <div class="w-6 h-4 rounded bg-teal-400 border border-teal-500"></div>
+              <div class="w-6 h-4 rounded bg-teal-500 border border-teal-600"></div>
+            </div>
+            <span class="text-gray-600">زیاد</span>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- دکمه‌های پایین-چپ -->
+    <div class="absolute bottom-4 left-4 flex flex-col space-y-2 z-10">
+      <button id="btn-zoom-in" class="bg-white w-10 h-10 rounded-lg shadow-md flex items-center justify-center hover:bg-gray-100 transition-colors"><span class="material-icons text-gray-700">add</span></button>
+      <button id="btn-zoom-out" class="bg-white w-10 h-10 rounded-lg shadow-md flex items-center justify-center hover:bg-gray-100 transition-colors"><span class="material-icons text-gray-700">remove</span></button>
+      <button id="btn-geolocate" class="bg-white w-10 h-10 rounded-lg shadow-md flex items-center justify-center hover:bg-gray-100 transition-colors mt-4"><span class="material-icons text-gray-700">my_location</span></button>
+    </div>
   </main>
 
   <footer class="mt-6 py-6 text-center text-slate-400 text-xs">WESH360 • Energy Spatial Planning • Leaflet</footer>
@@ -36,6 +127,6 @@
   <script defer src="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
   <script defer src="../assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <!-- supercluster optional (CDN removed due to CSP). Use local vendor if added. -->
-  <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script defer src="../assets/js/amaayesh-map.js"></script>
 </body>
 </html>

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -1,3 +1,13 @@
+// --- UI mode & debug
+window.AMA_UI_MODE = 'v2';        // v2 = UI جدید؛ 'legacy' = قدیمی
+window.AMA_DEBUG   = window.AMA_DEBUG ?? false;
+
+function dbg(){ if (window.AMA_DEBUG) console.log('[AMA]', ...arguments); }
+
+// --- single-boot guards
+window.__AMA_BOOTING = window.__AMA_BOOTING || false;
+window.__AMA_BOOTSTRAPPED = window.__AMA_BOOTSTRAPPED || false;
+
 // --- Build id ---
 window.__AMA_BUILD_ID = document.querySelector('meta[name="build-id"]')?.content || String(Date.now());
 
@@ -140,11 +150,13 @@ function normalizeDataPath(p){
   return s.replace(/\/\/+/g,'/');
 }
 
-window.__AMA_BOOTING = window.__AMA_BOOTING || false;
-window.__AMA_BOOTSTRAPPED = window.__AMA_BOOTSTRAPPED || false;
-window.AMA_DEBUG = window.AMA_DEBUG || /(?:^|[?&])ama_debug=1\b/.test(location.search);
-
 let boundary;
+
+function __resolveMapContainer(){
+  const el = document.querySelector('#ama-map, #map, #map-wrap, .map-wrap');
+  if (!el) throw new Error('[AMA] map container not found');
+  return el;
+}
 
 function safeRemoveLayer(map, layer) {
   if (!layer) return;
@@ -743,14 +755,18 @@ async function joinWindWeightsOnAll(){
     infoCtl._div.innerHTML = '';
   }
 
-  infoCtl = L.control({ position: 'topleft' });
-  infoCtl.onAdd = function(map){
-    const div = L.DomUtil.create('div','ama-infox');
-    div.style.cssText = 'background:rgba(17,24,39,.9);color:#e5e7eb;padding:8px 10px;border-radius:10px;font:12px Vazirmatn, sans-serif;display:none;backdrop-filter:blur(2px)';
-    div.setAttribute('dir','rtl');
-    return (infoCtl._div = div);
-  };
-  infoCtl.addTo(map);
+  if (window.AMA_UI_MODE === 'legacy') {
+    infoCtl = L.control({ position: 'topleft' });
+    infoCtl.onAdd = function(map){
+      const div = L.DomUtil.create('div','ama-infox');
+      div.style.cssText = 'background:rgba(17,24,39,.9);color:#e5e7eb;padding:8px 10px;border-radius:10px;font:12px Vazirmatn, sans-serif;display:none;backdrop-filter:blur(2px)';
+      div.setAttribute('dir','rtl');
+      return (infoCtl._div = div);
+    };
+    infoCtl.addTo(map);
+  } else {
+    dbg('skip legacy info control');
+  }
 
   // wind weights / KPI state
   let windKpiKey = window.__activeWindKPI || 'wind_wDensity';
@@ -1184,31 +1200,35 @@ async function actuallyLoadManifest(){
     if (damsLayer) tabs.push(damsLegendCfg);
 
     // === Province focus & toggle ===
-    (function(){
-      const ctl = L.control({position:"topleft"});
-      ctl.onAdd = function() {
-        const div = L.DomUtil.create("div","ama-modes");
-        div.innerHTML = `
+    if (window.AMA_UI_MODE === 'legacy') {
+      (function(){
+        const ctl = L.control({position:"topleft"});
+        ctl.onAdd = function() {
+          const div = L.DomUtil.create("div","ama-modes");
+          div.innerHTML = `
           <button class="chip active" id="btn-prov">استان</button>
           <button class="chip" id="btn-nat">کشور</button>`;
-        L.DomEvent.disableClickPropagation(div);
-        const toProv = ()=>{
-          map.fitBounds(boundary.getBounds(), { padding:[12,12] });
-          map.setMaxBounds(boundary.getBounds().pad(0.25));
-          div.querySelector("#btn-prov").classList.add("active");
-          div.querySelector("#btn-nat").classList.remove("active");
+          L.DomEvent.disableClickPropagation(div);
+          const toProv = ()=>{
+            map.fitBounds(boundary.getBounds(), { padding:[12,12] });
+            map.setMaxBounds(boundary.getBounds().pad(0.25));
+            div.querySelector("#btn-prov").classList.add("active");
+            div.querySelector("#btn-nat").classList.remove("active");
+          };
+          const toNat = ()=>{
+            map.setMaxBounds(null);
+            div.querySelector("#btn-nat").classList.add("active");
+            div.querySelector("#btn-prov").classList.remove("active");
+          };
+          div.querySelector("#btn-prov").addEventListener("click", toProv);
+          div.querySelector("#btn-nat").addEventListener("click", toNat);
+          return div;
         };
-        const toNat = ()=>{
-          map.setMaxBounds(null);
-          div.querySelector("#btn-nat").classList.add("active");
-          div.querySelector("#btn-prov").classList.remove("active");
-        };
-        div.querySelector("#btn-prov").addEventListener("click", toProv);
-        div.querySelector("#btn-nat").addEventListener("click", toNat);
-        return div;
-      };
-      ctl.addTo(map);
-    })();
+        ctl.addTo(map);
+      })();
+    } else {
+      dbg('skip legacy province toggle');
+    }
 
     // === WIND: load computed datasets (amaayesh/counties.geojson + amaayesh/wind_sites.geojson) ===
     {
@@ -1287,6 +1307,7 @@ async function actuallyLoadManifest(){
           map.on('click', (e)=>{ if(!e.layer) clearFocus(); });
           document.addEventListener('keydown', e=>{ if(e.key==='Escape') clearFocus(); });
 
+          if (window.AMA_UI_MODE === 'legacy') {
           // KPI switcher
           const kpiCtl = L.control({position:'topright'});
           kpiCtl.onAdd = function(){
@@ -1343,6 +1364,9 @@ async function actuallyLoadManifest(){
             return wrap;
           };
           window.__AMA_kpiLegend.addTo(map);
+          } else {
+            dbg('skip legacy KPI panels');
+          }
 
           window.renderLegend = debounce(function(){
             const el = document.getElementById('ama-kpi-legend');
@@ -1388,50 +1412,54 @@ async function actuallyLoadManifest(){
         }
       }
     // === Local search & geolocate ===
-    const searchCtl = L.control({position:'topleft'});
-    searchCtl.onAdd = function(){
-      const div = L.DomUtil.create('div','ama-search');
-      div.innerHTML = `<input type="text" placeholder="جستجوی شهرستان/سایت…"/><button title="یافتن موقعیت من">📍</button><div class="ama-suggestions" style="display:none"></div>`;
-      L.DomEvent.disableClickPropagation(div);
-      const input = div.querySelector('input');
-      const sugg = div.querySelector('.ama-suggestions');
-      let items=[], idx=-1;
-      const update = ()=>{
-        const q = input.value.trim();
-        sugg.innerHTML=''; idx=-1;
-        if(!q){ sugg.style.display='none'; return; }
-        const list=[];
-        const kq = keyOf(q);
-        if(countiesGeo?.features) countiesGeo.features.forEach(f=>{ const n=f.properties?.county||f.properties?.name||''; if(keyOf(n).includes(kq)) list.push({type:'county',name:n}); });
-        if(windSitesGeo?.features) windSitesGeo.features.forEach(f=>{ const n=f.properties?.name_fa||''; if(keyOf(n).includes(kq)) list.push({type:'site',name:n,latlng:f.geometry?.coordinates?.slice().reverse(),props:f.properties}); });
-        if(!list.length){ sugg.innerHTML='<div>داده‌ای برای جستجو موجود نیست.</div>'; sugg.style.display='block'; return; }
-        items = list.slice(0,10);
-        sugg.innerHTML = items.map((it,i)=>`<div data-i="${i}" data-type="${it.type}">${it.name}</div>`).join('');
-        sugg.style.display='block';
-        sugg.querySelectorAll('div').forEach(d=> d.addEventListener('click', ()=> select(items[+d.dataset.i])));
+    if (window.AMA_UI_MODE === 'legacy') {
+      const searchCtl = L.control({position:'topleft'});
+      searchCtl.onAdd = function(){
+        const div = L.DomUtil.create('div','ama-search');
+        div.innerHTML = `<input type="text" placeholder="جستجوی شهرستان/سایت…"/><button title="یافتن موقعیت من">📍</button><div class="ama-suggestions" style="display:none"></div>`;
+        L.DomEvent.disableClickPropagation(div);
+        const input = div.querySelector('input');
+        const sugg = div.querySelector('.ama-suggestions');
+        let items=[], idx=-1;
+        const update = ()=>{
+          const q = input.value.trim();
+          sugg.innerHTML=''; idx=-1;
+          if(!q){ sugg.style.display='none'; return; }
+          const list=[];
+          const kq = keyOf(q);
+          if(countiesGeo?.features) countiesGeo.features.forEach(f=>{ const n=f.properties?.county||f.properties?.name||''; if(keyOf(n).includes(kq)) list.push({type:'county',name:n}); });
+          if(windSitesGeo?.features) windSitesGeo.features.forEach(f=>{ const n=f.properties?.name_fa||''; if(keyOf(n).includes(kq)) list.push({type:'site',name:n,latlng:f.geometry?.coordinates?.slice().reverse(),props:f.properties}); });
+          if(!list.length){ sugg.innerHTML='<div>داده‌ای برای جستجو موجود نیست.</div>'; sugg.style.display='block'; return; }
+          items = list.slice(0,10);
+          sugg.innerHTML = items.map((it,i)=>`<div data-i="${i}" data-type="${it.type}">${it.name}</div>`).join('');
+          sugg.style.display='block';
+          sugg.querySelectorAll('div').forEach(d=> d.addEventListener('click', ()=> select(items[+d.dataset.i])));
+        };
+        const deb = debounce(update,300);
+        input.addEventListener('input', deb);
+        input.addEventListener('keydown', e=>{
+          if(e.key==='ArrowDown'){ e.preventDefault(); move(1); }
+          else if(e.key==='ArrowUp'){ e.preventDefault(); move(-1); }
+          else if(e.key==='Enter'){ if(idx>=0) select(items[idx]); }
+        });
+        function move(dir){ if(!items.length) return; idx=(idx+dir+items.length)%items.length; sugg.querySelectorAll('div').forEach((d,i)=>d.classList.toggle('active',i===idx)); }
+        function select(it){ sugg.style.display='none'; input.value=''; if(!it) return; if(it.type==='county'){ focusCountyByName(it.name); } else if(it.type==='site'){ safeClearGroup(searchLayer); const m=L.circleMarker(it.latlng,{radius:6,color:'#22d3ee'}).addTo(searchLayer); m.bindPopup(it.props?.name_fa||'').openPopup(); map.setView(it.latlng,12); } }
+        const btn = div.querySelector('button');
+        btn.addEventListener('click', ()=>{
+          if(!navigator.geolocation){ toast('مرورگر از موقعیت‌یابی پشتیبانی نمی‌کند'); return; }
+          navigator.geolocation.getCurrentPosition(pos=>{
+            const ll=[pos.coords.latitude,pos.coords.longitude];
+            safeClearGroup(searchLayer);
+            L.marker(ll).addTo(searchLayer).bindPopup('موقعیت من').openPopup();
+            map.setView(ll,12);
+          }, err=>{ toast(err.code===1?'مجوز دسترسی به موقعیت رد شد':'یافتن موقعیت ممکن نشد'); }, {enableHighAccuracy:false, timeout:8000});
+        });
+        return div;
       };
-      const deb = debounce(update,300);
-      input.addEventListener('input', deb);
-      input.addEventListener('keydown', e=>{
-        if(e.key==='ArrowDown'){ e.preventDefault(); move(1); }
-        else if(e.key==='ArrowUp'){ e.preventDefault(); move(-1); }
-        else if(e.key==='Enter'){ if(idx>=0) select(items[idx]); }
-      });
-      function move(dir){ if(!items.length) return; idx=(idx+dir+items.length)%items.length; sugg.querySelectorAll('div').forEach((d,i)=>d.classList.toggle('active',i===idx)); }
-      function select(it){ sugg.style.display='none'; input.value=''; if(!it) return; if(it.type==='county'){ focusCountyByName(it.name); } else if(it.type==='site'){ safeClearGroup(searchLayer); const m=L.circleMarker(it.latlng,{radius:6,color:'#22d3ee'}).addTo(searchLayer); m.bindPopup(it.props?.name_fa||'').openPopup(); map.setView(it.latlng,12); } }
-      const btn = div.querySelector('button');
-      btn.addEventListener('click', ()=>{
-        if(!navigator.geolocation){ toast('مرورگر از موقعیت‌یابی پشتیبانی نمی‌کند'); return; }
-        navigator.geolocation.getCurrentPosition(pos=>{
-          const ll=[pos.coords.latitude,pos.coords.longitude];
-          safeClearGroup(searchLayer);
-          L.marker(ll).addTo(searchLayer).bindPopup('موقعیت من').openPopup();
-          map.setView(ll,12);
-        }, err=>{ toast(err.code===1?'مجوز دسترسی به موقعیت رد شد':'یافتن موقعیت ممکن نشد'); }, {enableHighAccuracy:false, timeout:8000});
-      });
-      return div;
-    };
-    searchCtl.addTo(map);
+      searchCtl.addTo(map);
+    } else {
+      dbg('skip legacy search control');
+    }
 
     function debounce(fn,ms){ let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn.apply(this,args),ms); }; }
     function toast(msg){ const info=document.getElementById('info'); if(info){ info.textContent=msg; setTimeout(()=>{info.textContent='';},3000); } }
@@ -1455,10 +1483,11 @@ async function actuallyLoadManifest(){
     }
 
     // Infra drawer control
-    const infraCtl = L.control({position:'topleft'});
-    infraCtl.onAdd = function(){
-      const d = L.DomUtil.create('div','ama-infra');
-      d.innerHTML = `
+    if (window.AMA_UI_MODE === 'legacy') {
+      const infraCtl = L.control({position:'topleft'});
+      infraCtl.onAdd = function(){
+        const d = L.DomUtil.create('div','ama-infra');
+        d.innerHTML = `
         <button class="chip" id="btn-infra">زیرساخت ▾</button>
         <div id="infra-box" class="box" style="display:none">
           <label><input type="checkbox" data-layer="electricity"> خطوط انتقال برق</label>
@@ -1466,22 +1495,26 @@ async function actuallyLoadManifest(){
           <label><input type="checkbox" data-layer="gas"> خطوط انتقال گاز</label>
           <label><input type="checkbox" data-layer="oil"> خطوط لوله نفت</label>
         </div>`;
-      L.DomEvent.disableClickPropagation(d);
-      d.querySelector('#btn-infra').onclick = ()=> {
-        const el = d.querySelector('#infra-box');
-        el.style.display = (el.style.display==='none'?'block':'none');
-      };
-      d.querySelectorAll('input[type=checkbox]').forEach(ch=>{
-        ch.addEventListener('change', ()=>{
-          const LAY = { electricity:electricityLinesLayer, water:waterMainsLayer, gas:gasTransmissionLayer, oil:oilPipelinesLayer }[ch.dataset.layer];
-          if (!LAY) return;
-          if (ch.checked) map.addLayer(LAY); else safeRemoveLayer(map, LAY);
+        L.DomEvent.disableClickPropagation(d);
+        d.querySelector('#btn-infra').onclick = ()=> {
+          const el = d.querySelector('#infra-box');
+          el.style.display = (el.style.display==='none'?'block':'none');
+        };
+        d.querySelectorAll('input[type=checkbox]').forEach(ch=>{
+          ch.addEventListener('change', ()=>{
+            const LAY = { electricity:electricityLinesLayer, water:waterMainsLayer, gas:gasTransmissionLayer, oil:oilPipelinesLayer }[ch.dataset.layer];
+            if (!LAY) return;
+            if (ch.checked) map.addLayer(LAY); else safeRemoveLayer(map, LAY);
+          });
         });
-      });
-      return d;
-    };
-    infraCtl.addTo(map);
+        return d;
+      };
+      infraCtl.addTo(map);
+    } else {
+      dbg('skip legacy infra control');
+    }
 
+      if (window.AMA_UI_MODE === 'legacy') {
       // ===== LegendDock =====
       function LegendDock(){
         const div = L.DomUtil.create('div','legend-dock'); div.dir='rtl';
@@ -1593,6 +1626,9 @@ async function actuallyLoadManifest(){
       }
       window.addEventListener('resize', reevaluateLegendPosition);
       map.on('overlayadd overlayremove', reevaluateLegendPosition);
+      } else {
+      dbg('skip legacy legend dock');
+      }
 
       // === InfoChip: کارت اطلاعات سریع هنگام Hover ===
 
@@ -1636,7 +1672,11 @@ async function actuallyLoadManifest(){
       if (solarSitesLayer) overlays['سایت‌های خورشیدی']       = solarSitesLayer;
       if (damsLayer)       overlays['سدها']                    = damsLayer;
 
-      const ctrl = L.control.layers(null, overlays, { collapsed:false, position:'topleft' }).addTo(map);
+      if (window.AMA_UI_MODE === 'legacy') {
+        const ctrl = L.control.layers(null, overlays, { collapsed:false, position:'topleft' }).addTo(map);
+      } else {
+        dbg('skip legacy layers control');
+      }
       Object.values(overlays).forEach(Lyr=> safeRemoveLayer(map, Lyr));
       const overlayEntries = Object.entries(overlays);
 
@@ -1757,23 +1797,27 @@ async function actuallyLoadManifest(){
       if (window.AMA_DEBUG) console.log('[AHA] baseData:', windPath, solarPath, damsPath);
       // --- end custom layers dock ---
 
-      L.control.scale({ metric:true, imperial:false }).addTo(map);
+      if (window.AMA_UI_MODE === 'legacy') {
+        L.control.scale({ metric:true, imperial:false }).addTo(map);
 
-      if (L.Control && L.Control.geocoder) {
-        const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
-        geocoder.on('markgeocode', e => {
-          const center = e.geocode.center;
-          const name = e.geocode.name;
-          safeClearGroup(searchLayer);
-          searchLayer.addLayer(L.circleMarker(center, {
-            radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
-          }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
-          if (e.geocode.bbox) {
-            map.fitBounds(e.geocode.bbox);
-          } else {
-            map.setView(center, 14);
-          }
-        });
+        if (L.Control && L.Control.geocoder) {
+          const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
+          geocoder.on('markgeocode', e => {
+            const center = e.geocode.center;
+            const name = e.geocode.name;
+            safeClearGroup(searchLayer);
+            searchLayer.addLayer(L.circleMarker(center, {
+              radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
+            }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
+            if (e.geocode.bbox) {
+              map.fitBounds(e.geocode.bbox);
+            } else {
+              map.setView(center, 14);
+            }
+          });
+        }
+      } else {
+        dbg('skip legacy scale/geocoder');
       }
 
       // اگر لایه گاز موجود است، جلوه‌های اضافه اعمال شود
@@ -1841,6 +1885,7 @@ async function actuallyLoadManifest(){
   window.__amaHealthReport = __amaHealthReport;
 
   // === Persona mode chips (owner/edu/invest/ind) ===
+  if (window.AMA_UI_MODE === 'legacy') {
   (function(){
     // ابزار فرمت عدد: 12345.6 -> "۱۲٬۳۴۶"
     function toFaDigits(str){ return String(str).replace(/[0-9]/g, d=>'۰۱۲۳۴۵۶۷۸۹'[+d]); }
@@ -1957,20 +2002,66 @@ async function actuallyLoadManifest(){
       panels.layers.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const body=wrap.querySelector('.ama-panel-bd'); body.innerHTML='<label><input type="checkbox" data-layer="wind" checked/> لایه باد</label><label><input type="checkbox" data-layer="sites" checked/> سایت‌ها</label>'; body.querySelectorAll('input[data-layer]').forEach(ch=>{ ch.addEventListener('change',()=>{ const lay=ch.dataset.layer; const LAY = lay==='wind'?window.windChoroplethLayer:window.windSitesLayer; if(LAY){ if(ch.checked) map.addLayer(LAY); else safeRemoveLayer(map, LAY);} });}); return wrap; }; })(panels.layers.onAdd);
       panels.download.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const btn=wrap.querySelector('#ama-dl-csv'); btn?.addEventListener('click',()=>{ const rows=polysFC.features.map(f=>f.properties); const csv=makeTopCSV(rows); downloadBlob('kpi.csv',csv); }); return wrap; }; })(panels.download.onAdd);
     })();
-}
+  } else {
+    dbg('skip legacy tool dock');
+  }
 
 async function ama_bootstrap(){
-  if (window.__AMA_BOOTSTRAPPED || window.__AMA_BOOTING) return;
+  if (window.__AMA_BOOTSTRAPPED || window.__AMA_BOOTING) { dbg('bootstrap: skip (already)'); return; }
   window.__AMA_BOOTING = true;
-  const t0 = performance.now?performance.now():Date.now();
+  const t0 = performance.now();
 
-  await new Promise(r=>{
-    if (document.readyState!=='loading') r(); else
-      document.addEventListener('DOMContentLoaded', r, {once:true});
-  });
+  if (document.readyState === 'loading') {
+    await new Promise(r => document.addEventListener('DOMContentLoaded', r, {once:true}));
+  }
+
+  const mapContainer = __resolveMapContainer();
+  dbg('map container =', mapContainer.id || mapContainer.className);
+
+  if (!window.map) {
+    window.map = L.map(mapContainer, { preferCanvas:true, zoomControl:true });
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(window.map);
+    if (window.map.zoomControl && typeof window.map.zoomControl.setPosition==='function') window.map.zoomControl.setPosition('bottomleft');
+    if (window.map.attributionControl && typeof window.map.attributionControl.setPosition === 'function') {
+      window.map.attributionControl.setPosition('bottomleft');
+    }
+    window.map.setView([36.3,59.6],7);
+    (function ensureMapHasHeight(){
+      const h = mapContainer.getBoundingClientRect().height;
+      if (h < 200) {
+        mapContainer.style.minHeight = 'calc(100vh - 110px)';
+        setTimeout(()=> window.map?.invalidateSize?.(), 0);
+        dbg('map minHeight fallback applied');
+      }
+    })();
+
+    window.map.createPane('polygons');  window.map.getPane('polygons').style.zIndex = 400;
+    window.map.createPane('points');    window.map.getPane('points').style.zIndex   = 500;
+    window.map.createPane('boundary');  window.map.getPane('boundary').style.zIndex = 650;
+    if (window.AMA_DEBUG) console.log('[AHA] panes zIndex=', {
+      polygons: getComputedStyle(window.map.getPane('polygons')).zIndex,
+      points:   getComputedStyle(window.map.getPane('points')).zIndex,
+      boundary: getComputedStyle(window.map.getPane('boundary')).zIndex
+    });
+
+    const canvasRenderer = L.canvas({padding:0.5});
+    window.__AMA_canvasRenderer = canvasRenderer;
+    window.__AMA_MAP = window.map;
+
+    const _rm = window.map.removeLayer.bind(window.map);
+    window.map.removeLayer = (lyr) => {
+      if (lyr?.__AMA_PROTECTED && !lyr.__AMA_ALLOW_REPLACE) {
+        if (window.AMA_DEBUG) console.warn('[AMA] blocked remove on protected layer');
+        return window.map;
+      }
+      return _rm(lyr);
+    };
+  } else {
+    dbg('map already exists, reuse');
+  }
 
   const manifestUrl = normalizeDataPath('layers.config.json') + '?v=' + (window.__BUILD_ID || Date.now());
-  if (window.AMA_DEBUG) console.log('[AMA] manifest path', manifestUrl);
+  dbg('manifest path', manifestUrl);
   const manifest = await fetch(manifestUrl).then(r=>r.json()).catch(_=>null);
   const base = (manifest && manifest.baseData) || {};
   const paths = {
@@ -1980,7 +2071,7 @@ async function ama_bootstrap(){
     solar:    normalizeDataPath(base.solar_sites || 'amaayesh/solar_sites.geojson'),
     dams:     normalizeDataPath(base.dams || 'amaayesh/dams.geojson'),
   };
-  if (window.AMA_DEBUG) console.log('[AMA] paths', paths);
+  dbg('paths', paths);
 
   window.__LAYER_MANIFEST_JSON = manifest;
   window.__LAYER_MANIFEST_URL = manifestUrl;
@@ -2005,54 +2096,135 @@ async function ama_bootstrap(){
   if (!all) all = { type:'FeatureCollection', features:[] };
   window.__countiesGeoAll = all;
   window.__combinedGeo = combinedFC;
-  if (window.AMA_DEBUG) console.log('[AHA] all-counties.features =', all.features.length);
+  dbg('all-counties.features =', all.features.length);
 
-  const map = L.map('map', { preferCanvas:true, zoomControl:true });
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(map);
-  if (map.zoomControl && typeof map.zoomControl.setPosition==='function') map.zoomControl.setPosition('bottomleft');
-  if (map.attributionControl && typeof map.attributionControl.setPosition === 'function') {
-    map.attributionControl.setPosition('bottomleft');
+  if (typeof __refreshBoundary === 'function') {
+    await __refreshBoundary(window.map, { keepOld:false });
+    window.map.fitBounds(boundary.getBounds(), { padding:[12,12] });
+    window.map.setMaxBounds(boundary.getBounds().pad(0.25));
+    boundary.setStyle({ className: 'neon-edge' });
+    window.map.on('layeradd overlayadd overlayremove', () => {
+      if (boundary?.bringToFront) boundary.bringToFront();
+    });
+    dbg('boundary refreshed');
   }
-  map.setView([36.3,59.6],7);
 
-  map.createPane('polygons');  map.getPane('polygons').style.zIndex = 400;
-  map.createPane('points');    map.getPane('points').style.zIndex   = 500;
-  map.createPane('boundary');  map.getPane('boundary').style.zIndex = 650;
-  if (window.AMA_DEBUG) console.log('[AHA] panes zIndex=', {
-    polygons: getComputedStyle(map.getPane('polygons')).zIndex,
-    points:   getComputedStyle(map.getPane('points')).zIndex,
-    boundary: getComputedStyle(map.getPane('boundary')).zIndex
-  });
+  if (typeof buildOverlaysAfterBoundary === 'function') {
+    await buildOverlaysAfterBoundary(paths);
+    dbg('overlays built');
+  }
 
-  const canvasRenderer = L.canvas({padding:0.5});
-  window.__AMA_canvasRenderer = canvasRenderer;
-  window.__AMA_MAP = map;
-
-  const _rm = map.removeLayer.bind(map);
-  map.removeLayer = (lyr) => {
-    if (lyr?.__AMA_PROTECTED && !lyr.__AMA_ALLOW_REPLACE) {
-      if (window.AMA_DEBUG) console.warn('[AMA] blocked remove on protected layer');
-      return map;
-    }
-    return _rm(lyr);
-  };
-
-  await __refreshBoundary(map, { keepOld:false });
-  map.fitBounds(boundary.getBounds(), { padding:[12,12] });
-  map.setMaxBounds(boundary.getBounds().pad(0.25));
-  boundary.setStyle({ className: 'neon-edge' });
-  map.on('layeradd overlayadd overlayremove', () => {
-    if (boundary?.bringToFront) boundary.bringToFront();
-  });
-
-  await buildOverlaysAfterBoundary(paths);
+  if (window.AMA_UI_MODE === 'v2') {
+    wireAmaUiV2Controls();
+    dbg('UI v2 wired');
+  }
 
   window.__AMA_BOOTSTRAPPED = true;
   window.__AMA_BOOTING = false;
-  if (window.AMA_DEBUG) {
-    const t1 = performance.now?performance.now():Date.now();
-    console.log('[AMA] bootstrap done in', Math.round(t1-t0),'ms');
-  }
+  const t1 = performance.now();
+  dbg('bootstrap done in', Math.round(t1 - t0), 'ms');
 }
 
 ama_bootstrap();
+function wireAmaUiV2Controls(){
+  const $ = sel => document.querySelector(sel);
+  const on = (el, ev, fn) => el && el.addEventListener(ev, fn);
+
+  // دکمه‌های تب
+  const tabs = { wind: $('#tab-wind'), solar: $('#tab-solar'), dams: $('#tab-dams') };
+  function setActiveTab(key){
+    Object.entries(tabs).forEach(([k,btn])=>{
+      if(!btn) return;
+      if(k===key){ btn.classList.remove('bg-gray-200','text-gray-700'); btn.classList.add('bg-blue-600','text-white'); btn.setAttribute('aria-pressed','true'); }
+      else { btn.classList.remove('bg-blue-600','text-white'); btn.classList.add('bg-gray-200','text-gray-700'); btn.setAttribute('aria-pressed','false'); }
+    });
+  }
+
+  // دسترسی به لایه‌ها/گروه‌ها به‌صورت ایمن
+  function getOverlay(keyCandidates){
+    const ov = (window.overlays || {});
+    for(const k of keyCandidates){
+      if(ov[k]) return ov[k];
+    }
+    return null;
+  }
+  // کلروپلث باد (پلیگون/فیل)
+  const windPoly = getOverlay(['wind','باد','windChoropleth','wind_poly']);
+  // نقاط
+  const windPts  = getOverlay(['wind_sites','سایت‌های بادی (برآوردی)','wind_points']);
+  const solarPts = getOverlay(['solar_sites','سایت‌های خورشیدی','solar']);
+  const damsPts  = getOverlay(['dams','سدها','dams_points']);
+
+  function addL(layer){ try{ if(layer && layer.addTo) layer.addTo(window.map); }catch(_){/*noop*/} }
+  function rmL(layer){ try{ if(layer && window.map && window.map.removeLayer) window.map.removeLayer(layer); }catch(_){/*noop*/} }
+  function bringBoundary(){ try{ if(window.boundary?.bringToFront) window.boundary.bringToFront(); }catch(_){} }
+
+  // تب‌ها: single-select روی نمای بالایی
+  on(tabs.wind, 'click', ()=>{ setActiveTab('wind'); if(windPoly){ addL(windPoly); } /* نمایش باد */ bringBoundary(); });
+  on(tabs.solar,'click', ()=>{ setActiveTab('solar'); if(windPoly){ rmL(windPoly); } bringBoundary(); });
+  on(tabs.dams, 'click', ()=>{ setActiveTab('dams'); if(windPoly){ rmL(windPoly); } bringBoundary(); });
+
+  // چک‌باکس‌ها
+  const chkWind  = $('#chk-wind-sites');
+  const chkSolar = $('#chk-solar-sites');
+  const chkDams  = $('#chk-dam-sites');
+
+  on(chkWind,  'change', e=>{ (e.target.checked? addL: rmL)(windPts); bringBoundary(); applyZoomGating(); });
+  on(chkSolar, 'change', e=>{ (e.target.checked? addL: rmL)(solarPts); bringBoundary(); applyZoomGating(); });
+  on(chkDams,  'change', e=>{ (e.target.checked? addL: rmL)(damsPts); bringBoundary(); applyZoomGating(); });
+
+  // جستجوی شهرستان
+  const search = $('#ama-search');
+  on(search, 'keydown', e=>{
+    if(e.key!=='Enter') return;
+    const q = (search.value||'').trim();
+    const fc = window.__countiesGeoAll;
+    if(!q || !fc?.features?.length) return;
+    const f = fc.features.find(f=>{
+      const p=f.properties||{};
+      const n=(p.name_fa||p.name||'').toString();
+      const c=(p.county||p.shahrestan||'').toString();
+      return n.includes(q) || c.includes(q);
+    });
+    if(!f) return;
+    try{
+      const g = L.geoJSON(f);
+      window.map.fitBounds(g.getBounds(), {padding:[24,24]});
+      g.remove();
+    }catch(_){}}
+  );
+
+  // دکمه‌های پایین چپ
+  on($('#btn-zoom-in'),  'click', ()=> window.map.zoomIn());
+  on($('#btn-zoom-out'), 'click', ()=> window.map.zoomOut());
+  on($('#btn-geolocate'),'click', async ()=>{
+    try { window.map.locate({setView:true, maxZoom:10}); } catch(e){ if(window.AMA_DEBUG) console.log('geolocate blocked',e); }
+  });
+
+  // Gating نقاط زیر زوم 8
+  const Z_GATE = 8;
+  function applyZoomGating(){
+    const z = window.map?.getZoom?.() ?? 0;
+    const show = z >= Z_GATE;
+    function toggle(layer, shouldShow, chk){
+      if(!layer) return;
+      if(!chk?.checked){ rmL(layer); return; }
+      if(shouldShow) addL(layer); else rmL(layer);
+    }
+    toggle(windPts,  show, chkWind);
+    toggle(solarPts, show, chkSolar);
+    toggle(damsPts,  show, chkDams);
+    bringBoundary();
+  }
+  window.map?.on?.('zoomend', applyZoomGating);
+
+  // حالت اولیه: تب باد فعال، ولی نقاط خاموش تا کاربر انتخاب کند
+  setActiveTab('wind');
+  if(chkWind)  chkWind.checked  = false;
+  if(chkSolar) chkSolar.checked = false;
+  if(chkDams)  chkDams.checked  = false;
+  if(windPoly) addL(windPoly);
+  applyZoomGating();
+
+  if(window.AMA_DEBUG) console.log('[AMA-UI] wired controls; overlays=', Object.keys(window.overlays||{}));
+}


### PR DESCRIPTION
## Summary
- add debug flags and single bootstrapping path that resolves the map container and builds overlays once
- guard legacy Leaflet controls behind UI mode flag and wire new tab/checkbox/search UI in v2

## Testing
- `npm run validate:layers`
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68bbc77ef840832883bb40ea10f1c19b