### PR TITLE
chore: enforce strict CSP for netlify

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' https://cdn.tailwindcss.com; connect-src 'self';
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self'; script-src 'self'; connect-src 'self';
   Referrer-Policy: no-referrer
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY

--- a/netlify.toml
+++ b/netlify.toml
@@ -72,10 +72,10 @@ for = "/assets/*"
   [headers.values]
   Cache-Control = "public, max-age=31536000, immutable"
 
-# [[headers]]
-#   for = "/*"
-#   [headers.values]
-#   Content-Security-Policy = "default-src 'self'; script-src 'self'; style-src 'self'; img-src 'self' data:; font-src 'self'; worker-src 'self'; connect-src 'self'"
+[[headers]]
+for = "/*"
+  [headers.values]
+  Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self'; script-src 'self'; connect-src 'self';"
 
 [[headers]]
 for = "/data/amaayesh/*"


### PR DESCRIPTION
## Summary
- enforce strict CSP header in Netlify `_headers`
- add matching CSP for `/*` in `netlify.toml`

## Testing
- `npm test` *(fails: TimeoutError in e2e-cld.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68be6503b8b8832897cc06ce5dcc4c81