### PR TITLE
Add inline migration stylesheet and include across docs

### DIFF
--- a/docs/assets/inline-migration.css
+++ b/docs/assets/inline-migration.css
@@ -1,0 +1,41 @@
+/* layout & display */
+.relative{position:relative} .absolute{position:absolute} .block{display:block} .hidden{display:none} .flex{display:flex} .items-center{align-items:center} .text-center{text-align:center} .flex-1{flex:1} .overflow-hidden{overflow:hidden}
+
+/* spacing */
+.mt-26{margin-top:26px} .mt-12{margin-top:12px} .mt-10{margin-top:10px} .mt-8{margin-top:8px} .mt-6{margin-top:6px} .mb-1{margin-bottom:4px} .my-8{margin:8px 0} .gap-1{gap:4px}
+
+/* sizing (percents & px) */
+.w-full{width:100%} .h-full{height:100%} .min-h-480{min-height:480px}
+.h-250{height:250px}
+.h-59p{height:59%} .h-100p{height:100%}
+.w-54p{width:54.17%} .w-16p{width:16.67%} .w-8p{width:8.33%} .w-4p{width:4.16%}
+.w-33p{width:33.33%} .w-57p{width:57%} .w-31p{width:31%} .w-7p{width:7%} .w-3p{width:3%}
+
+/* position helpers */
+.right-0{right:0%}
+
+/* typography & color & opacity */
+.fw-600{font-weight:600} .text-amber{color:#fbbf24}
+.opacity-70{opacity:.7} .opacity-80{opacity:.8} .opacity-60{opacity:.6}
+
+/* decorations & interactions */
+.dot-dashed{border:2px dashed #cbd5e1} .select-none{user-select:none} .pe-none{pointer-events:none} .cursor-move{cursor:move}
+
+/* z-index */
+.z-400{z-index:400} .z-500{z-index:500} .z-650{z-index:650}
+
+/* QR vendor replacements */
+.qr-table{border:0;border-collapse:collapse;padding:0;margin:var(--m)}
+.qr-cell{border:0;border-collapse:collapse;padding:0;margin:0}
+
+/* CLD containers */
+#system-graph, #cy, #cy-wrap{position:relative}
+#cy{min-height:480px;height:100%;width:100%;display:block}
+
+/* components used in JS refactors */
+.footer-fixed{position:fixed;left:0;right:0;bottom:0;font-size:13px;color:#555;text-align:center;padding:12px 0}
+.body-mb{margin-bottom:60px}
+.debug-chip{position:fixed;left:8px;top:8px;z-index:9999;background:#111;color:#0ff;padding:4px 8px;border-radius:8px;font:12px/1 Vazirmatn,system-ui}
+.toast{position:absolute;top:8px;right:8px;z-index:9999;background:#2b2b2b;color:#fff;padding:8px 10px;border-radius:10px;font-size:12px;box-shadow:0 6px 24px rgba(0,0,0,.2)}
+.info-popup{background:rgba(17,24,39,.9);color:#e5e7eb;padding:8px 10px;border-radius:10px;font:12px Vazirmatn,sans-serif;display:none;backdrop-filter:blur(2px)}
+.overlay{position:fixed;inset:0;background:rgba(0,0,0,.3);display:none;z-index:999}

--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -20,6 +20,7 @@
   <script defer src="/assets/global-footer.js"></script>
 
   <link rel="stylesheet" href="../assets/date-badge.css">
+  <link rel="stylesheet" href="../assets/inline-migration.css" />
   <script defer src="../assets/shamsi-date.js"></script>
 </head>
 <body>

--- a/docs/electricity/peak.html
+++ b/docs/electricity/peak.html
@@ -10,6 +10,7 @@
     <link rel="stylesheet" href="/assets/global-footer.css">
     <link rel="stylesheet" href="/assets/unified-badge.css">
     <link rel="stylesheet" href="../assets/site-overrides.css">
+    <link rel="stylesheet" href="../assets/inline-migration.css" />
     <script src="/assets/vendor/chart.umd.min.js"></script>
     <script src="../assets/electricity-management.js"></script>
     <script defer src="/assets/unified-badge.js"></script>

--- a/docs/electricity/power-tariff.html
+++ b/docs/electricity/power-tariff.html
@@ -10,6 +10,7 @@
   <script defer src="../assets/power-tariff.js"></script>
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
+  <link rel="stylesheet" href="../assets/inline-migration.css" />
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
 </head>

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -14,6 +14,7 @@
   <!-- Bundled CLD styles -->
   <link rel="stylesheet" href="../assets/dist/water-cld.bundle.css" />
   <link rel="stylesheet" href="../assets/water-cld.css" />
+  <link rel="stylesheet" href="../assets/inline-migration.css" />
 
 </head>
 

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="../assets/water-cost.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
+  <link rel="stylesheet" href="../assets/inline-migration.css" />
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
 </head>

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -15,10 +15,11 @@
       <link rel="stylesheet" href="../assets/tailwind.css">
       <link rel="stylesheet" href="../assets/fonts.css">
 
-      <link rel="stylesheet" href="water.css">
+  <link rel="stylesheet" href="water.css">
   <!-- Vazirmatn -->
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
+  <link rel="stylesheet" href="../assets/inline-migration.css" />
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
 </head>


### PR DESCRIPTION
## Summary
- add new `inline-migration.css` with utility classes for layout, spacing, sizing, and components
- load `inline-migration.css` after existing CSS in water and electricity HTML pages

## Testing
- `npm test` *(fails: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68be87ca0fc88328b2e50062f5b3bbc1