### PR TITLE
refactor: drop legacy id bindings

### DIFF
--- a/docs/assets/js/ama-bridge-new-panel.js
+++ b/docs/assets/js/ama-bridge-new-panel.js
@@ -1,6 +1,5 @@
 ;(function(){
   const STEP=250, MAX=8000, NEW_SCOPE='#ama-layer-dock';
-  const idMap = { wind:'#chk-wind-sites', solar:'#chk-solar-sites', dams:'#chk-dam-sites' };
   const rxMap = { wind:/باد/i, solar:/خورشیدی/i, dams:/سد/i };
   const missing = new Set(['wind','solar','dams']);
   const bridgedPairs = [];
@@ -19,8 +18,6 @@
       .filter(x=>x.key);
   }
   function findLegacyByKey(key){
-    const byId = document.querySelector(idMap[key]);
-    if (byId && !inNewScope(byId)) return byId;
     const rx = rxMap[key]; if(!rx) return null;
     const labels = Array.from(document.querySelectorAll('label')).filter(l=>!inNewScope(l));
     for (const lbl of labels){

--- a/docs/assets/js/panel-direct-wire.js
+++ b/docs/assets/js/panel-direct-wire.js
@@ -40,7 +40,10 @@
   }
 
   function syncUi(){
-    ['wind','solar','dams','counties','province'].forEach(k=> updateUi(k, isOn(k)));
+    document.querySelectorAll('[data-layer-toggle]').forEach(el=>{
+      const key = (el.getAttribute('data-layer-toggle')||'').trim();
+      if(key) updateUi(key, isOn(key));
+    });
   }
 
   function bind(){


### PR DESCRIPTION
## Summary
- remove hard-coded legacy checkbox IDs from AMA bridge script
- wire panel updates only for elements using `data-layer-toggle`

## Testing
- `npm test` *(fails: Error: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file)*
- `node -e "...puppeteer.launch..."` *(fails: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68be76cd60888328bdc28864e8f962ad