### PR TITLE
refactor: externalize water cld inline css

### DIFF
--- a/docs/assets/water-cld.css
+++ b/docs/assets/water-cld.css
@@ -218,3 +218,14 @@
     .btn-reset:hover{border-color:var(--accent)}
     @media (max-width: 1100px){ #cld-control-hub{grid-template-columns:1fr 1fr} }
     @media (max-width: 720px){  #cld-control-hub{grid-template-columns:1fr} }
+#system-graph {
+  min-height: 480px;
+  height: 100%;
+}
+
+#cy {
+  min-height: 480px;
+  height: 100%;
+  width: 100%;
+  display: block;
+}

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -13,10 +13,7 @@
 
   <!-- Bundled CLD styles -->
   <link rel="stylesheet" href="../assets/dist/water-cld.bundle.css" />
-
-  <style>
-    #system-graph, #cy { min-height: 480px; height: 100%; }
-  </style>
+  <link rel="stylesheet" href="../assets/water-cld.css" />
 
 </head>
 


### PR DESCRIPTION
## Summary
- load `water-cld.css` after bundle and remove inline sizing styles
- add default graph layout rules for `#system-graph` and `#cy`

## Testing
- `rg '<style' docs/test/water-cld.html`
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68be611850dc8328aaf24613cc6d384e