### PR TITLE
Add AMA map bootstrap guard and debug utilities

### DIFF
--- a/docs/amaayesh/js/amaayesh-map.js
+++ b/docs/amaayesh/js/amaayesh-map.js
@@ -1,6 +1,25 @@
 (function(){
   const MAP_ID = 'map';
 
+  if (!document.getElementById('map')) {
+    console.error('[AMA] #map container not found; abort bootstrap');
+    return;
+  }
+  // single-run guard
+  if (window.__AMA_BOOTED__) { console.warn('[AMA] already bootstrapped'); return; }
+  window.__AMA_BOOTED__ = true;
+
+  // expose quick checks
+  window.AMA_DEBUG = false;
+  window.AMA_CHECK = () => ({
+    hasMap: !!document.getElementById('map'),
+    overlays: {
+      wind: !!(window.AMA && AMA.groups && AMA.groups.wind && AMA.groups.wind.getLayers().length),
+      solar: !!(window.AMA && AMA.groups && AMA.groups.solar && AMA.groups.solar.getLayers().length),
+      dams: !!(window.AMA && AMA.groups && AMA.groups.dams && AMA.groups.dams.getLayers().length),
+    }
+  });
+
   function dbg(){ if (window.AMA_DEBUG) console.log('[AMA]', ...arguments); }
   function warn(){ console.warn('[AMA]', ...arguments); }
 


### PR DESCRIPTION
## Summary
- Avoid bootstrapping when `#map` element is missing
- Prevent double initialization with single-run guard
- Expose `AMA_CHECK` helper for quick overlay status checks

## Testing
- ⚠️ `npm test` *(Puppeteer `TimeoutError` running e2e tests)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3eee07608328a1de09963dc619e5