### PR TITLE
feat: add county search bridge

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -7,7 +7,6 @@
   <link rel="icon" href="../page/landing/favicon.ico"/>
   <link rel="stylesheet" href="../assets/tailwind.css"/>
   <link rel="stylesheet" href="../assets/vendor/leaflet/leaflet.css" />
-  <link rel="stylesheet" href="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.css" />
   <link rel="stylesheet" href="/assets/css/map-overrides.css" />
   <link rel="stylesheet" href="../assets/legend.css"/>
   <style>
@@ -43,8 +42,16 @@
         <button id="tab-dams"  data-layer-toggle="dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
       </div>
       <div style="position:relative;margin-bottom:8px">
-        <input id="ama-search" type="text" placeholder="جستجوی شهرستان..."
-               style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none" />
+        <input
+          id="ama-county-search"
+          type="text"
+          inputmode="search"
+          autocomplete="off"
+          aria-label="جستجوی شهرستان"
+          placeholder="...جستجوی شهرستان"
+          style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none"
+        />
+        <div id="ama-county-search-hint" style="display:none;font-size:12px;color:#b91c1c;margin-top:4px;"></div>
       </div>
       <div style="display:grid;gap:8px">
         <label data-layer-toggle="wind"><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
@@ -76,9 +83,9 @@
   <!-- supercluster optional (CDN removed due to CSP). Use local vendor if added. -->
   <script defer src="/assets/vendor/leaflet/leaflet.js"></script>
   <script defer src="/assets/js/leaflet-icon-patch.js"></script>
-  <script defer src="/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
   <script defer src="/assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script defer src="/assets/js/ama-search-bridge.js"></script>
   <script defer src="/assets/js/panel-direct-wire.js"></script>
   <script defer src="/assets/js/ama-diag.js"></script>
 </body>

--- a/docs/assets/js/ama-search-bridge.js
+++ b/docs/assets/js/ama-search-bridge.js
@@ -1,0 +1,161 @@
+/* docs/assets/js/ama-search-bridge.js */
+(function AMA_SEARCH_BRIDGE(){
+  // --- Helpers ---
+  function normalizeFa(s=''){
+    return s
+      .replace(/\u200c/g, ' ') // ZWNJ -> space
+      .replace(/[ي]/g, 'ی').replace(/[ك]/g, 'ک')
+      .replace(/[ۀة]/g, 'ه')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .toLowerCase();
+  }
+
+  // Wait until map + counties are ready
+  const T_MAX = 8000, STEP = 150;
+  const t0 = performance.now();
+
+  function getMap(){
+    return (window.__AMA_MAP && (window.__AMA_MAP.map || window.__AMA_MAP.leaflet)) ||
+           window.AMA_MAP || window.map || null;
+  }
+
+  function countiesReady(){
+    // 1) ترجیح: GeoJSON لودشده توسط بوت‌استرپ
+    if (window.__AMA_MAP?.countiesGeo?.features?.length) return true;
+    // 2) فallback: گروه لِفلتی شهرستان‌ها
+    const grp = window.__AMA_MAP?.groups?.counties?.[0] || window.__AMA_COUNTIES_LAYER;
+    if (grp && (grp.getLayers?.() || grp.eachLayer)) return true;
+    return false;
+  }
+
+  function collectCountyFeatures(){
+    // ترجیح: GeoJSON خام
+    if (window.__AMA_MAP?.countiesGeo?.features?.length) {
+      return window.__AMA_MAP.countiesGeo.features;
+    }
+    // فallback: از گروه لفلتی استخراج کن
+    const grp = window.__AMA_MAP?.groups?.counties?.[0] || window.__AMA_COUNTIES_LAYER;
+    const feats = [];
+    if (grp?.eachLayer){
+      grp.eachLayer(l => { if (l?.feature) feats.push(l.feature); });
+    } else if (grp?.toGeoJSON){
+      const gj = grp.toGeoJSON();
+      if (gj?.features?.length) return gj.features;
+    }
+    return feats;
+  }
+
+  function run(){
+    const map = getMap();
+    const input = document.getElementById('ama-county-search');
+    if (!map || !input) {
+      console.warn('[AMA-search] map or input not found');
+      return;
+    }
+
+    // Build index from ALL county features (should be ~73)
+    const feats = collectCountyFeatures();
+    const index = [];
+    const pushIdx = (name, f) => {
+      if (!name) return;
+      index.push({ raw:name, norm:normalizeFa(name), f });
+    };
+
+    for (const f of feats){
+      const p = f.properties || {};
+      const name = p.county || p.NAME || p.name || p.title || '';
+      pushIdx(name, f);
+      // پوشش نام‌های مستعار اگر شیء AMA_ALIASES موجود است
+      if (window.AMA_ALIASES && Array.isArray(window.AMA_ALIASES[name])){
+        for (const a of window.AMA_ALIASES[name]) pushIdx(a, f);
+      }
+    }
+
+    // Make sure counties layer is visible on search
+    function ensureCountiesVisible(){
+      const grp = window.__AMA_MAP?.groups?.counties?.[0];
+      try { if (grp && !map.hasLayer(grp)) map.addLayer(grp); } catch(e){}
+    }
+
+    // Highlight + fit
+    let lastHL = null;
+    function clearHL(){
+      try {
+        if (lastHL?.setStyle) lastHL.setStyle({ weight:2, color:'#000', fillOpacity:0.0 });
+        if (lastHL?.remove && lastHL.__tempHL) lastHL.remove(); // اگر لایه‌ی موقت بود
+      } catch(e){}
+      lastHL = null;
+    }
+
+    function findLeafletLayerForFeature(f){
+      const grp = window.__AMA_MAP?.groups?.counties?.[0] || window.__AMA_COUNTIES_LAYER;
+      let found = null;
+      if (grp?.eachLayer){
+        grp.eachLayer(l => { if (!found && l?.feature === f) found = l; });
+      }
+      return found;
+    }
+
+    function showFeature(f){
+      ensureCountiesVisible();
+      let lyr = findLeafletLayerForFeature(f);
+      // اگر لایهٔ اصلی پیدا نشد، یک geoJSON موقت برای های‌لایت بساز
+      if (!lyr && window.L && L.geoJSON){
+        lyr = L.geoJSON(f, { style:{ weight:3, color:'#0ea5e9', fillOpacity:0.15 } });
+        lyr.__tempHL = true;
+        lyr.addTo(map);
+      }
+      if (lyr){
+        clearHL();
+        if (!lyr.__tempHL && lyr.setStyle) lyr.setStyle({ weight:3, color:'#0ea5e9', fillOpacity:0.15 });
+        lastHL = lyr;
+        try { map.fitBounds(lyr.getBounds(), { padding:[20,20] }); } catch(e){}
+      }
+    }
+
+    function searchNow(q){
+      const nq = normalizeFa(q);
+      if (!nq){ clearHL(); return; }
+      // exact first, then contains
+      let hit = index.find(x => x.norm === nq) || index.find(x => x.norm.includes(nq));
+      if (hit) showFeature(hit.f);
+    }
+
+    // Wire UI
+    let deb=null;
+    input.addEventListener('input', ()=>{
+      clearTimeout(deb);
+      deb = setTimeout(()=>searchNow(input.value||''), 220);
+    });
+    input.addEventListener('keydown', (e)=>{
+      if (e.key === 'Enter'){ e.preventDefault(); searchNow(input.value||''); }
+      if (e.key === 'Escape'){ input.value=''; clearHL(); }
+    });
+    const clearBtn = document.getElementById('ama-county-clear');
+    if (clearBtn) clearBtn.addEventListener('click', ()=>{ input.value=''; clearHL(); input.focus(); });
+
+    // قطع اتصال پل/شنونده‌های قدیمی (اگر باقی‌مانده‌اند)
+    try {
+      const legacy = document.querySelector('.leaflet-control-search, .leaflet-control-geocoder');
+      if (legacy && legacy.parentNode) legacy.parentNode.removeChild(legacy);
+    } catch(e){}
+
+    window.__amaSearch = { index, searchNow, clearHL };
+    console.info('[AMA-search] wired. counties:', feats.length, 'index:', index.length);
+  }
+
+  (function wait(){
+    const map = getMap();
+    if (map && countiesReady()){
+      run();
+      return;
+    }
+    if (performance.now() - t0 > T_MAX){
+      console.warn('[AMA-search] timeout waiting for map/counties');
+      return;
+    }
+    setTimeout(wait, STEP);
+  })();
+})();
+

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -99,6 +99,10 @@ const __COUNTY_ALIASES = Object.assign(
     'بينالود': 'بینالود'
   }
 );
+const AMA_ALIASES = window.AMA_ALIASES = window.AMA_ALIASES || {};
+for (const [alias, canon] of Object.entries(__COUNTY_ALIASES)) {
+  if (alias !== canon) (AMA_ALIASES[canon] = AMA_ALIASES[canon] || []).push(alias);
+}
 function canonicalCountyName(s=''){
   let t = (s||'').toString()
     .replace(/[يى]/g,'ی').replace(/ك/g,'ک')
@@ -1482,8 +1486,9 @@ async function actuallyLoadManifest(){
           if(infoEl) infoEl.textContent = 'داده شهرستان‌ها در دسترس نیست.';
         }
       }
-    // === Local search & geolocate ===
-    const searchCtl = L.control({position:'topleft'});
+      // === Local search & geolocate (legacy search) ===
+      if (!document.getElementById('ama-county-search')) {
+      const searchCtl = L.control({position:'topleft'});
     searchCtl.onAdd = function(){
       const div = L.DomUtil.create('div','ama-search');
       div.innerHTML = `<input type="text" placeholder="جستجوی شهرستان/سایت…"/><button title="یافتن موقعیت من">📍</button><div class="ama-suggestions" style="display:none"></div>`;
@@ -1526,7 +1531,8 @@ async function actuallyLoadManifest(){
       });
       return div;
     };
-    searchCtl.addTo(map);
+      searchCtl.addTo(map);
+      }
 
     function debounce(fn,ms){ let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn.apply(this,args),ms); }; }
     function toast(msg){ const info=document.getElementById('info'); if(info){ info.textContent=msg; setTimeout(()=>{info.textContent='';},3000); } }
@@ -1854,21 +1860,23 @@ async function actuallyLoadManifest(){
 
       L.control.scale({ metric:true, imperial:false }).addTo(map);
 
-      if (L.Control && L.Control.geocoder) {
-        const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
-        geocoder.on('markgeocode', e => {
-          const center = e.geocode.center;
-          const name = e.geocode.name;
-          safeClearGroup(searchLayer);
-          searchLayer.addLayer(L.circleMarker(center, {
-            radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
-          }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
-          if (e.geocode.bbox) {
-            map.fitBounds(e.geocode.bbox);
-          } else {
-            map.setView(center, 14);
-          }
-        });
+      if (!document.getElementById('ama-county-search')) {
+        if (L.Control && L.Control.geocoder) {
+          const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
+          geocoder.on('markgeocode', e => {
+            const center = e.geocode.center;
+            const name = e.geocode.name;
+            safeClearGroup(searchLayer);
+            searchLayer.addLayer(L.circleMarker(center, {
+              radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
+            }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
+            if (e.geocode.bbox) {
+              map.fitBounds(e.geocode.bbox);
+            } else {
+              map.setView(center, 14);
+            }
+          });
+        }
       }
 
       // اگر لایه گاز موجود است، جلوه‌های اضافه اعمال شود
@@ -2006,8 +2014,9 @@ async function actuallyLoadManifest(){
 
       applyMode();
 
-      // === Tool Dock ===
-      function makePanel(title, bodyHtml){
+        // === Tool Dock ===
+        if (!document.getElementById('ama-county-search')) {
+        function makePanel(title, bodyHtml){
         const ctl = L.control({position:'topleft'});
         ctl.onAdd = function(){
           const wrap=L.DomUtil.create('div','ama-panel');
@@ -2050,8 +2059,9 @@ async function actuallyLoadManifest(){
 
       panels.search.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); setTimeout(()=>{wrap.querySelector('#ama-search-input')?.focus();},0); const btn=wrap.querySelector('#ama-search-go'); btn?.addEventListener('click',()=>{ const val=wrap.querySelector('#ama-search-input').value.trim(); if(!val) return; const site = windSitesRaw.find(s=>s.name_fa===val); if(site){ map.setView([+site.lat,+site.lon],11); } else { focusCountyByName(val); } }); return wrap; }; })(panels.search.onAdd);
       panels.layers.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const body=wrap.querySelector('.ama-panel-bd'); body.innerHTML='<label><input type="checkbox" data-layer="wind" checked/> لایه باد</label><label><input type="checkbox" data-layer="sites" checked/> سایت‌ها</label>'; body.querySelectorAll('input[data-layer]').forEach(ch=>{ ch.addEventListener('change',()=>{ const lay=ch.dataset.layer; const LAY = lay==='wind'?window.windChoroplethLayer:window.windSitesLayer; if(LAY){ if(ch.checked) map.addLayer(LAY); else safeRemoveLayer(map, LAY);} });}); return wrap; }; })(panels.layers.onAdd);
-      panels.download.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const btn=wrap.querySelector('#ama-dl-csv'); btn?.addEventListener('click',()=>{ const rows=polysFC.features.map(f=>f.properties); const csv=makeTopCSV(rows); downloadBlob('kpi.csv',csv); }); return wrap; }; })(panels.download.onAdd);
-    })();
+        panels.download.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const btn=wrap.querySelector('#ama-dl-csv'); btn?.addEventListener('click',()=>{ const rows=polysFC.features.map(f=>f.properties); const csv=makeTopCSV(rows); downloadBlob('kpi.csv',csv); }); return wrap; }; })(panels.download.onAdd);
+        }
+      })();
 }
 
 async function ama_bootstrap(){


### PR DESCRIPTION
## Summary
- build direct county search bridge with normalized Persian queries and alias indexing
- expose alias map and guard legacy geocoder and tool-dock when new search input exists

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `node tests/mapper.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0dcefcd083288654c5ac56ab8b1b