### PR TITLE
feat: add county and wind site search

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -7,7 +7,6 @@
   <link rel="icon" href="../page/landing/favicon.ico"/>
   <link rel="stylesheet" href="../assets/tailwind.css"/>
   <link rel="stylesheet" href="../assets/vendor/leaflet/leaflet.css" />
-  <link rel="stylesheet" href="../assets/vendor/leaflet-control-geocoder/Control.Geocoder.css" />
   <link rel="stylesheet" href="/assets/css/map-overrides.css" />
   <link rel="stylesheet" href="../assets/legend.css"/>
   <style>
@@ -43,8 +42,16 @@
         <button id="tab-dams"  data-layer-toggle="dams"  style="flex:1;padding:8px 12px;border-radius:10px;background:#e5e7eb;border:0;cursor:pointer">آب</button>
       </div>
       <div style="position:relative;margin-bottom:8px">
-        <input id="ama-search" type="text" placeholder="جستجوی شهرستان..."
-               style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none" />
+        <input
+          id="ama-search"
+          type="text"
+          inputmode="search"
+          autocomplete="off"
+          aria-label="جستجوی شهرستان"
+          placeholder="...جستجوی شهرستان"
+          style="width:100%;padding:10px 12px;border:1px solid #d1d5db;border-radius:10px;outline:none"
+        />
+        <div id="ama-search-hint" style="display:none;font-size:12px;color:#b91c1c;margin-top:4px;"></div>
       </div>
       <div style="display:grid;gap:8px">
         <label data-layer-toggle="wind"><input id="chk-wind-sites"  type="checkbox"/> سایت‌های بادی (انرژی)</label>
@@ -76,9 +83,9 @@
   <!-- supercluster optional (CDN removed due to CSP). Use local vendor if added. -->
   <script defer src="/assets/vendor/leaflet/leaflet.js"></script>
   <script defer src="/assets/js/leaflet-icon-patch.js"></script>
-  <script defer src="/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js"></script>
   <script defer src="/assets/vendor/leaflet.polylineDecorator.min.js"></script>
   <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script defer src="/assets/js/ama-search-bridge.js"></script>
   <script defer src="/assets/js/panel-direct-wire.js"></script>
   <script defer src="/assets/js/ama-diag.js"></script>
 </body>

--- a/docs/assets/js/ama-diag.js
+++ b/docs/assets/js/ama-diag.js
@@ -1,8 +1,9 @@
 ;(function(){
   const MAX_MS = 10000, STEP = 300;
   function collect() {
-    const map = window.__AMA_MAP || (window.AMA && window.AMA.map) || null;
-    const G = (window.AMA && window.AMA.G) || {};
+    const map = window.__AMA_MAP?.map || (window.AMA && window.AMA.map) || null;
+    if (!map || typeof map.hasLayer !== 'function') return { mapReady:false, gKeys:[], groups:[], ui:[] };
+    const G = (window.AMA && typeof window.AMA.G === 'function') ? window.AMA.G() : {};
     const keys = Object.keys(G||{});
     const toggles = Array.from(document.querySelectorAll('[data-layer-toggle]'));
     const groups = keys.map(k=>{

--- a/docs/assets/js/ama-search-bridge.js
+++ b/docs/assets/js/ama-search-bridge.js
@@ -1,0 +1,86 @@
+/* docs/assets/js/ama-search-bridge.js */
+(function AMA_SEARCH_BRIDGE(){
+  const STEP=150, MAX=12000, t0=performance.now();
+  const log=(...a)=>console.log('%c[AMA-search]','color:#0ea5e9',...a);
+  const warn=(...a)=>console.warn('%c[AMA-search]','color:#f59e0b',...a);
+
+  function norm(s){ return String(s||'').replace(/\u200c/g,'').replace(/[^\w\u0600-\u06FF\s]+/g,' ').replace(/\s+/g,' ').trim().toLowerCase(); }
+  function countyName(p){
+    const cands = [p?.name, p?.NAME, p?.name_fa, p?.county_fa, p?.county_name_fa, p?.['نام'], p?.['نام شهرستان'], p?.['نام_شهرستان']];
+    return cands.find(Boolean)||'';
+  }
+  function windName(p){
+    const cands = [p?.name, p?.site_name, p?.name_fa, p?.title, p?.['نام'], p?.['نام سایت']];
+    return cands.find(Boolean)||'';
+  }
+
+  function ready(){
+    const M = window.__AMA_MAP, map = M && M.map;
+    const countiesFC = window.__countiesGeoAll;
+    const cl = window.__countiesLayer;
+    return !!(map && typeof map.fitBounds==='function' && countiesFC?.features?.length && cl);
+  }
+
+  function getCountyFeatures(){
+    return (window.__countiesGeoAll?.features || []).slice();
+  }
+  function getWindFeatures(){
+    const fc = (window.__AMA_MAP?.windSitesGeo) || (window.windSitesLayer?.toGeoJSON?.());
+    return (fc?.features || []).slice();
+  }
+
+  function findCountyByName(name){
+    const nq=norm(name); if(!nq) return null;
+    return getCountyFeatures().find(f => norm(countyName(f.properties))===nq) || null;
+  }
+  function focusCountyByName(name){
+    try{
+      const f = findCountyByName(name); if(!f) return (warn('county not found:', name), false);
+      const gj = L.geoJSON(f); const b = gj.getBounds(); gj.remove();
+      window.__AMA_MAP.map.fitBounds(b, { padding:[20,20] });
+      return true;
+    }catch(e){ warn('focusCountyByName error', e); return false; }
+  }
+
+  function findWindSiteByName(name){
+    const nq=norm(name); if(!nq) return null;
+    return getWindFeatures().find(f => norm(windName(f.properties))===nq) || null;
+  }
+  function focusWindSiteByName(name){
+    try{
+      const f = findWindSiteByName(name); if(!f) return (warn('wind site not found:', name), false);
+      const g = f.geometry, ll = (g?.type==='Point' && g.coordinates) ? [g.coordinates[1], g.coordinates[0]] : null;
+      if (ll){ window.__AMA_MAP.map.setView(ll, 11); return true; }
+      return false;
+    }catch(e){ warn('focusWindSiteByName error', e); return false; }
+  }
+
+  function bind(){
+    const el = document.getElementById('ama-county-search') || document.getElementById('ama-search');
+    if (!el) return warn('search input not found');
+    el.addEventListener('keydown', (e)=>{
+      if (e.key !== 'Enter') return;
+      const q = el.value||'';
+      if (focusCountyByName(q)) return;
+      focusWindSiteByName(q);
+    });
+    log('wired:', { total: getCountyFeatures().length, wind: getWindFeatures().length });
+  }
+
+  (function wait(){
+    if (ready()){ bind(); return; }
+    if (performance.now()-t0 > MAX){ warn('timeout waiting for map/data'); return; }
+    setTimeout(wait, STEP);
+  })();
+
+  // exposed for debugging
+  window.__amaSearch = { focusCountyByName, focusWindSiteByName, stats: ()=>({ total: getCountyFeatures().length, wind: getWindFeatures().length }) };
+})();
+
+document.addEventListener('ama:groups-ready', ()=>{
+  // اگر counties/wind تازه اکسپوز شد، لاج وضعیت و آماده‌سازی
+  try {
+    if (window.__amaSearch?.stats) console.log('[AMA-search] reindexed:', window.__amaSearch.stats());
+  } catch(_){ }
+});
+

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -10,8 +10,7 @@ AMA.G = AMA.G || {
   counties: L.layerGroup(),
   province: L.layerGroup(),
 };
-// expose map placeholder
-window.__AMA_MAP = window.__AMA_MAP || null;
+const __MAP__ = window.__AMA_MAP = window.__AMA_MAP || {};
 
 // Choropleth flag (opt-in) + debug marker control
 AMA.flags = AMA.flags || {};
@@ -23,6 +22,45 @@ const CHORO_ON = !!AMA.flags.enableChoropleth;
 if (AMA.flags.disableMarkerIcons && typeof L !== 'undefined' && L && L.Marker && L.Marker.prototype){
   const _initIcon = L.Marker.prototype._initIcon;
   L.Marker.prototype._initIcon = function(){ /* no-op: hide image icon */ };
+}
+
+// --- unified registry & helpers (runs after layers/map exist) ---
+window.AMA = window.AMA || {};
+
+function rebuildGroupsAndExpose(){
+  // map: create once if missing (avoid black screen)
+  if (!__MAP__.map && typeof L !== 'undefined') {
+    __MAP__.map = L.map('map', { preferCanvas:true, zoomControl:true });
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      { attribution:'© OpenStreetMap' }).addTo(__MAP__.map);
+    if (__MAP__.map.zoomControl?.setPosition) __MAP__.map.zoomControl.setPosition('bottomleft');
+    if (__MAP__.map.attributionControl?.setPosition) __MAP__.map.attributionControl.setPosition('bottomleft');
+  }
+
+  // expose GeoJSON sources for search (prefer preloaded full counties)
+  __MAP__.countiesGeo = window.__countiesGeoAll || __MAP__.countiesGeo || null;
+  if (!__MAP__.countiesGeo?.features?.length && window.__countiesLayer?.toGeoJSON) {
+    __MAP__.countiesGeo = window.__countiesLayer.toGeoJSON();
+  }
+  __MAP__.windSitesGeo  = __MAP__.windSitesGeo  || (window.windSitesLayer?.toGeoJSON?.()  || null);
+
+  // groups (any available)
+  const GROUPS = {
+    wind:     window.windSitesLayer  || null,
+    solar:    window.solarSitesLayer || null,
+    dams:     window.damsLayer       || null,
+    counties: window.__countiesLayer || null,
+    province: (typeof baseAdminGroup !== 'undefined' && baseAdminGroup) ? baseAdminGroup : null
+  };
+  __MAP__.groups = Object.fromEntries(Object.entries(GROUPS).filter(([,v]) => !!v));
+
+  // public accessor for panel
+  AMA.G = () => (__MAP__.groups || {});
+
+  // notify listeners (search/panel) once something became available
+  if (Object.keys(__MAP__.groups).length) {
+    document.dispatchEvent(new CustomEvent('ama:groups-ready', { detail:{ keys:Object.keys(__MAP__.groups) }}));
+  }
 }
 
 ;(function(){
@@ -99,6 +137,10 @@ const __COUNTY_ALIASES = Object.assign(
     'بينالود': 'بینالود'
   }
 );
+const AMA_ALIASES = window.AMA_ALIASES = window.AMA_ALIASES || {};
+for (const [alias, canon] of Object.entries(__COUNTY_ALIASES)) {
+  if (alias !== canon) (AMA_ALIASES[canon] = AMA_ALIASES[canon] || []).push(alias);
+}
 function canonicalCountyName(s=''){
   let t = (s||'').toString()
     .replace(/[يى]/g,'ی').replace(/ك/g,'ک')
@@ -221,7 +263,7 @@ function boundsFromGeoJSON(gj){
 }
 
 function enforceDefaultVisibility(map){
-  const G = (window.AMA && AMA.G) || {};
+  const G = (window.AMA && typeof AMA.G === 'function') ? AMA.G() : {};
   const DEFAULT_ON = new Set(['counties','province']); // فقط مرزها
   Object.keys(G).forEach(k=>{
     const grp = G[k]; if (!grp) return;
@@ -610,7 +652,7 @@ window.addEventListener('error', e => {
 // (IIFE wrapper) — now converted to callable function
 async function buildOverlaysAfterBoundary(paths){
 // === AMA HELPERS (top-level, safe scope) ===
-const map = window.__AMA_MAP;
+const map = window.__AMA_MAP?.map;
 const canvasRenderer = window.__AMA_canvasRenderer;
 const AMA_DEBUG = window.AMA_DEBUG;
 let __LAYER_MANIFEST_BASE = '/data/';
@@ -776,6 +818,8 @@ async function joinWindWeightsOnAll(){
       window.__countiesLayer = countiesFill;
       window.__AMA_countySource = 'preloaded all-counties';
       window.__countiesGeoAll = countiesGJ;
+      window.__AMA_COUNTIES_LAYER = countiesFill;
+      rebuildGroupsAndExpose();
       if (window.AMA_DEBUG) console.log('[AHA] county source=preloaded');
       if (window.AMA_DEBUG) console.log('[AMA] base groups protected:', !!baseAdminGroup, !!countiesFill?.__AMA_PROTECTED, !!boundary?.__AMA_PROTECTED);
     }
@@ -1482,8 +1526,9 @@ async function actuallyLoadManifest(){
           if(infoEl) infoEl.textContent = 'داده شهرستان‌ها در دسترس نیست.';
         }
       }
-    // === Local search & geolocate ===
-    const searchCtl = L.control({position:'topleft'});
+      // === Local search & geolocate (legacy search) ===
+      if (!document.getElementById('ama-county-search')) {
+      const searchCtl = L.control({position:'topleft'});
     searchCtl.onAdd = function(){
       const div = L.DomUtil.create('div','ama-search');
       div.innerHTML = `<input type="text" placeholder="جستجوی شهرستان/سایت…"/><button title="یافتن موقعیت من">📍</button><div class="ama-suggestions" style="display:none"></div>`;
@@ -1526,7 +1571,8 @@ async function actuallyLoadManifest(){
       });
       return div;
     };
-    searchCtl.addTo(map);
+      searchCtl.addTo(map);
+      }
 
     function debounce(fn,ms){ let t; return (...args)=>{ clearTimeout(t); t=setTimeout(()=>fn.apply(this,args),ms); }; }
     function toast(msg){ const info=document.getElementById('info'); if(info){ info.textContent=msg; setTimeout(()=>{info.textContent='';},3000); } }
@@ -1854,21 +1900,23 @@ async function actuallyLoadManifest(){
 
       L.control.scale({ metric:true, imperial:false }).addTo(map);
 
-      if (L.Control && L.Control.geocoder) {
-        const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
-        geocoder.on('markgeocode', e => {
-          const center = e.geocode.center;
-          const name = e.geocode.name;
-          safeClearGroup(searchLayer);
-          searchLayer.addLayer(L.circleMarker(center, {
-            radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
-          }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
-          if (e.geocode.bbox) {
-            map.fitBounds(e.geocode.bbox);
-          } else {
-            map.setView(center, 14);
-          }
-        });
+      if (!document.getElementById('ama-county-search')) {
+        if (L.Control && L.Control.geocoder) {
+          const geocoder = L.Control.geocoder({ defaultMarkGeocode:false }).addTo(map);
+          geocoder.on('markgeocode', e => {
+            const center = e.geocode.center;
+            const name = e.geocode.name;
+            safeClearGroup(searchLayer);
+            searchLayer.addLayer(L.circleMarker(center, {
+              radius: 7, color: '#22d3ee', weight: 2, fillColor: '#22d3ee', fillOpacity: 1
+            }).bindTooltip(name, {direction:'top', offset:[0,-10]}));
+            if (e.geocode.bbox) {
+              map.fitBounds(e.geocode.bbox);
+            } else {
+              map.setView(center, 14);
+            }
+          });
+        }
       }
 
       // اگر لایه گاز موجود است، جلوه‌های اضافه اعمال شود
@@ -2006,8 +2054,9 @@ async function actuallyLoadManifest(){
 
       applyMode();
 
-      // === Tool Dock ===
-      function makePanel(title, bodyHtml){
+        // === Tool Dock ===
+        if (!document.getElementById('ama-county-search')) {
+        function makePanel(title, bodyHtml){
         const ctl = L.control({position:'topleft'});
         ctl.onAdd = function(){
           const wrap=L.DomUtil.create('div','ama-panel');
@@ -2050,8 +2099,9 @@ async function actuallyLoadManifest(){
 
       panels.search.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); setTimeout(()=>{wrap.querySelector('#ama-search-input')?.focus();},0); const btn=wrap.querySelector('#ama-search-go'); btn?.addEventListener('click',()=>{ const val=wrap.querySelector('#ama-search-input').value.trim(); if(!val) return; const site = windSitesRaw.find(s=>s.name_fa===val); if(site){ map.setView([+site.lat,+site.lon],11); } else { focusCountyByName(val); } }); return wrap; }; })(panels.search.onAdd);
       panels.layers.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const body=wrap.querySelector('.ama-panel-bd'); body.innerHTML='<label><input type="checkbox" data-layer="wind" checked/> لایه باد</label><label><input type="checkbox" data-layer="sites" checked/> سایت‌ها</label>'; body.querySelectorAll('input[data-layer]').forEach(ch=>{ ch.addEventListener('change',()=>{ const lay=ch.dataset.layer; const LAY = lay==='wind'?window.windChoroplethLayer:window.windSitesLayer; if(LAY){ if(ch.checked) map.addLayer(LAY); else safeRemoveLayer(map, LAY);} });}); return wrap; }; })(panels.layers.onAdd);
-      panels.download.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const btn=wrap.querySelector('#ama-dl-csv'); btn?.addEventListener('click',()=>{ const rows=polysFC.features.map(f=>f.properties); const csv=makeTopCSV(rows); downloadBlob('kpi.csv',csv); }); return wrap; }; })(panels.download.onAdd);
-    })();
+        panels.download.onAdd = (function(orig){ return function(){ const wrap=orig.call(this); const btn=wrap.querySelector('#ama-dl-csv'); btn?.addEventListener('click',()=>{ const rows=polysFC.features.map(f=>f.properties); const csv=makeTopCSV(rows); downloadBlob('kpi.csv',csv); }); return wrap; }; })(panels.download.onAdd);
+        }
+      })();
 }
 
 async function ama_bootstrap(){
@@ -2121,8 +2171,12 @@ async function ama_bootstrap(){
   addPolyGroup('counties', countiesFC);
   addPolyGroup('province', provinceFC);
   setPointGroup('wind', windFC);
+  window.windSitesLayer = AMA.G.wind;
   setPointGroup('solar', solarFC);
+  window.solarSitesLayer = AMA.G.solar;
   setPointGroup('dams', damsFC);
+  window.damsLayer = AMA.G.dams;
+  rebuildGroupsAndExpose();
 
   function coerceMarkersToCircles(groupKey){
     const grp = AMA.G[groupKey]; if (!grp) return;
@@ -2152,10 +2206,9 @@ async function ama_bootstrap(){
   window.__countiesGeoAll = countiesFC || { type:'FeatureCollection', features:[] };
   window.__combinedGeo = provinceFC;
   if (window.AMA_DEBUG) console.log('[AHA] all-counties.features =', (countiesFC?.features||[]).length);
-
-  const map = window.__AMA_MAP || AMA.map || L.map('map', { preferCanvas:true, zoomControl:true });
-  window.__AMA_MAP = map;
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(map);
+  rebuildGroupsAndExpose();
+  __MAP__.leaflet = __MAP__.map;
+  const map = __MAP__.map;
   if (map.zoomControl && typeof map.zoomControl.setPosition==='function') map.zoomControl.setPosition('bottomleft');
   if (map.attributionControl && typeof map.attributionControl.setPosition === 'function') {
     map.attributionControl.setPosition('bottomleft');
@@ -2185,7 +2238,6 @@ async function ama_bootstrap(){
 
   enforceDefaultVisibility(map);
   setTimeout(()=>enforceDefaultVisibility(map), 0);
-  if (window.AMA && AMA.initPanelDirectWire) AMA.initPanelDirectWire();
 
   await __refreshBoundary(map, { keepOld:false });
 

--- a/docs/assets/js/panel-direct-wire.js
+++ b/docs/assets/js/panel-direct-wire.js
@@ -1,17 +1,32 @@
+/* docs/assets/js/panel-direct-wire.js */
 ;(function(){
   const A = window.AMA = window.AMA || {};
   A.flags = A.flags || {};
   A.flags.useDomBridge = false;
 
-  function G(){ return (A.G)||{} }
-  function map(){ return window.__AMA_MAP }
+  const G   = () => (A.G && A.G()) || {};
+  const map = () => (window.__AMA_MAP && window.__AMA_MAP.map) || null;
 
-  function isOn(key){
+  const $cb = el => (el?.matches?.('input[type="checkbox"]')) ? el
+                 : (el?.querySelector?.('input[type="checkbox"]') || null);
+
+  const isOn = key => {
     const m = map(), g = G()[key];
-    return !!(m && g && m.hasLayer(g));
+    return !!(m && g && typeof m.hasLayer === 'function' && m.hasLayer(g));
+  };
+
+  function updateUi(key, on){
+    const el = document.querySelector(`[data-layer-toggle="${key}"]`);
+    if (!el) return;
+    const cb = $cb(el);
+    if (cb) { cb.checked = !!on; el.setAttribute('aria-checked', on?'true':'false'); }
+    else    { el.setAttribute('aria-pressed', on?'true':'false'); }
+    el.classList.toggle('muted', !on);
   }
+
   function setOn(key, on){
-    const m = map(), g = G()[key]; if(!m || !g) return false;
+    const m = map(), g = G()[key];
+    if (!m || !g) return false;
     const cur = isOn(key);
     if (on && !cur) g.addTo(m);
     if (!on && cur) m.removeLayer(g);
@@ -19,61 +34,43 @@
     return true;
   }
 
-  function $checkbox(el){
-    return el && (el.matches && el.matches('input[type="checkbox"]'))
-      ? el
-      : el && el.querySelector && el.querySelector('input[type="checkbox"]');
-  }
-
-  function updateUi(key, on){
-    const el = document.querySelector(`[data-layer-toggle="${key}"]`);
-    if(!el) return;
-    const cb = $checkbox(el);
-    if (cb){
-      cb.checked = !!on;
-      el.setAttribute('aria-checked', on ? 'true':'false');
-      el.classList.toggle('muted', !on);
-    } else {
-      el.setAttribute('aria-pressed', on ? 'true':'false');
-      el.classList.toggle('muted', !on);
-    }
-  }
-
-  function syncUi(){
-    ['wind','solar','dams','counties','province'].forEach(k=> updateUi(k, isOn(k)));
-  }
-
   function bind(){
     document.querySelectorAll('[data-layer-toggle]').forEach(el=>{
       const key = (el.getAttribute('data-layer-toggle')||'').trim();
-      if(!key) return;
-
-      const cb = $checkbox(el);
-
+      if (!key) return;
+      const cb = $cb(el);
       if (cb){
         cb.checked = isOn(key);
-        cb.addEventListener('change', (e)=>{
-          setOn(key, cb.checked);
-          e.stopPropagation();
-        });
-      } else {
-        el.addEventListener('click', (e)=>{
+        cb.addEventListener('change', e=>{ setOn(key, cb.checked); e.stopPropagation(); });
+      }else{
+        el.addEventListener('click', e=>{
           const on = el.getAttribute('aria-pressed') !== 'true';
-          setOn(key, on);
-          e.preventDefault();
+          setOn(key, on); e.preventDefault();
         });
       }
+      updateUi(key, isOn(key));
     });
-    syncUi();
-    setTimeout(syncUi, 0);
   }
 
-  A.initPanelDirectWire = function(){
-    if (!document.querySelector('[data-layer-toggle]')) return;
-    bind();
+  const ready = () => {
+    const m = map();
+    const hasGroups = !!Object.keys(G()).length;
+    const hasCounties = !!window.__countiesLayer;
+    return !!(m && (hasGroups || hasCounties));
   };
 
-  document.addEventListener('DOMContentLoaded', ()=>{
-    if (document.querySelector('[data-layer-toggle]')) A.initPanelDirectWire();
+  function init(){
+    const start = performance.now(), MAX=12000, STEP=150;
+    (function wait(){
+      if (ready()){ bind(); return; }
+      if (performance.now()-start > MAX){ console.warn('[AMA-panel] timeout waiting for panel/map'); return; }
+      setTimeout(wait, STEP);
+    })();
+  }
+
+  // run on DOM ready, and also when groups become available
+  document.addEventListener('DOMContentLoaded', ()=> {
+    if (document.querySelector('[data-layer-toggle]')) init();
   });
+  document.addEventListener('ama:groups-ready', init);
 })();


### PR DESCRIPTION
## Summary
- centralize map and layer exposure with a `rebuildGroupsAndExpose` helper that builds the `__AMA_MAP` registry and notifies listeners
- wire layer-toggle checkboxes to the registry and re-init when groups become available
- log search reindexing when new groups are exposed

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `node tests/mapper.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd0dcefcd083288654c5ac56ab8b1b