### PR TITLE
amaayesh: standardize /data/layers.config.json and prefer it over legacy manifest

### DIFF
--- a/docs/amaayesh/js/amaayesh-map.js
+++ b/docs/amaayesh/js/amaayesh-map.js
@@ -90,8 +90,8 @@
       { maxZoom: 18, attribution: '&copy; OpenStreetMap' }).addTo(map);
 
     // 2) Manifest
-    const manifest = await fetchJsonSafe('amaayesh/layers.config.json')
-                   || await fetchJsonSafe('./layers.config.json');
+    const manifest = await fetchJsonSafe('/data/layers.config.json')
+                   || await fetchJsonSafe('/amaayesh/layers.config.json');
     if (!manifest || !manifest.files) {
       warn('manifest missing → only base map will render');
       return;

--- a/docs/amaayesh/layers.config.json
+++ b/docs/amaayesh/layers.config.json
@@ -1,10 +1,10 @@
 {
   "title": "نقشه تعاملی آمایش انرژی — خراسان رضوی",
   "files": {
-    "counties": "amaayesh/counties.geojson",
-    "province": "amaayesh/khorasan_razavi_combined.geojson",
-    "wind_sites": "amaayesh/wind_sites.geojson",
-    "solar_sites": "amaayesh/solar_sites.geojson",
-    "dams": "amaayesh/dams.geojson"
+    "counties": "counties.geojson",
+    "province": "khorasan_razavi_combined.geojson",
+    "wind_sites": "wind_sites.geojson",
+    "solar_sites": "solar_sites.geojson",
+    "dams": "dams.geojson"
   }
 }

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -213,7 +213,8 @@ function dataBases(){
     new URL('./data/',  here).pathname,
     new URL('../data/', here).pathname
   ];
-  const bases = [...new Set([...preferred, ...relatives])] // dedupe, keep order
+  const legacy = ['/amaayesh/'];
+  const bases = [...new Set([...preferred, ...relatives, ...legacy])] // dedupe, keep order
     .map(p => (p || '/')
       .replace(/\/{2,}/g,'/')
       .replace(/([^/])$/,'$1/'));
@@ -1969,9 +1970,15 @@ async function ama_bootstrap(){
       document.addEventListener('DOMContentLoaded', r, {once:true});
   });
 
-  const manifestUrl = normalizeDataPath('layers.config.json') + '?v=' + (window.__BUILD_ID || Date.now());
+  const manifestUrl1 = normalizeDataPath('layers.config.json') + '?v=' + (window.__BUILD_ID || Date.now());
+  const manifestUrl2 = '/amaayesh/layers.config.json?v=' + (window.__BUILD_ID || Date.now());
+  let manifestUrl = manifestUrl1;
   if (window.AMA_DEBUG) console.log('[AMA] manifest path', manifestUrl);
-  const manifest = await fetch(manifestUrl).then(r=>r.json()).catch(_=>null);
+  let manifest = await fetch(manifestUrl1).then(r=>r.ok ? r.json() : null).catch(_=>null);
+  if(!manifest){
+    manifestUrl = manifestUrl2;
+    manifest = await fetch(manifestUrl2).then(r=>r.ok ? r.json() : null).catch(_=>null);
+  }
   const base = (manifest && manifest.baseData) || {};
   const paths = {
     counties: normalizeDataPath(base.counties || 'amaayesh/counties.geojson'),

--- a/docs/data/layers.config.json
+++ b/docs/data/layers.config.json
@@ -8,15 +8,12 @@
     "amaayesh/solar_sites.geojson",
     "amaayesh/dams.geojson"
   ],
-  "baseData": {
-    "counties": "amaayesh/counties.geojson",
-    "combined": "amaayesh/khorasan_razavi_combined.geojson",
-    "wind_sites": "amaayesh/wind_sites.geojson",
-    "solar_sites": "amaayesh/solar_sites.geojson",
-    "dams": "amaayesh/dams.geojson",
-    "wind_raw_csv": "amaayesh/wind_sites_raw.csv",
-    "wind_weights_csv": "amaayesh/wind_weights_by_county.csv",
-    "version": "2025-09-05",
-    "updated": "2025-09-05T00:00:00Z"
+  "baseData": "amaayesh/",
+  "layers": {
+    "province": "khorasan_razavi_combined.geojson",
+    "counties": "counties.geojson",
+    "wind_sites": "wind_sites.geojson",
+    "solar_sites": "solar_sites.geojson",
+    "dams": "dams.geojson"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:wind": "python3 tools/build_wind_geojson.py",
     "vendor:supercluster": "node tools/vendorize_supercluster.js",
     "audit:ama": "node tools/audit_amaayesh.js",
-    "verify:publish": "node tools/verify_publish_paths.js https://wesh360.ir/amaayesh/layers.config.json https://wesh360.ir/amaayesh/data/counties.geojson https://wesh360.ir/amaayesh/data/wind_sites.geojson || true",
+    "verify:publish": "node tools/verify_publish_paths.js https://wesh360.ir/data/layers.config.json https://wesh360.ir/data/amaayesh/counties.geojson https://wesh360.ir/data/amaayesh/wind_sites.geojson || true",
     "rca:publish": "node tools/rca_publish.js --base=$SITE_URL"
   },
   "keywords": [],

--- a/tools/audit_amaayesh.js
+++ b/tools/audit_amaayesh.js
@@ -5,7 +5,9 @@ function readJSON(fp){ try{ return JSON.parse(fs.readFileSync(fp,'utf8')); }catc
 function exists(fp){ return fs.existsSync(fp) && fs.statSync(fp).isFile(); }
 
 const root = p.resolve(__dirname, '..');
-const manifestPath = p.join(root, 'docs/amaayesh/layers.config.json');
+const manifestPathStd = p.join(root, 'docs/data/layers.config.json');
+const manifestPathLegacy = p.join(root, 'docs/amaayesh/layers.config.json');
+const manifestPath = exists(manifestPathStd) ? manifestPathStd : manifestPathLegacy;
 const jsPath       = p.join(root, 'docs/assets/js/amaayesh-map.js');
 const htmlPath     = p.join(root, 'docs/amaayesh/index.html');
 

--- a/tools/rca_publish.js
+++ b/tools/rca_publish.js
@@ -1,8 +1,8 @@
 const paths = [
-  '/data/amaayesh/layers.config.json',
+  '/data/layers.config.json',
   '/data/amaayesh/counties.geojson',
   '/data/amaayesh/wind_sites.geojson',
-  '/amaayesh/data/layers.config.json',
+  '/amaayesh/layers.config.json',
   '/amaayesh/data/counties.geojson',
   '/amaayesh/data/wind_sites.geojson'
 ];

--- a/tools/verify_publish_paths.js
+++ b/tools/verify_publish_paths.js
@@ -1,13 +1,14 @@
 const args = process.argv.slice(2);
 const paths = args.length ? args : [
-  '/amaayesh/layers.config.json',
+  '/data/layers.config.json',
   '/data/amaayesh/counties.geojson',
   '/data/amaayesh/khorasan_razavi_combined.geojson',
   '/data/amaayesh/wind_sites.geojson',
   '/data/amaayesh/solar_sites.geojson',
   '/data/amaayesh/dams.geojson',
   '/data/amaayesh/wind_sites_raw.csv',
-  '/data/amaayesh/wind_weights_by_county.csv'
+  '/data/amaayesh/wind_weights_by_county.csv',
+  '/amaayesh/layers.config.json'
 ];
 
 const base = process.env.VERIFY_BASE || 'http://localhost:8888';


### PR DESCRIPTION
## Summary
- normalize docs/data/layers.config.json and introduce layers map
- simplify legacy manifest paths and prefer `/data/layers.config.json` in loaders
- update verification tools and scripts to check new manifest first

## Testing
- ⚠️ `npm test` *(missing libatk-1.0.so.0)*
- ✅ `npm run validate:layers`


------
https://chatgpt.com/codex/tasks/task_e_68bc6067201c8328b054b3922c2f3c7c