### PR TITLE
style: improve layer dock and checkbox layout

### DIFF
--- a/docs/assets/css/map-inline.css
+++ b/docs/assets/css/map-inline.css
@@ -6,7 +6,7 @@ html, body { height:100% }
 .ama-main{ isolation:isolate; }
 
 .ama-panel{ position:absolute; z-index:1001; pointer-events:auto; background:rgba(255,255,255,.9); backdrop-filter:saturate(150%) blur(4px); border-radius:12px; box-shadow:0 10px 25px rgba(0,0,0,.12); padding:12px; }
-.ama-layer-dock{ top:16px; right:16px; width:320px; }
+.ama-layer-dock{ top:16px; right:16px; width:320px; color:#000; }
 .ama-top-dock{ top:16px; left:16px; width:280px; }
 
 .ama-panel-header{ display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; border-bottom:1px solid rgba(0,0,0,.08); padding-bottom:8px; }
@@ -19,6 +19,8 @@ html, body { height:100% }
 .ama-tab-inactive{ background:#e5e7eb; }
 
 .ama-checkbox-grid{ display:grid; gap:8px; }
+
+.ama-check-item{ display:flex; align-items:center; gap:8px; }
 
 .ama-top-badge{ padding:.25rem .5rem; border-radius:9999px; background:#dbeafe; color:#1d4ed8; font:600 12px system-ui; }
 .ama-top-table{ width:100%; font:500 12px system-ui; color:#374151; }


### PR DESCRIPTION
## Summary
- set layer dock text color to black
- add flex styling for checkbox items

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68be858ec3ac8328afa3c13b17eb999e