### PR TITLE
fix: order CLD dependencies for UMD builds

### DIFF
--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -249,6 +249,9 @@
     } catch (e) {}
   </script>
   <script defer src="../assets/vendor/cytoscape.min.js"></script>
+  <script defer src="../assets/vendor/dagre.min.js"></script>
+  <script defer src="../assets/vendor/cytoscape-dagre.js"></script>
+  <script defer src="../assets/vendor/chart.umd.min.js"></script>
   <script defer src="../assets/water-cld.defer.js"></script>
   <script>
     document.addEventListener('cld:bundle:loaded', () => {


### PR DESCRIPTION
## Summary
- load Cytoscape, Dagre, cytoscape-dagre, and Chart UMD builds in the correct order before the CLD bundle loader

## Testing
- `npm test` *(fails: Waiting failed: 15000ms exceeded)*
- `npm run check:cld-html`


------
https://chatgpt.com/codex/tasks/task_e_68be672c14b083289887db088df608bf