### PR TITLE
amaayesh: add ama-wire-buttons.js, fix 404s, reliably wire new panel

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../assets/tailwind.css"/>
   <link rel="stylesheet" href="../assets/vendor/leaflet/leaflet.css" />
   <link rel="stylesheet" href="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.css" />
+  <link rel="stylesheet" href="/assets/css/map-overrides.css" />
   <link rel="stylesheet" href="../assets/legend.css"/>
   <style>
     html, body { height:100% }
@@ -37,18 +38,18 @@
         <button aria-label="تنظیمات" style="border:0;background:transparent;cursor:pointer;opacity:.7">⚙️</button>
       </div>
       <div style="display:flex;gap:8px;margin-bottom:8px">
-        <button id="tab-wind"  style="flex:1;padding:8px 12px;border-radius:10px;background:#2563eb;color:#fff;border:0;cursor:pointer">باد</button>
-        <button id="tab-solar" style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">خورشیدی</button>
-        <button id="tab-dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
+        <button id="tab-wind"  data-layer-toggle="wind"  style="flex:1;padding:8px 12px;border-radius:10px;background:#2563eb;color:#fff;border:0;cursor:pointer">باد</button>
+        <button id="tab-solar" data-layer-toggle="solar" style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">خورشیدی</button>
+        <button id="tab-dams"  data-layer-toggle="dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
       </div>
       <div style="position:relative;margin-bottom:8px">
         <input id="ama-search" type="text" placeholder="جستجوی شهرستان..."
                style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none" />
       </div>
       <div style="display:grid;gap:8px">
-        <label><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
-        <label><input id="chk-solar-sites" type="checkbox"/> سایت‌های خورشیدی</label>
-        <label><input id="chk-dam-sites"   type="checkbox"/> سد</label>
+        <label data-layer-toggle="wind"><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
+        <label data-layer-toggle="solar"><input id="chk-solar-sites" type="checkbox"/> سایت‌های خورشیدی</label>
+        <label data-layer-toggle="dams"><input id="chk-dam-sites"   type="checkbox"/> سد</label>
       </div>
     </aside>
 
@@ -74,8 +75,12 @@
 
   <!-- supercluster optional (CDN removed due to CSP). Use local vendor if added. -->
   <script defer src="/assets/vendor/leaflet/leaflet.js"></script>
+  <script defer src="/assets/js/leaflet-icon-patch.js"></script>
   <script defer src="/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
   <script defer src="/assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script defer src="/assets/js/ama-bridge-new-panel.js"></script>
+  <script defer src="/assets/js/ama-wire-buttons.js"></script>
+  <script defer src="/assets/js/ama-diag.js"></script>
 </body>
 </html>

--- a/docs/assets/css/map-overrides.css
+++ b/docs/assets/css/map-overrides.css
@@ -1,0 +1,2 @@
+/* stop leaflet from probing images/marker-icon.png via CSS */
+.leaflet-default-icon-path { background-image: none !important; }

--- a/docs/assets/js/ama-bridge-new-panel.js
+++ b/docs/assets/js/ama-bridge-new-panel.js
@@ -1,0 +1,81 @@
+;(function(){
+  const STEP=250, MAX=8000, NEW_SCOPE='#ama-layer-dock';
+  const idMap = { wind:'#chk-wind-sites', solar:'#chk-solar-sites', dams:'#chk-dam-sites' };
+  const rxMap = { wind:/باد/i, solar:/خورشیدی/i, dams:/سد/i };
+  const missing = new Set(['wind','solar','dams']);
+  const bridgedPairs = [];
+  const wiredOnce = { info:false };
+
+  function inNewScope(el){ return !!el && !!el.closest(NEW_SCOPE); }
+  function setUi(el, on){
+    if (el.matches('input[type="checkbox"]')) el.checked = !!on;
+    el.classList.toggle('muted', !on);
+    if (el.hasAttribute('aria-pressed')) el.setAttribute('aria-pressed', on?'true':'false');
+  }
+  function findNewToggles(){
+    const root = document.querySelector(NEW_SCOPE); if(!root) return [];
+    return Array.from(root.querySelectorAll('[data-layer-toggle]'))
+      .map(el=>({ el, key:(el.dataset.layerToggle||'').trim().toLowerCase() }))
+      .filter(x=>x.key);
+  }
+  function findLegacyByKey(key){
+    const byId = document.querySelector(idMap[key]);
+    if (byId && !inNewScope(byId)) return byId;
+    const rx = rxMap[key]; if(!rx) return null;
+    const labels = Array.from(document.querySelectorAll('label')).filter(l=>!inNewScope(l));
+    for (const lbl of labels){
+      const txt=(lbl.textContent||'').trim();
+      if (!rx.test(txt)) continue;
+      const forId = lbl.getAttribute('for');
+      const input = forId ? document.getElementById(forId) : lbl.querySelector('input[type="checkbox"]');
+      if (input && !inNewScope(input)) return input;
+    }
+    return null;
+  }
+  function syncPair(newEl, legacy){
+    setUi(newEl, !!legacy.checked);
+    const fwd = ()=>{ legacy.click(); setUi(newEl, !!legacy.checked); };
+    newEl.addEventListener('change', fwd);
+    newEl.addEventListener('click',  fwd);
+    legacy.addEventListener('change', ()=> setUi(newEl, !!legacy.checked));
+  }
+
+  function tryBind(){
+    const toggles = findNewToggles(); if (!toggles.length) return 'no-new';
+    let bound=0;
+    toggles.forEach(({el,key})=>{
+      if (el.__bridged) return;
+      const legacy = findLegacyByKey(key);
+      if (!legacy) { missing.add(key); return; }
+      missing.delete(key);
+      syncPair(el, legacy);
+      el.__bridged = true;
+      bridgedPairs.push({key, newSel: describeEl(el), legacySel: describeEl(legacy)});
+      bound++;
+    });
+    if (bound>0 && !wiredOnce.info) { console.info('[AMA-bridge] bridged:', bound); wiredOnce.info=true; }
+    return bound>0 ? 'ok' : 'pending';
+  }
+
+  function describeEl(el){
+    if (!el) return '';
+    const id = el.id ? '#'+el.id : '';
+    const cls = (el.className && typeof el.className==='string') ? '.'+el.className.trim().split(/\s+/).slice(0,2).join('.') : '';
+    return el.tagName.toLowerCase()+id+cls;
+  }
+
+  (function wait(t0=performance.now()){
+    const res = tryBind();
+    if (res==='ok') return;
+    if (performance.now()-t0 > MAX) {
+      if (missing.size) console.warn('[AMA-bridge] timeout: missing', Array.from(missing));
+      return;
+    }
+    setTimeout(()=>wait(t0), STEP);
+  })();
+
+  const mo = new MutationObserver(()=> tryBind());
+  mo.observe(document.documentElement, {subtree:true, childList:true, attributes:false});
+
+  window.__amaBridgePairs = function(){ return bridgedPairs.slice(); };
+})();

--- a/docs/assets/js/ama-diag.js
+++ b/docs/assets/js/ama-diag.js
@@ -1,0 +1,39 @@
+;(function(){
+  const MAX_MS = 10000, STEP = 300;
+  function collect() {
+    const map = window.__AMA_MAP || (window.AMA && window.AMA.map) || null;
+    const G = (window.AMA && window.AMA.G) || {};
+    const keys = Object.keys(G||{});
+    const toggles = Array.from(document.querySelectorAll('[data-layer-toggle]'));
+    const groups = keys.map(k=>{
+      const grp = G[k]; let size = 0;
+      if (grp && typeof grp.getLayers==='function') { try{ size = grp.getLayers().length } catch(e){ size = -1 } }
+      const on = map && grp ? map.hasLayer(grp) : false;
+      return { key:k, layers:size, visible:on };
+    });
+    const ui = toggles.map(el=>{
+      const key = (el.getAttribute('data-layer-toggle')||'').trim();
+      return { el: el.tagName.toLowerCase()+'#'+(el.id||''), key, bridged: !!el.__bridged, checked: !!el.checked };
+    });
+    return { mapReady: !!map, gKeys: keys, groups, ui };
+  }
+  function logReport(tag, data){
+    console.log(`[AMA-DIAG] ${tag}`);
+    console.log('mapReady:', data.mapReady);
+    console.log('G keys:', data.gKeys);
+    console.table(data.groups);
+    console.table(data.ui);
+    console.table(window.__amaBridgePairs && window.__amaBridgePairs());
+  }
+  function runDiag(){ const d = collect(); logReport('panel wiring status', d); return d; }
+  window.__amaDiag = runDiag;
+  const t0 = Date.now();
+  (function loop(){
+    const d = collect();
+    if (d.mapReady && d.gKeys.length) { logReport('ready', d); return; }
+    if (d.mapReady && !d.gKeys.length) { logReport('ready(no-registry)', d); return; }
+    if (Date.now()-t0 > MAX_MS) { logReport('timeout', d); return; }
+    setTimeout(loop, STEP);
+  })();
+  document.addEventListener('keydown', (e)=>{ if ((e.ctrlKey||e.metaKey)&&e.altKey && e.key.toLowerCase()==='d') window.__amaDiag(); });
+})();

--- a/docs/assets/js/ama-wire-buttons.js
+++ b/docs/assets/js/ama-wire-buttons.js
@@ -1,0 +1,51 @@
+;(function () {
+  const STEP = 250, MAX_MS = 10000;
+  function norm(s){ return String(s||'').toLowerCase().replace(/[_\-\s]/g,''); }
+  function resolve(G, rawKey){
+    if (!rawKey || !G) return null;
+    if (G[rawKey]) return G[rawKey];
+    const want = norm(rawKey);
+    for (const k of Object.keys(G)) if (norm(k)===want) return G[k];
+    const syn = { wind:['wind','باد'], solar:['solar','خورشیدی'], dams:['dams','سد'], counties:['counties','شهرستان'], province:['province','استان'] };
+    for (const k in syn){ if (syn[k].some(x=>norm(x)===want)) return G[k] || G[k+'_sites'] || null; }
+    return null;
+  }
+  function setUi(el, on){
+    if (el.matches('input[type="checkbox"]')) el.checked = !!on;
+    el.classList.toggle('muted', !on);
+    if (el.hasAttribute('aria-pressed')) el.setAttribute('aria-pressed', on?'true':'false');
+  }
+  let registryLogged = false, bridgedLogged = false;
+  function wireAll(){
+    const map = window.__AMA_MAP || (window.AMA && window.AMA.map) || null;
+    const G = (window.AMA && window.AMA.G) || {};
+    if (!map) return 'map-missing';
+    if (!G || Object.keys(G).length===0){
+      if (!registryLogged){ console.info('[AMA-wire] skipped: registry-empty'); registryLogged = true; }
+      return 'registry-empty';
+    }
+    const nodes = Array.from(document.querySelectorAll('[data-layer-toggle]'));
+    const unBridged = nodes.filter(el => !el.__bridged);
+    if (!unBridged.length){
+      if (!bridgedLogged){ console.info('[AMA-wire] skipped: bridged-by-dom'); bridgedLogged = true; }
+      return 'skipped-bridged';
+    }
+    unBridged.forEach(el=>{
+      const key = (el.getAttribute('data-layer-toggle')||'').trim();
+      const grp = resolve(G, key);
+      if (!grp) { console.warn('[AMA-wire] group not found for key:', key, 'available:', Object.keys(G)); return; }
+      setUi(el, map.hasLayer(grp));
+      const handler = ()=>{ const on = map.hasLayer(grp); on ? map.removeLayer(grp) : map.addLayer(grp); setUi(el, map.hasLayer(grp)); };
+      el.addEventListener('change', handler);
+      el.addEventListener('click', handler);
+    });
+    console.info('[AMA-wire] wired:', unBridged.length);
+    return 'wired';
+  }
+  (function wait(t0=performance.now()){
+    const res = wireAll();
+    if (res==='wired' || res==='registry-empty' || res==='skipped-bridged') return;
+    if (performance.now() - t0 > MAX_MS) { console.warn('[AMA-wire] timeout:', res); return; }
+    setTimeout(()=>wait(t0), STEP);
+  })();
+})();

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -1,6 +1,23 @@
 // --- Build id ---
 window.__AMA_BUILD_ID = document.querySelector('meta[name="build-id"]')?.content || String(Date.now());
 
+// --- AMA global & layer registry (early)
+const AMA = window.AMA = window.AMA || {};
+AMA.G = AMA.G || {
+  wind: L.layerGroup(),
+  solar: L.layerGroup(),
+  dams: L.layerGroup(),
+  counties: L.layerGroup(),
+  province: L.layerGroup(),
+};
+// expose map placeholder
+window.__AMA_MAP = window.__AMA_MAP || null;
+
+// Choropleth flag (opt-in) + debug marker control
+AMA.flags = AMA.flags || {};
+AMA.flags.debugCountyMarker = false;
+const CHORO_ON = !!AMA.flags.enableChoropleth;
+
 ;(function(){
   window.__AMA_UI_VERSION = 'dock-probe-v1';
   if (window.AMA_DEBUG) console.log('[AMA:UI]', window.__AMA_UI_VERSION, 'build=', window.__AMA_BUILD_ID, 'path=', location.pathname);
@@ -138,6 +155,74 @@ function normalizeDataPath(p){
   if(/^https?:\/\//i.test(p)) return p;
   const s = p.startsWith('/') ? p : '/data/' + p.replace(/^(\.\/)?/,'');
   return s.replace(/\/\/+/g,'/');
+}
+
+// Join helper
+function joinPath(base, file){
+  const b = String(base||'').replace(/^\/+|\/+$/g,'');
+  const f = String(file||'').replace(/^\/+/, '');
+  return b ? `${b}/${f}` : f;
+}
+
+// Resolve paths from manifest
+function resolvePathsFromManifest(manifest){
+  const base = (manifest && manifest.baseData) || '';
+  const LAY  = (manifest && manifest.layers) || {};
+  const provinceFile = LAY.province || LAY.combined || 'khorasan_razavi_combined.geojson';
+  return {
+    counties: joinPath(base, LAY.counties || 'counties.geojson'),
+    province: joinPath(base, provinceFile),
+    wind:     joinPath(base, LAY.wind_sites  || 'wind_sites.geojson'),
+    solar:    joinPath(base, LAY.solar_sites || 'solar_sites.geojson'),
+    dams:     joinPath(base, LAY.dams        || 'dams.geojson'),
+  };
+}
+
+// Safe fetch with timeout + legacy fallback
+async function getJSONwithFallback(relPath, timeoutMs = 30000){
+  const urlPrimary = `/data/${String(relPath).replace(/^\/+/, '')}`;
+  const urlLegacy  = `/${String(relPath).replace(/^\/+/, '')}`;
+  async function fetchJson(url){
+    const ctl = new AbortController();
+    const t = setTimeout(()=>ctl.abort(), timeoutMs);
+    try {
+      const res = await fetch(url, { signal: ctl.signal, cache:'no-store' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const ct = (res.headers.get('content-type')||'').toLowerCase();
+      const txt = await res.text();
+      if (ct.includes('html') || txt.trim().startsWith('<!DOCTYPE')) throw new Error('not-json');
+      return JSON.parse(txt);
+    } finally { clearTimeout(t); }
+  }
+  try {
+    return await fetchJson(urlPrimary);
+  } catch(e1){
+    console.warn('[AHA] primary failed:', urlPrimary, e1.message, '→ trying legacy', urlLegacy);
+    try { return await fetchJson(urlLegacy); }
+    catch(e2){ console.error('[AHA] fetch fail:', relPath, e2.message); return null; }
+  }
+}
+
+// Bounds helper
+function boundsFromGeoJSON(gj){
+  try {
+    if (gj && Array.isArray(gj.features) && gj.features.length) {
+      return L.geoJSON(gj).getBounds();
+    }
+  } catch(_){ }
+  return null;
+}
+
+function enforceDefaultVisibility(map){
+  const G = (window.AMA && AMA.G) || {};
+  const DEFAULT_ON = new Set(['counties','province']); // فقط مرزها
+  Object.keys(G).forEach(k=>{
+    const grp = G[k]; if (!grp) return;
+    const shouldOn = DEFAULT_ON.has(k);
+    const isOn = map.hasLayer(grp);
+    if (shouldOn && !isOn) grp.addTo(map);
+    if (!shouldOn && isOn) map.removeLayer(grp);
+  });
 }
 
 window.__AMA_BOOTING = window.__AMA_BOOTING || false;
@@ -308,9 +393,11 @@ window.setActiveWindKPI = function(k){
   if (window.__countiesLayer) {
     const dyn = computeQuantileBreaksFromLayer(window.__countiesLayer, k);
     if (dyn) window.__WIND_BREAKS = dyn;
-    eachPolyFeatureLayer(window.__countiesLayer, l=>{
-      if (l.feature) l.setStyle(styleForCounty(l.feature));
-    });
+    if (CHORO_ON) {
+      eachPolyFeatureLayer(window.__countiesLayer, l=>{
+        if (l.feature) l.setStyle(styleForCounty(l.feature));
+      });
+    }
   }
   if (typeof renderLegend==='function') renderLegend();
   if (typeof __AMA_renderTop10==='function') __AMA_renderTop10();
@@ -631,7 +718,7 @@ async function joinWindWeightsOnAll(){
     p.wind_class   = w.wind_class||'';
     p.__hasWindData= (p.wind_N>0 || p.wind_sumW>0);
 
-    leaf.setStyle(styleForCounty(leaf.feature));
+    if (CHORO_ON) leaf.setStyle(styleForCounty(leaf.feature));
   });
 
   window.__WIND_DATA_READY = true;
@@ -1212,7 +1299,7 @@ async function actuallyLoadManifest(){
     })();
 
     // === WIND: load computed datasets (amaayesh/counties.geojson + amaayesh/wind_sites.geojson) ===
-    {
+    if (CHORO_ON) {
       const classColors = {1:'#bdbdbd', 2:'#f6c945', 3:'#29cc7a'};
       const fmt = (x, d=1) => (x==null || isNaN(x)) ? '—' : Number(x).toFixed(d);
       const radiusFromMW = mw => Math.max(5, 1.6*Math.sqrt(Math.max(0, mw||0)));
@@ -1979,42 +2066,88 @@ async function ama_bootstrap(){
     manifestUrl = manifestUrl2;
     manifest = await fetch(manifestUrl2).then(r=>r.ok ? r.json() : null).catch(_=>null);
   }
-  const base = (manifest && manifest.baseData) || {};
-  const paths = {
-    counties: normalizeDataPath(base.counties || 'amaayesh/counties.geojson'),
-    combined: normalizeDataPath(base.combined || 'amaayesh/khorasan_razavi_combined.geojson'),
-    wind:     normalizeDataPath(base.wind_sites || 'amaayesh/wind_sites.geojson'),
-    solar:    normalizeDataPath(base.solar_sites || 'amaayesh/solar_sites.geojson'),
-    dams:     normalizeDataPath(base.dams || 'amaayesh/dams.geojson'),
-  };
-  if (window.AMA_DEBUG) console.log('[AMA] paths', paths);
+  const pathsResolved = resolvePathsFromManifest(manifest);
+  if (window.AMA_DEBUG) console.log('[AMA] paths', pathsResolved);
 
   window.__LAYER_MANIFEST_JSON = manifest;
   window.__LAYER_MANIFEST_URL = manifestUrl;
-  window.__AMA_BASE_PATHS = paths;
+  window.__AMA_BASE_PATHS = pathsResolved;
 
-  function getJSON(url){ return Promise.race([
-    fetch(url).then(r=>{ if(!r.ok) throw new Error(url+' '+r.status); return r.json(); }),
-    new Promise((_,rej)=> setTimeout(()=>rej(new Error('timeout '+url)), 9000))
-  ]).catch(e=>{ console.error('[AHA] fetch fail:',e.message); return null; }); }
-
-  const [countiesFC, combinedFC] = await Promise.all([
-    getJSON(paths.counties), getJSON(paths.combined)
+  const [countiesFC, provinceFC, windFC, solarFC, damsFC] = await Promise.all([
+    getJSONwithFallback(pathsResolved.counties),
+    getJSONwithFallback(pathsResolved.province),
+    getJSONwithFallback(pathsResolved.wind),
+    getJSONwithFallback(pathsResolved.solar),
+    getJSONwithFallback(pathsResolved.dams),
   ]);
 
-  let all = null;
-  if (Array.isArray(countiesFC?.features) && countiesFC.features.length > 10) {
-    all = countiesFC;
-  } else if (Array.isArray(combinedFC?.features)) {
-    const f = combinedFC.features.filter(x => String(x?.properties?.admin_level) === '6');
-    if (f.length) all = { type:'FeatureCollection', features:f };
+  // سبک پایه برای نقاط
+  function pointStyle(kind){
+    return { radius: 4, weight: 1, opacity: 1, fillOpacity: 0.7 };
   }
-  if (!all) all = { type:'FeatureCollection', features:[] };
-  window.__countiesGeoAll = all;
-  window.__combinedGeo = combinedFC;
-  if (window.AMA_DEBUG) console.log('[AHA] all-counties.features =', all.features.length);
 
-  const map = L.map('map', { preferCanvas:true, zoomControl:true });
+  // ساخت لایه GeoJSON با circleMarker
+  function asCircleLayer(gj, kind){
+    if (!gj) return null;
+    return L.geoJSON(gj, {
+      pointToLayer: (_f, latlng)=> L.circleMarker(latlng, pointStyle(kind))
+    });
+  }
+
+  // افزودن ایمن به رجیستری بدون مارکر آیکنی
+  function setPointGroup(key, gj){
+    const grp = AMA.G[key]; if (!grp) return;
+    grp.clearLayers();
+    const lyr = asCircleLayer(gj, key); if (lyr) grp.addLayer(lyr);
+  }
+
+  function addPolyGroup(key, gj){
+    if(!gj) return;
+    const style = key==='province'
+      ? { color:'#6b7280', weight:2, opacity:0.8, fillOpacity:0 }
+      : { color:'#111',    weight:2, opacity:1,   fillOpacity:0 };
+    const layer = L.geoJSON(gj, { style: () => style });
+    AMA.G[key].clearLayers();
+    AMA.G[key].addLayer(layer);
+  }
+
+  addPolyGroup('counties', countiesFC);
+  addPolyGroup('province', provinceFC);
+  setPointGroup('wind', windFC);
+  setPointGroup('solar', solarFC);
+  setPointGroup('dams', damsFC);
+
+  function coerceMarkersToCircles(groupKey){
+    const grp = AMA.G[groupKey]; if (!grp) return;
+    const toAdd = [], toRemove = [];
+    grp.eachLayer(l=>{
+      if (l instanceof L.GeoJSON){
+        l.eachLayer(inn=>{
+          if (inn instanceof L.Marker && typeof inn.getLatLng==='function'){
+            const ll = inn.getLatLng();
+            toRemove.push(inn);
+            toAdd.push(L.circleMarker(ll, pointStyle(groupKey)));
+          }
+        });
+      } else if (l instanceof L.Marker && typeof l.getLatLng==='function'){
+        const ll = l.getLatLng();
+        toRemove.push(l);
+        toAdd.push(L.circleMarker(ll, pointStyle(groupKey)));
+      }
+    });
+    toRemove.forEach(x=> grp.removeLayer(x));
+    toAdd.forEach(x=> grp.addLayer(x));
+  }
+
+  ['wind','solar','dams'].forEach(k=>{ coerceMarkersToCircles(k); });
+  setTimeout(()=> ['wind','solar','dams'].forEach(k=> coerceMarkersToCircles(k)), 0);
+
+  window.__countiesGeoAll = countiesFC || { type:'FeatureCollection', features:[] };
+  window.__combinedGeo = provinceFC;
+  if (window.AMA_DEBUG) console.log('[AHA] all-counties.features =', (countiesFC?.features||[]).length);
+
+  const map = window.__AMA_MAP || AMA.map || L.map('map', { preferCanvas:true, zoomControl:true });
+  window.__AMA_MAP = map;
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(map);
   if (map.zoomControl && typeof map.zoomControl.setPosition==='function') map.zoomControl.setPosition('bottomleft');
   if (map.attributionControl && typeof map.attributionControl.setPosition === 'function') {
@@ -2033,7 +2166,6 @@ async function ama_bootstrap(){
 
   const canvasRenderer = L.canvas({padding:0.5});
   window.__AMA_canvasRenderer = canvasRenderer;
-  window.__AMA_MAP = map;
 
   const _rm = map.removeLayer.bind(map);
   map.removeLayer = (lyr) => {
@@ -2044,15 +2176,42 @@ async function ama_bootstrap(){
     return _rm(lyr);
   };
 
+  enforceDefaultVisibility(map);
+  setTimeout(()=>enforceDefaultVisibility(map), 0);
+
   await __refreshBoundary(map, { keepOld:false });
-  map.fitBounds(boundary.getBounds(), { padding:[12,12] });
-  map.setMaxBounds(boundary.getBounds().pad(0.25));
+
+  const b1 = (countiesFC && L.geoJSON(countiesFC).getBounds()) || null;
+  const b2 = (provinceFC && L.geoJSON(provinceFC).getBounds()) || null;
+  let bounds = b1 || b2;
+  if (b1 && b2) { try { bounds = b1.extend(b2); } catch(_){} }
+  if (bounds && bounds.isValid && bounds.isValid()) map.fitBounds(bounds);
+  else console.warn('[AMA] no valid bounds; skip fitBounds');
   boundary.setStyle({ className: 'neon-edge' });
   map.on('layeradd overlayadd overlayremove', () => {
     if (boundary?.bringToFront) boundary.bringToFront();
   });
 
-  await buildOverlaysAfterBoundary(paths);
+  window.__AMA_COUNTS = {
+    counties: (countiesFC?.features||[]).length,
+    province: (provinceFC?.features||[]).length,
+    wind: (windFC?.features||[]).length,
+    solar: (solarFC?.features||[]).length,
+    dams: (damsFC?.features||[]).length,
+  };
+
+  window.__dumpAmaState = function(){
+    const info = {
+      manifestUrl,
+      baseData: manifest?.baseData || null,
+      paths: window.__AMA_BASE_PATHS,
+      counts: window.__AMA_COUNTS,
+    };
+    if (window.AMA_DEBUG) console.log('[AMA] dump', info);
+    return info;
+  };
+
+  await buildOverlaysAfterBoundary(pathsResolved);
 
   window.__AMA_BOOTSTRAPPED = true;
   window.__AMA_BOOTING = false;

--- a/docs/assets/js/leaflet-icon-patch.js
+++ b/docs/assets/js/leaflet-icon-patch.js
@@ -1,0 +1,6 @@
+;(function(){
+  const PX='data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Yg7Q7MAAAAASUVORK5CYII=';
+  if (window.L && L.Icon && L.Icon.Default) {
+    L.Icon.Default.mergeOptions({ iconUrl: PX, iconRetinaUrl: PX, shadowUrl: PX });
+  }
+})();


### PR DESCRIPTION
## Summary
- Remove Leaflet icon binaries and load a small patch after Leaflet to stop missing image probes
- Render wind, solar and dam points as `circleMarker` layers and guard debug county markers behind a flag
- Wire new-panel toggles without auto-adding layers so only counties/province are visible by default

## Testing
- `npm test` *(fails: Failed to launch the browser process: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc64b3a7c8832899f42a107266df5d