### PR TITLE
wrap legacy layer control in debug block

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -1681,7 +1681,10 @@ async function actuallyLoadManifest(){
       if (solarSitesLayer) overlays['سایت‌های خورشیدی']       = solarSitesLayer;
       if (damsLayer)       overlays['سدها']                    = damsLayer;
 
-      const ctrl = L.control.layers(null, overlays, { collapsed:false, position:'topleft' }).addTo(map);
+      if (window.AMA_DEBUG) {
+        const ctrl = L.control.layers(null, overlays, { collapsed:false, position:'topleft' }).addTo(map);
+        map.removeControl(ctrl);
+      }
       Object.values(overlays).forEach(Lyr=> safeRemoveLayer(map, Lyr));
       const overlayEntries = Object.entries(overlays);
 


### PR DESCRIPTION
## Summary
- disable legacy Leaflet layer control unless in debug mode and remove its UI

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68be6b9b77dc8328915c85fa2aa928a8