### PR TITLE
feat: add county and wind site search

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -7,7 +7,6 @@
   <link rel="icon" href="../page/landing/favicon.ico"/>
   <link rel="stylesheet" href="../assets/tailwind.css"/>
   <link rel="stylesheet" href="../assets/vendor/leaflet/leaflet.css" />
-  <link rel="stylesheet" href="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.css" />
   <link rel="stylesheet" href="/assets/css/map-overrides.css" />
   <link rel="stylesheet" href="../assets/legend.css"/>
   <style>
@@ -43,8 +42,16 @@
         <button id="tab-dams"  data-layer-toggle="dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
       </div>
       <div style="position:relative;margin-bottom:8px">
-        <input id="ama-search" type="text" placeholder="جستجوی شهرستان..."
-               style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none" />
+        <input
+          id="ama-county-search"
+          type="text"
+          inputmode="search"
+          autocomplete="off"
+          aria-label="جستجوی شهرستان"
+          placeholder="...جستجوی شهرستان"
+          style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none"
+        />
+        <div id="ama-county-search-hint" style="display:none;font-size:12px;color:#b91c1c;margin-top:4px;"></div>
       </div>
       <div style="display:grid;gap:8px">
         <label data-layer-toggle="wind"><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
@@ -76,9 +83,9 @@
   <!-- supercluster optional (CDN removed due to CSP). Use local vendor if added. -->
   <script defer src="/assets/vendor/leaflet/leaflet.js"></script>
   <script defer src="/assets/js/leaflet-icon-patch.js"></script>
-  <script defer src="/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
   <script defer src="/assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script defer src="/assets/js/ama-search-bridge.js"></script>
   <script defer src="/assets/js/panel-direct-wire.js"></script>
   <script defer src="/assets/js/ama-diag.js"></script>
 </body>

--- a/docs/assets/js/ama-search-bridge.js
+++ b/docs/assets/js/ama-search-bridge.js
@@ -1,0 +1,113 @@
+/* docs/assets/js/ama-search-bridge.js */
+(function AMA_SEARCH_BRIDGE(){
+  const STEP=200, T_MAX=20000, t0=performance.now();
+  const log=(...a)=>console.log('%c[AMA-search]','color:#0ea5e9',...a);
+  const warn=(...a)=>console.warn('%c[AMA-search]','color:#f59e0b',...a);
+
+  if(!window.__amaSearch) window.__amaSearch = {
+    index:[], get stats(){return {total:0,counties:0,wind:0,missingCounties:[],missingWind:[]}},
+    focusCountyByName(){return false;}, focusWindSiteByName(){return false;}, rebuild(){/*noop*/}
+  };
+
+  const NFA=s=>String(s||'')
+    .replace(/\u200c/g,' ')
+    .replace(/[ي]/g,'ی').replace(/[ك]/g,'ک').replace(/[ۀة]/g,'ه')
+    .replace(/\s+/g,' ').trim().toLowerCase();
+
+  const getMap = ()=> (window.__AMA_MAP && (window.__AMA_MAP.map||window.__AMA_MAP.leaflet)) || null;
+  const groups = ()=> window.__AMA_MAP?.groups || {};
+
+  const countyName=f=> f?.properties?.county ?? f?.properties?.COUNTY ?? f?.properties?.name ?? f?.properties?.NAME ?? f?.properties?.title ?? f?.properties?.نام ?? '';
+  const windName  =f=> f?.properties?.site_name ?? f?.properties?.name ?? f?.properties?.title ?? f?.properties?.label ?? f?.properties?.نام ?? f?.properties?.site ?? '';
+
+  function featuresFromGroup(key, rawFC){
+    if (rawFC?.features?.length) return rawFC.features.slice();
+    const grp = groups()[key]?.[0] || (key==='counties'?window.__AMA_COUNTIES_LAYER:window.__AMA_WIND_LAYER);
+    if (!grp) return [];
+    if (grp.toGeoJSON){ const gj=grp.toGeoJSON(); return Array.isArray(gj?.features)?gj.features:[]; }
+    const out=[]; grp.eachLayer?.(l=>{ if(l?.feature) out.push(l.feature); });
+    return out;
+  }
+
+  const countyFeatures = ()=> featuresFromGroup('counties', window.__AMA_MAP?.countiesGeo);
+  const windFeatures   = ()=> featuresFromGroup('wind',     window.__AMA_MAP?.windSitesGeo);
+
+  let lastHL=null;
+  function clearHL(){ try{ if(lastHL?.__tempHL&&lastHL.remove) lastHL.remove(); else if(lastHL?.setStyle) lastHL.setStyle({weight:2,color:'#000',fillOpacity:0}); }catch(e){} lastHL=null; }
+  function ensureCountiesVisible(){ const map=getMap(), grp=groups().counties?.[0]||window.__AMA_COUNTIES_LAYER; try{ if(map&&grp&&typeof map.hasLayer==='function'&&!map.hasLayer(grp)) map.addLayer(grp); }catch(e){} return grp; }
+  function findLayerForFeature(grp,f){ if(!grp?.eachLayer) return null; let found=null; grp.eachLayer(l=>{ if(!found && l?.feature===f) found=l; }); return found; }
+
+  function focusCountyByName(name){
+    const nq=NFA(name); const f=countyFeatures().find(ff=>NFA(countyName(ff))===nq);
+    if(!f){ warn('county not found:',name); return false; }
+    const map=getMap(), grp=ensureCountiesVisible(); let lyr=findLayerForFeature(grp,f);
+    if(!lyr && window.L?.geoJSON){ lyr=L.geoJSON(f,{style:{weight:3,color:'#0ea5e9',fillOpacity:0.15}}); lyr.__tempHL=true; lyr.addTo(map); }
+    if(lyr){ clearHL(); if(!lyr.__tempHL && lyr.setStyle) lyr.setStyle({weight:3,color:'#0ea5e9',fillOpacity:0.15}); try{ map.fitBounds(lyr.getBounds(),{padding:[20,20]}); }catch(e){} lastHL=lyr; }
+    return true;
+  }
+
+  function focusWindSiteByName(name){
+    const nq=NFA(name); const f=windFeatures().find(ff=>NFA(windName(ff))===nq);
+    if(!f){ warn('wind site not found:',name); return false; }
+    const map=getMap(); let latlng=null; try{
+      const g=f.geometry; if(g?.type==='Point') latlng=[g.coordinates[1],g.coordinates[0]];
+      else if(window.L?.geoJSON){ const gj=L.geoJSON(f); const b=gj.getBounds(); latlng=b.getCenter(); gj.remove(); }
+    }catch(e){}
+    if(latlng){ try{ map.setView(latlng, Math.max(map.getZoom?.()||10, 11)); }catch(e){} }
+    return !!latlng;
+  }
+
+  function buildIndex(){
+    const idx=[], push=(label,type,f)=>{ const raw=(label??'').toString().trim(); if(!raw) return; idx.push({raw, norm:NFA(raw), type, f}); };
+    countyFeatures().forEach(f=>push(countyName(f),'county',f));
+    windFeatures().forEach(f=>push(windName(f),'wind',f));
+    return idx;
+  }
+
+  function run(){
+    const input=document.getElementById('ama-county-search'), map=getMap();
+    if(!map||!input) return warn('map or input not found');
+
+    let index=buildIndex();
+
+    // baseline Q&A (۵ شهرستان + نام سایت‌های بادی)
+    const expectedCounties=['تایباد','خواف','زاوه','مشهد','نیشابور'].map(NFA);
+    const expectedWind=['البلاغ','باراکوه','تق‌قز سفلی','حصاریزدان','خرگرد','خواف','رهنه','سراب','سنگال‌آباد','سنگان','طرح توسعه چخماق','طرح توسعه کنگ اولیا','عباسی‌آباد','عبدل‌آباد','فهندر','فیندر','قادری‌آباد','مهرآباد','نشتیفان','نصر‌آباد','نوده','کودکان','کوه‌آباد'].map(NFA);
+    const have=new Set(index.map(x=>x.norm));
+    const missingCounties=expectedCounties.filter(n=>!have.has(n));
+    const missingWind=expectedWind.filter(n=>!have.has(n));
+    log('wired:',{ total:index.length, counties:index.filter(x=>x.type==='county').length, wind:index.filter(x=>x.type==='wind').length, missingCounties, missingWind });
+
+    let deb=null;
+    function searchNow(q){
+      const nq=NFA(q); if(!nq){ clearHL(); return; }
+      const hit=index.find(x=>x.type==='county'&&x.norm===nq)
+             || index.find(x=>x.type==='county'&&x.norm.includes(nq))
+             || index.find(x=>x.norm===nq)
+             || index.find(x=>x.norm.includes(nq));
+      if(!hit) return;
+      if(hit.type==='county') focusCountyByName(hit.raw); else focusWindSiteByName(hit.raw);
+    }
+    input.addEventListener('input',()=>{ clearTimeout(deb); deb=setTimeout(()=>searchNow(input.value||''),220); });
+    input.addEventListener('keydown',e=>{ if(e.key==='Enter'){ e.preventDefault(); searchNow(input.value||''); } if(e.key==='Escape'){ input.value=''; clearHL(); } });
+
+    window.__amaSearch={
+      get index(){return index;},
+      focusCountyByName, focusWindSiteByName,
+      get stats(){ return { total:index.length, counties:index.filter(x=>x.type==='county').length, wind:index.filter(x=>x.type==='wind').length, missingCounties, missingWind }; },
+      rebuild(){ index=buildIndex(); log('reindexed:',{total:index.length}); }
+    };
+
+    // late re-index if data arrives after
+    const tryReindex=()=>{ const c=countyFeatures().length, w=windFeatures().length; if(c+w>index.length) window.__amaSearch.rebuild(); };
+    setTimeout(tryReindex,800); setTimeout(tryReindex,2000);
+  }
+
+  (function wait(){
+    const ready = !!getMap() && (countyFeatures().length + windFeatures().length) > 0 && document.getElementById('ama-county-search');
+    if(ready) return run();
+    if(performance.now()-t0 > T_MAX) return warn('timeout waiting for map/data');
+    setTimeout(wait, STEP);
+  })();
+})();
+

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -11,7 +11,7 @@ AMA.G = AMA.G || {
   province: L.layerGroup(),
 };
 // expose map placeholder
-window.__AMA_MAP = window.__AMA_MAP || null;
+window.__AMA_MAP = window.__AMA_MAP || {};
 
 // Choropleth flag (opt-in) + debug marker control
 AMA.flags = AMA.flags || {};
@@ -99,6 +99,10 @@ const __COUNTY_ALIASES = Object.assign(
     'بينالود': 'بینالود'
   }
 );
+const AMA_ALIASES = window.AMA_ALIASES = window.AMA_ALIASES || {};
+for (const [alias, canon] of Object.entries(__COUNTY_ALIASES)) {
+  if (alias !== canon) (AMA_ALIASES[canon] = AMA_ALIASES[canon] || []).push(alias);
+}
 function canonicalCountyName(s=''){
   let t = (s||'').toString()
     .replace(/[يى]/g,'ی').replace(/ك/g,'ک')
@@ -610,7 +614,7 @@ window.addEventListener('error', e => {
 // (IIFE wrapper) — now converted to callable function
 async function buildOverlaysAfterBoundary(paths){
 // === AMA HELPERS (top-level, safe scope) ===
-const map = window.__AMA_MAP;
+const map = window.__AMA_MAP?.map;
 const canvasRenderer = window.__AMA_canvasRenderer;
 const AMA_DEBUG = window.AMA_DEBUG;
 let __LAYER_MANIFEST_BASE = '/data/';
@@ -776,6 +780,11 @@ async function joinWindWeightsOnAll(){
       window.__countiesLayer = countiesFill;
       window.__AMA_countySource = 'preloaded all-counties';
       window.__countiesGeoAll = countiesGJ;
+      window.__AMA_MAP = window.__AMA_MAP || {};
+      window.__AMA_MAP.groups = window.__AMA_MAP.groups || {};
+      window.__AMA_MAP.countiesGeo = countiesGJ;
+      window.__AMA_MAP.groups.counties = [countiesFill];
+      window.__AMA_COUNTIES_LAYER = countiesFill;
       if (window.AMA_DEBUG) console.log('[AHA] county source=preloaded');
       if (window.AMA_DEBUG) console.log('[AMA] base groups protected:', !!baseAdminGroup, !!countiesFill?.__AMA_PROTECTED, !!boundary?.__AMA_PROTECTED);
     }
@@ -1482,8 +1491,9 @@ async function actuallyLoadManifest(){
           if(infoEl) infoEl.textContent = 'داده شهرستان‌ها در دسترس نیست.';
         }
       }
-    // === Local search & geolocate ===
-    const searchCtl = L.control({position:'topleft'});
+      // === Local search & geolocate (legacy search) ===
+      if (!document.getElementById('ama-county-search')) {
+      const searchCtl = L.control({position:'topleft'});
     searchCtl.onAdd = function(){
       const div = L.DomUtil.create('div','ama-search');
       div.innerHTML = `<input type="text" placeholder="جستجوی شهرستان/سایت…"/><button title="یافتن موقعیت من">📍</button><div class="ama-suggestions" style="display:none"></div>`;
@@ -1526,7 +1536,8 @@ async function actuallyLoadManifest(){
       });
       return div;
     };
-    searchCtl.addTo(map);
+      searchCtl.addTo(map);
+      }
 
     function debounce(fn,ms){ let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn.apply(this,args),ms); }; }
     function toast(msg){ const info=document.getElementById('info'); if(info){ info.textContent=msg; setTimeout(()=>{info.textContent='';},3000); } }
@@ -1854,21 +1865,23 @@ async function actuallyLoadManifest(){
 
       L.control.scale({ metric:true, imperial:false }).addTo(map);
 
-      if (L.Control && L.Control.geocoder) {
-        const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
-        geocoder.on('markgeocode', e => {
-          const center = e.geocode.center;
-          const name = e.geocode.name;
-          safeClearGroup(searchLayer);
-          searchLayer.addLayer(L.circleMarker(center, {
-            radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
-          }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
-          if (e.geocode.bbox) {
-            map.fitBounds(e.geocode.bbox);
-          } else {
-            map.setView(center, 14);
-          }
-        });
+      if (!document.getElementById('ama-county-search')) {
+        if (L.Control && L.Control.geocoder) {
+          const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
+          geocoder.on('markgeocode', e => {
+            const center = e.geocode.center;
+            const name = e.geocode.name;
+            safeClearGroup(searchLayer);
+            searchLayer.addLayer(L.circleMarker(center, {
+              radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
+            }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
+            if (e.geocode.bbox) {
+              map.fitBounds(e.geocode.bbox);
+            } else {
+              map.setView(center, 14);
+            }
+          });
+        }
       }
 
       // اگر لایه گاز موجود است، جلوه‌های اضافه اعمال شود
@@ -2006,8 +2019,9 @@ async function actuallyLoadManifest(){
 
       applyMode();
 
-      // === Tool Dock ===
-      function makePanel(title, bodyHtml){
+        // === Tool Dock ===
+        if (!document.getElementById('ama-county-search')) {
+        function makePanel(title, bodyHtml){
         const ctl = L.control({position:'topleft'});
         ctl.onAdd = function(){
           const wrap=L.DomUtil.create('div','ama-panel');
@@ -2050,8 +2064,9 @@ async function actuallyLoadManifest(){
 
       panels.search.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); setTimeout(()=>{wrap.querySelector('#ama-search-input')?.focus();},0); const btn=wrap.querySelector('#ama-search-go'); btn?.addEventListener('click',()=>{ const val=wrap.querySelector('#ama-search-input').value.trim(); if(!val) return; const site = windSitesRaw.find(s=>s.name_fa===val); if(site){ map.setView([+site.lat,+site.lon],11); } else { focusCountyByName(val); } }); return wrap; }; })(panels.search.onAdd);
       panels.layers.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const body=wrap.querySelector('.ama-panel-bd'); body.innerHTML='<label><input type="checkbox" data-layer="wind" checked/> لایه باد</label><label><input type="checkbox" data-layer="sites" checked/> سایت‌ها</label>'; body.querySelectorAll('input[data-layer]').forEach(ch=>{ ch.addEventListener('change',()=>{ const lay=ch.dataset.layer; const LAY = lay==='wind'?window.windChoroplethLayer:window.windSitesLayer; if(LAY){ if(ch.checked) map.addLayer(LAY); else safeRemoveLayer(map, LAY);} });}); return wrap; }; })(panels.layers.onAdd);
-      panels.download.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const btn=wrap.querySelector('#ama-dl-csv'); btn?.addEventListener('click',()=>{ const rows=polysFC.features.map(f=>f.properties); const csv=makeTopCSV(rows); downloadBlob('kpi.csv',csv); }); return wrap; }; })(panels.download.onAdd);
-    })();
+        panels.download.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const btn=wrap.querySelector('#ama-dl-csv'); btn?.addEventListener('click',()=>{ const rows=polysFC.features.map(f=>f.properties); const csv=makeTopCSV(rows); downloadBlob('kpi.csv',csv); }); return wrap; }; })(panels.download.onAdd);
+        }
+      })();
 }
 
 async function ama_bootstrap(){
@@ -2153,8 +2168,10 @@ async function ama_bootstrap(){
   window.__combinedGeo = provinceFC;
   if (window.AMA_DEBUG) console.log('[AHA] all-counties.features =', (countiesFC?.features||[]).length);
 
-  const map = window.__AMA_MAP || AMA.map || L.map('map', { preferCanvas:true, zoomControl:true });
-  window.__AMA_MAP = map;
+  window.__AMA_MAP = window.__AMA_MAP || {};
+  const map = window.__AMA_MAP.map || AMA.map || L.map('map', { preferCanvas:true, zoomControl:true });
+  window.__AMA_MAP.map = map;
+  window.__AMA_MAP.leaflet = map;
   L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(map);
   if (map.zoomControl && typeof map.zoomControl.setPosition==='function') map.zoomControl.setPosition('bottomleft');
   if (map.attributionControl && typeof map.attributionControl.setPosition === 'function') {
@@ -2199,6 +2216,34 @@ async function ama_bootstrap(){
   map.on('layeradd overlayadd overlayremove', () => {
     if (boundary?.bringToFront) boundary.bringToFront();
   });
+
+  // --- expose map & data safely (single source of truth) ---
+  window.__AMA_MAP = window.__AMA_MAP || {};
+  const G = window.__AMA_MAP;
+
+  // 0) map reference
+  G.map = map;         // Leaflet map instance
+  G.leaflet = map;     // back-compat
+
+  // 1) raw FeatureCollections (fallback-aware)
+  G.countiesGeo   = (typeof countiesFC   !== 'undefined' ? countiesFC   : (typeof countiesGeo   !== 'undefined' ? countiesGeo   : null));
+  G.windSitesGeo  = (typeof windFC       !== 'undefined' ? windFC       : (typeof windGeojson  !== 'undefined' ? windGeojson  : (typeof windSitesGeo  !== 'undefined' ? windSitesGeo  : null)));
+  G.solarSitesGeo = (typeof solarFC      !== 'undefined' ? solarFC      : (typeof solarGeojson !== 'undefined' ? solarGeojson : null));
+  G.damsGeo       = (typeof damsFC       !== 'undefined' ? damsFC       : (typeof damsGeojson  !== 'undefined' ? damsGeojson  : null));
+
+  // 2) layer groups actually added to the map (normalize to arrays)
+  G.groups = G.groups || {};
+  const toArr = v => Array.isArray(v) ? v.filter(Boolean) : (v ? [v] : []);
+  const countiesLayer = AMA.G.counties;
+
+  G.groups.counties = toArr(typeof countiesLayer      !== 'undefined' ? countiesLayer      : (G.groups.counties||[]));
+  G.groups.wind     = toArr(typeof windSitesLayer     !== 'undefined' ? windSitesLayer     : (G.groups.wind||[]));
+  G.groups.solar    = toArr(typeof solarSitesLayer    !== 'undefined' ? solarSitesLayer    : (G.groups.solar||[]));
+  G.groups.dams     = toArr(typeof damsLayer          !== 'undefined' ? damsLayer          : (G.groups.dams||[]));
+
+  // handy fallbacks for older bridges (do NOT remove)
+  window.__AMA_COUNTIES_LAYER = G.groups.counties[0] || null;
+  window.__AMA_WIND_LAYER     = G.groups.wind[0]     || null;
 
   window.__AMA_COUNTS = {
     counties: (countiesFC?.features||[]).length,

--- a/docs/assets/js/panel-direct-wire.js
+++ b/docs/assets/js/panel-direct-wire.js
@@ -1,79 +1,42 @@
-;(function(){
-  const A = window.AMA = window.AMA || {};
-  A.flags = A.flags || {};
-  A.flags.useDomBridge = false;
+/* docs/assets/js/panel-direct-wire.js */
+(function AMA_PANEL_WIRE(){
+  const STEP=150, T_MAX=12000, t0=performance.now();
+  const log=(...a)=>console.log('%c[AMA-panel]','color:#22c55e',...a);
+  const warn=(...a)=>console.warn('%c[AMA-panel]','color:#f59e0b',...a);
 
-  function G(){ return (A.G)||{} }
-  function map(){ return window.__AMA_MAP }
+  const getMap=()=> (window.__AMA_MAP && (window.__AMA_MAP.map||window.__AMA_MAP.leaflet)) || null;
+  const norm = v => Array.isArray(v)?v.filter(Boolean):(v?[v]:[]);
+  const layersOf = k => norm(window.__AMA_MAP?.groups?.[k]);
 
-  function isOn(key){
-    const m = map(), g = G()[key];
-    return !!(m && g && m.hasLayer(g));
-  }
-  function setOn(key, on){
-    const m = map(), g = G()[key]; if(!m || !g) return false;
-    const cur = isOn(key);
-    if (on && !cur) g.addTo(m);
-    if (!on && cur) m.removeLayer(g);
-    updateUi(key, on);
-    return true;
-  }
-
-  function $checkbox(el){
-    return el && (el.matches && el.matches('input[type="checkbox"]'))
-      ? el
-      : el && el.querySelector && el.querySelector('input[type="checkbox"]');
-  }
-
-  function updateUi(key, on){
-    const el = document.querySelector(`[data-layer-toggle="${key}"]`);
-    if(!el) return;
-    const cb = $checkbox(el);
-    if (cb){
-      cb.checked = !!on;
-      el.setAttribute('aria-checked', on ? 'true':'false');
-      el.classList.toggle('muted', !on);
-    } else {
-      el.setAttribute('aria-pressed', on ? 'true':'false');
-      el.classList.toggle('muted', !on);
-    }
-  }
-
-  function syncUi(){
-    ['wind','solar','dams','counties','province'].forEach(k=> updateUi(k, isOn(k)));
-  }
-
-  function bind(){
-    document.querySelectorAll('[data-layer-toggle]').forEach(el=>{
-      const key = (el.getAttribute('data-layer-toggle')||'').trim();
-      if(!key) return;
-
-      const cb = $checkbox(el);
-
-      if (cb){
-        cb.checked = isOn(key);
-        cb.addEventListener('change', (e)=>{
-          setOn(key, cb.checked);
-          e.stopPropagation();
-        });
-      } else {
-        el.addEventListener('click', (e)=>{
-          const on = el.getAttribute('aria-pressed') !== 'true';
-          setOn(key, on);
-          e.preventDefault();
-        });
-      }
-    });
-    syncUi();
-    setTimeout(syncUi, 0);
-  }
-
-  A.initPanelDirectWire = function(){
-    if (!document.querySelector('[data-layer-toggle]')) return;
-    bind();
+  const isOn=(map,lyr)=>{ try{ return !!(map && typeof map.hasLayer==='function' && lyr && map.hasLayer(lyr)); }catch(e){ return false; } };
+  const setGroup=(k,checked)=>{
+    const map=getMap(); if(!map) return;
+    layersOf(k).forEach(lyr=>{ try{ if(checked && !isOn(map,lyr)) map.addLayer(lyr); if(!checked && isOn(map,lyr)) map.removeLayer(lyr); }catch(e){} });
   };
 
-  document.addEventListener('DOMContentLoaded', ()=>{
-    if (document.querySelector('[data-layer-toggle]')) A.initPanelDirectWire();
-  });
+  const byId=id=>document.getElementById(id);
+
+  function wire(){
+    const map=getMap(), wind=byId('chk-wind-sites'), solar=byId('chk-solar-sites'), dams=byId('chk-dam-sites');
+    if(!map||!wind||!solar||!dams) return warn('map or checkboxes not ready');
+
+    // init from current map state
+    wind.checked  = layersOf('wind').some(l=>isOn(map,l));
+    solar.checked = layersOf('solar').some(l=>isOn(map,l));
+    dams.checked  = layersOf('dams').some(l=>isOn(map,l));
+
+    wind.addEventListener('change',()=>setGroup('wind', wind.checked));
+    solar.addEventListener('change',()=>setGroup('solar', solar.checked));
+    dams.addEventListener('change',()=>setGroup('dams',  dams.checked));
+
+    log('wired checkboxes:',{wind:wind.checked, solar:solar.checked, dams:dams.checked});
+  }
+
+  (function wait(){
+    const ok = !!getMap() && window.__AMA_MAP?.groups && byId('chk-wind-sites') && byId('chk-solar-sites') && byId('chk-dam-sites');
+    if(ok) return wire();
+    if(performance.now()-t0 > T_MAX) return warn('timeout waiting for panel/map');
+    setTimeout(wait, STEP);
+  })();
 })();
+


### PR DESCRIPTION
## Summary
- expose map, feature collections, and layer groups through a single `__AMA_MAP` registry
- provide a robust search bridge that indexes county and wind features with late reindexing
- wire panel checkboxes directly to map layer groups with safe layer toggling

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `node tests/mapper.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0dcefcd083288654c5ac56ab8b1b