### PR TITLE
Use defer and standard load event for CLD bundle

### DIFF
--- a/docs/assets/water-cld.defer.js
+++ b/docs/assets/water-cld.defer.js
@@ -14,11 +14,11 @@
     var url = new URL(candidates[i], location.href).href;
     var s = document.createElement('script');
     s.setAttribute('data-cld-bundle', 'true');
-    s.async = true;
+    s.defer = true;
     s.src = url;
     s.onload = function () {
       console.log('[CLD defer] bundle loaded OK:', url, 'CLD_SAFE=', !!window.CLD_SAFE);
-      document.dispatchEvent(new CustomEvent('cld:bundle:loaded', { detail: { url } }));
+      document.dispatchEvent(new Event('cld:bundle:loaded'));
     };
     s.onerror = function () {
       console.warn('[CLD defer] bundle load failed:', url, '→ next…');


### PR DESCRIPTION
## Summary
- load `water-cld` bundle with `defer` instead of `async`
- dispatch simple `Event('cld:bundle:loaded')` after bundle loads

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68be4c29e6f483288bfd56a7b402ff59