### PR TITLE
amaayesh: add ama-wire-buttons.js, fix 404s, reliably wire new panel

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -37,18 +37,18 @@
         <button aria-label="تنظیمات" style="border:0;background:transparent;cursor:pointer;opacity:.7">⚙️</button>
       </div>
       <div style="display:flex;gap:8px;margin-bottom:8px">
-        <button id="tab-wind"  style="flex:1;padding:8px 12px;border-radius:10px;background:#2563eb;color:#fff;border:0;cursor:pointer">باد</button>
-        <button id="tab-solar" style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">خورشیدی</button>
-        <button id="tab-dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
+        <button id="tab-wind"  data-layer-toggle="wind"  style="flex:1;padding:8px 12px;border-radius:10px;background:#2563eb;color:#fff;border:0;cursor:pointer">باد</button>
+        <button id="tab-solar" data-layer-toggle="solar" style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">خورشیدی</button>
+        <button id="tab-dams"  data-layer-toggle="dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
       </div>
       <div style="position:relative;margin-bottom:8px">
         <input id="ama-search" type="text" placeholder="جستجوی شهرستان..."
                style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none" />
       </div>
       <div style="display:grid;gap:8px">
-        <label><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
-        <label><input id="chk-solar-sites" type="checkbox"/> سایت‌های خورشیدی</label>
-        <label><input id="chk-dam-sites"   type="checkbox"/> سد</label>
+        <label data-layer-toggle="wind"><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
+        <label data-layer-toggle="solar"><input id="chk-solar-sites" type="checkbox"/> سایت‌های خورشیدی</label>
+        <label data-layer-toggle="dams"><input id="chk-dam-sites"   type="checkbox"/> سد</label>
       </div>
     </aside>
 
@@ -77,5 +77,8 @@
   <script defer src="/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
   <script defer src="/assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script defer src="/assets/js/ama-bridge-new-panel.js"></script>
+  <script defer src="/assets/js/ama-wire-buttons.js"></script>
+  <script defer src="/assets/js/ama-diag.js"></script>
 </body>
 </html>

--- a/docs/assets/js/ama-bridge-new-panel.js
+++ b/docs/assets/js/ama-bridge-new-panel.js
@@ -1,0 +1,81 @@
+;(function(){
+  const STEP=250, MAX=8000, NEW_SCOPE='#ama-layer-dock';
+  const idMap = { wind:'#chk-wind-sites', solar:'#chk-solar-sites', dams:'#chk-dam-sites' };
+  const rxMap = { wind:/باد/i, solar:/خورشیدی/i, dams:/سد/i };
+  const missing = new Set(['wind','solar','dams']);
+  const bridgedPairs = [];
+  const wiredOnce = { info:false };
+
+  function inNewScope(el){ return !!el && !!el.closest(NEW_SCOPE); }
+  function setUi(el, on){
+    if (el.matches('input[type="checkbox"]')) el.checked = !!on;
+    el.classList.toggle('muted', !on);
+    if (el.hasAttribute('aria-pressed')) el.setAttribute('aria-pressed', on?'true':'false');
+  }
+  function findNewToggles(){
+    const root = document.querySelector(NEW_SCOPE); if(!root) return [];
+    return Array.from(root.querySelectorAll('[data-layer-toggle]'))
+      .map(el=>({ el, key:(el.dataset.layerToggle||'').trim().toLowerCase() }))
+      .filter(x=>x.key);
+  }
+  function findLegacyByKey(key){
+    const byId = document.querySelector(idMap[key]);
+    if (byId && !inNewScope(byId)) return byId;
+    const rx = rxMap[key]; if(!rx) return null;
+    const labels = Array.from(document.querySelectorAll('label')).filter(l=>!inNewScope(l));
+    for (const lbl of labels){
+      const txt=(lbl.textContent||'').trim();
+      if (!rx.test(txt)) continue;
+      const forId = lbl.getAttribute('for');
+      const input = forId ? document.getElementById(forId) : lbl.querySelector('input[type="checkbox"]');
+      if (input && !inNewScope(input)) return input;
+    }
+    return null;
+  }
+  function syncPair(newEl, legacy){
+    setUi(newEl, !!legacy.checked);
+    const fwd = ()=>{ legacy.click(); setUi(newEl, !!legacy.checked); };
+    newEl.addEventListener('change', fwd);
+    newEl.addEventListener('click',  fwd);
+    legacy.addEventListener('change', ()=> setUi(newEl, !!legacy.checked));
+  }
+
+  function tryBind(){
+    const toggles = findNewToggles(); if (!toggles.length) return 'no-new';
+    let bound=0;
+    toggles.forEach(({el,key})=>{
+      if (el.__bridged) return;
+      const legacy = findLegacyByKey(key);
+      if (!legacy) { missing.add(key); return; }
+      missing.delete(key);
+      syncPair(el, legacy);
+      el.__bridged = true;
+      bridgedPairs.push({key, newSel: describeEl(el), legacySel: describeEl(legacy)});
+      bound++;
+    });
+    if (bound>0 && !wiredOnce.info) { console.info('[AMA-bridge] bridged:', bound); wiredOnce.info=true; }
+    return bound>0 ? 'ok' : 'pending';
+  }
+
+  function describeEl(el){
+    if (!el) return '';
+    const id = el.id ? '#'+el.id : '';
+    const cls = (el.className && typeof el.className==='string') ? '.'+el.className.trim().split(/\s+/).slice(0,2).join('.') : '';
+    return el.tagName.toLowerCase()+id+cls;
+  }
+
+  (function wait(t0=performance.now()){
+    const res = tryBind();
+    if (res==='ok') return;
+    if (performance.now()-t0 > MAX) {
+      if (missing.size) console.warn('[AMA-bridge] timeout: missing', Array.from(missing));
+      return;
+    }
+    setTimeout(()=>wait(t0), STEP);
+  })();
+
+  const mo = new MutationObserver(()=> tryBind());
+  mo.observe(document.documentElement, {subtree:true, childList:true, attributes:false});
+
+  window.__amaBridgePairs = function(){ return bridgedPairs.slice(); };
+})();

--- a/docs/assets/js/ama-diag.js
+++ b/docs/assets/js/ama-diag.js
@@ -1,0 +1,39 @@
+;(function(){
+  const MAX_MS = 10000, STEP = 300;
+  function collect() {
+    const map = window.__AMA_MAP || (window.AMA && window.AMA.map) || null;
+    const G = (window.AMA && window.AMA.G) || {};
+    const keys = Object.keys(G||{});
+    const toggles = Array.from(document.querySelectorAll('[data-layer-toggle]'));
+    const groups = keys.map(k=>{
+      const grp = G[k]; let size = 0;
+      if (grp && typeof grp.getLayers==='function') { try{ size = grp.getLayers().length } catch(e){ size = -1 } }
+      const on = map && grp ? map.hasLayer(grp) : false;
+      return { key:k, layers:size, visible:on };
+    });
+    const ui = toggles.map(el=>{
+      const key = (el.getAttribute('data-layer-toggle')||'').trim();
+      return { el: el.tagName.toLowerCase()+'#'+(el.id||''), key, bridged: !!el.__bridged, checked: !!el.checked };
+    });
+    return { mapReady: !!map, gKeys: keys, groups, ui };
+  }
+  function logReport(tag, data){
+    console.log(`[AMA-DIAG] ${tag}`);
+    console.log('mapReady:', data.mapReady);
+    console.log('G keys:', data.gKeys);
+    console.table(data.groups);
+    console.table(data.ui);
+    console.table(window.__amaBridgePairs && window.__amaBridgePairs());
+  }
+  function runDiag(){ const d = collect(); logReport('panel wiring status', d); return d; }
+  window.__amaDiag = runDiag;
+  const t0 = Date.now();
+  (function loop(){
+    const d = collect();
+    if (d.mapReady && d.gKeys.length) { logReport('ready', d); return; }
+    if (d.mapReady && !d.gKeys.length) { logReport('ready(no-registry)', d); return; }
+    if (Date.now()-t0 > MAX_MS) { logReport('timeout', d); return; }
+    setTimeout(loop, STEP);
+  })();
+  document.addEventListener('keydown', (e)=>{ if ((e.ctrlKey||e.metaKey)&&e.altKey && e.key.toLowerCase()==='d') window.__amaDiag(); });
+})();

--- a/docs/assets/js/ama-wire-buttons.js
+++ b/docs/assets/js/ama-wire-buttons.js
@@ -1,0 +1,52 @@
+;(function () {
+  const STEP = 250, MAX_MS = 10000;
+  function norm(s){ return String(s||'').toLowerCase().replace(/[_\-\s]/g,''); }
+  function resolve(G, rawKey){
+    if (!rawKey || !G) return null;
+    if (G[rawKey]) return G[rawKey];
+    const want = norm(rawKey);
+    for (const k of Object.keys(G)) if (norm(k)===want) return G[k];
+    const syn = { wind:['wind','باد'], solar:['solar','خورشیدی'], dams:['dams','سد'], counties:['counties','شهرستان'], province:['province','استان'] };
+    for (const k in syn){ if (syn[k].some(x=>norm(x)===want)) return G[k] || G[k+'_sites'] || null; }
+    return null;
+  }
+  function setUi(el, on){
+    if (el.matches('input[type="checkbox"]')) el.checked = !!on;
+    el.classList.toggle('muted', !on);
+    if (el.hasAttribute('aria-pressed')) el.setAttribute('aria-pressed', on?'true':'false');
+  }
+  let registryLogged = false, bridgedLogged = false;
+  function wireAll(){
+    const map = window.__AMA_MAP || (window.AMA && window.AMA.map) || null;
+    const G = (window.AMA && window.AMA.G) || {};
+    if (!map) return 'map-missing';
+    if (!G || Object.keys(G).length===0){
+      if (!registryLogged){ console.info('[AMA-wire] skipped: registry-empty'); registryLogged = true; }
+      return 'registry-empty';
+    }
+    const nodes = Array.from(document.querySelectorAll('[data-layer-toggle]'));
+    const unBridged = nodes.filter(el => !el.__bridged);
+    if (!unBridged.length){
+      if (!bridgedLogged){ console.info('[AMA-wire] skipped: bridged-by-dom'); bridgedLogged = true; }
+      return 'skipped-bridged';
+    }
+    unBridged.forEach(el=>{
+      const key = (el.getAttribute('data-layer-toggle')||'').trim();
+      const grp = resolve(G, key);
+      if (!grp) { console.warn('[AMA-wire] group not found for key:', key, 'available:', Object.keys(G)); return; }
+      if (!map.hasLayer(grp)) grp.addTo(map);
+      setUi(el, map.hasLayer(grp));
+      const handler = ()=>{ const on = map.hasLayer(grp); on ? map.removeLayer(grp) : map.addLayer(grp); setUi(el, map.hasLayer(grp)); };
+      el.addEventListener('change', handler);
+      el.addEventListener('click', handler);
+    });
+    console.info('[AMA-wire] wired:', unBridged.length);
+    return 'wired';
+  }
+  (function wait(t0=performance.now()){
+    const res = wireAll();
+    if (res==='wired' || res==='registry-empty' || res==='skipped-bridged') return;
+    if (performance.now() - t0 > MAX_MS) { console.warn('[AMA-wire] timeout:', res); return; }
+    setTimeout(()=>wait(t0), STEP);
+  })();
+})();


### PR DESCRIPTION
## Summary
- Bridge new-panel toggles to legacy controls with MutationObserver rebinds and precise UI syncing
- Skip DOM-bridged nodes and empty registries when wiring layer toggles, keeping logs clean
- Diagnostic helper prints UI status and bridged pairs via `window.__amaDiag()`

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64b3a7c8832899f42a107266df5d