### PR TITLE
amaayesh: add ama-wire-buttons.js, fix 404s, reliably wire new panel

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -37,18 +37,18 @@
         <button aria-label="تنظیمات" style="border:0;background:transparent;cursor:pointer;opacity:.7">⚙️</button>
       </div>
       <div style="display:flex;gap:8px;margin-bottom:8px">
-        <button id="tab-wind"  style="flex:1;padding:8px 12px;border-radius:10px;background:#2563eb;color:#fff;border:0;cursor:pointer">باد</button>
-        <button id="tab-solar" style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">خورشیدی</button>
-        <button id="tab-dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
+        <button id="tab-wind"  data-layer-toggle="wind"  style="flex:1;padding:8px 12px;border-radius:10px;background:#2563eb;color:#fff;border:0;cursor:pointer">باد</button>
+        <button id="tab-solar" data-layer-toggle="solar" style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">خورشیدی</button>
+        <button id="tab-dams"  data-layer-toggle="dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
       </div>
       <div style="position:relative;margin-bottom:8px">
         <input id="ama-search" type="text" placeholder="جستجوی شهرستان..."
                style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none" />
       </div>
       <div style="display:grid;gap:8px">
-        <label><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
-        <label><input id="chk-solar-sites" type="checkbox"/> سایت‌های خورشیدی</label>
-        <label><input id="chk-dam-sites"   type="checkbox"/> سد</label>
+        <label data-layer-toggle="wind"><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
+        <label data-layer-toggle="solar"><input id="chk-solar-sites" type="checkbox"/> سایت‌های خورشیدی</label>
+        <label data-layer-toggle="dams"><input id="chk-dam-sites"   type="checkbox"/> سد</label>
       </div>
     </aside>
 
@@ -77,5 +77,7 @@
   <script defer src="/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
   <script defer src="/assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script defer src="/assets/js/ama-bridge-new-panel.js"></script>
+  <script defer src="/assets/js/ama-wire-buttons.js"></script>
 </body>
 </html>

--- a/docs/assets/js/ama-bridge-new-panel.js
+++ b/docs/assets/js/ama-bridge-new-panel.js
@@ -1,0 +1,58 @@
+;(function(){
+  function ready(fn){ if(document.readyState!=='loading') fn(); else document.addEventListener('DOMContentLoaded', fn); }
+
+  // نگاشت کلیدها به ورودی‌های پنل قدیمی
+  const LEGACY = {
+    wind:   '#chk-wind-sites',
+    solar:  '#chk-solar-sites',
+    dams:   '#chk-dam-sites'
+  };
+
+  function q(sel){ try { return document.querySelector(sel); } catch { return null; } }
+
+  function findLegacyFor(key){
+    // ابتدا بر اساس IDهای مشهور
+    let el = q(LEGACY[key]);
+    if (el) return el;
+
+    // fallback: بر اساس متن لیبل‌ها (برای زمانی که IDها عوض شده باشد)
+    const map = { wind:/باد/i, solar:/خورشیدی/i, dams:/سد/i };
+    const rx = map[key]; if (!rx) return null;
+    const labels = Array.from(document.querySelectorAll('label'));
+    for (const lbl of labels){
+      const txt=(lbl.textContent||'').trim();
+      if (!rx.test(txt)) continue;
+      const forId=lbl.getAttribute('for');
+      const input = forId ? q('#'+CSS.escape(forId)) : lbl.querySelector('input[type="checkbox"]');
+      if (input) return input;
+    }
+    return null;
+  }
+
+  function bindToggle(newInput, key, legacyInput){
+    if (!newInput || !legacyInput) return;
+    // همگام‌سازی وضعیت اولیه
+    newInput.checked = !!legacyInput.checked;
+    // وقتی جدید تغییر کرد، قدیمی را کلیک کن (تا منطق موجود اجرا شود)
+    newInput.addEventListener('change', ()=> { legacyInput.click(); newInput.checked = legacyInput.checked; });
+    // وقتی قدیمی تغییر کرد، جدید را هم همگام کن (اگر کاربر از پنل قدیم استفاده کند)
+    legacyInput.addEventListener('change', ()=> { newInput.checked = legacyInput.checked; });
+  }
+
+  ready(function(){
+    // همه‌ی کنترل‌های جدید با data-layer-toggle را پیدا کن
+    const news = Array.from(document.querySelectorAll('[data-layer-toggle]'));
+    if (!news.length) return;
+
+    for (const el of news){
+      const key = (el.getAttribute('data-layer-toggle')||'').trim().toLowerCase();
+      if (!key) continue;
+      const legacy = findLegacyFor(key);
+      if (!legacy){
+        console.warn('[AMA-bridge] legacy control not found for', key);
+        continue;
+      }
+      bindToggle(el, key, legacy);
+    }
+  });
+})();

--- a/docs/assets/js/ama-wire-buttons.js
+++ b/docs/assets/js/ama-wire-buttons.js
@@ -1,0 +1,26 @@
+;(function () {
+  function ready(fn){ if (document.readyState !== 'loading') fn(); else document.addEventListener('DOMContentLoaded', fn); }
+
+  ready(function () {
+    const map = window.__AMA_MAP;
+    const G = window.AMA?.G || {};
+    if (!map) { console.warn('[AMA-wire] map missing'); return; }
+
+    // init state of checkboxes (unchecked by default)
+    document.querySelectorAll('[data-layer-toggle]').forEach(el => {
+      const key = el.getAttribute('data-layer-toggle')?.trim();
+      if (!key) return;
+
+      // reflect current visibility
+      const grp = G[key];
+      el.checked = !!(grp && map.hasLayer(grp));
+
+      el.addEventListener('change', () => {
+        const grp2 = (window.AMA?.G || {})[key];
+        if (!grp2) { console.warn('[AMA-wire] group not found:', key, Object.keys(window.AMA?.G || {})); return; }
+        if (el.checked) grp2.addTo(map);
+        else map.removeLayer(grp2);
+      });
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- replace `amaayesh-map.js` with a lightweight bootstrap that registers core layer groups on `window.AMA.G` and loads GeoJSON data from `layers.config.json`
- simplify `ama-wire-buttons.js` to attach change listeners that toggle the corresponding map layers and log when a group is missing
- restore `amaayesh-map.js` to the original full engine so `__dumpAmaState` and layer manifest handling work as before
- bridge new panel toggles to legacy checkbox controls so existing map logic handles layer visibility

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64b3a7c8832899f42a107266df5d