### PR TITLE
refactor inline styles to CSS classes

### DIFF
--- a/dash/components/Footer.js
+++ b/dash/components/Footer.js
@@ -1,26 +1,20 @@
+import { useEffect } from 'react';
+import '../../docs/assets/inline-migration.css';
+
 export default function Footer() {
-  if (typeof document !== 'undefined') {
-    document.body.style.marginBottom = '60px';
-  }
+  useEffect(() => {
+    document.body.classList.add('body-mb');
+    return () => document.body.classList.remove('body-mb');
+  }, []);
   return (
     <footer
       dir="rtl"
-      style={{
-        position: 'fixed',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        fontSize: '13px',
-        color: '#555',
-        textAlign: 'center',
-        paddingTop: '12px',
-        paddingBottom: '12px',
-      }}
+      className="footer-fixed"
     >
       <img
         src="/assets/IRAN-FLAG.png"
         alt="Iran flag"
-        style={{ height: '16px', verticalAlign: 'middle', marginLeft: '6px' }}
+        className="img-flag"
       />
       کلیه حقوق مادی و معنوی این سایت متعلق به خانه هم‌افزایی انرژی و آب استان خراسان رضوی است.
       <br />

--- a/docs/assets/badge-updated.js
+++ b/docs/assets/badge-updated.js
@@ -1,3 +1,5 @@
+import { setClass } from './css-classes.js';
+
 (function () {
   'use strict';
 
@@ -54,10 +56,8 @@
         header.appendChild(badge);
       } else {
         // گوشه‌ی کارت بدون به‌هم‌ریختگی
-        card.style.position ||= 'relative';
-        badge.style.position = 'absolute';
-        badge.style.top = '0.5rem';
-        badge.style.left = '0.5rem';
+        setClass(card, ['relative']);
+        setClass(badge, ['badge-pos']);
         card.appendChild(badge);
       }
     });

--- a/docs/assets/css-classes.js
+++ b/docs/assets/css-classes.js
@@ -1,0 +1,5 @@
+export function setClass(el, add=[], remove=[]){
+  if(!el) return;
+  add.forEach(c=>el.classList.add(c));
+  remove.forEach(c=>el.classList.remove(c));
+}

--- a/docs/assets/inline-migration.css
+++ b/docs/assets/inline-migration.css
@@ -1,3 +1,4 @@
+
 /* layout & display */
 .relative{position:relative} .absolute{position:absolute} .block{display:block} .hidden{display:none} .flex{display:flex} .items-center{align-items:center} .text-center{text-align:center} .flex-1{flex:1} .overflow-hidden{overflow:hidden}
 
@@ -37,5 +38,11 @@
 .body-mb{margin-bottom:60px}
 .debug-chip{position:fixed;left:8px;top:8px;z-index:9999;background:#111;color:#0ff;padding:4px 8px;border-radius:8px;font:12px/1 Vazirmatn,system-ui}
 .toast{position:absolute;top:8px;right:8px;z-index:9999;background:#2b2b2b;color:#fff;padding:8px 10px;border-radius:10px;font-size:12px;box-shadow:0 6px 24px rgba(0,0,0,.2)}
-.info-popup{background:rgba(17,24,39,.9);color:#e5e7eb;padding:8px 10px;border-radius:10px;font:12px Vazirmatn,sans-serif;display:none;backdrop-filter:blur(2px)}
-.overlay{position:fixed;inset:0;background:rgba(0,0,0,.3);display:none;z-index:999}
+.info-popup{background:rgba(17,24,39,.9);color:#e5e7eb;padding:8px 10px;border-radius:10px;font:12px Vazirmatn,sans-serif;backdrop-filter:blur(2px)}
+.overlay{position:fixed;inset:0;background:rgba(0,0,0,.3);z-index:999}
+.badge-pos{position:absolute;top:.5rem;left:.5rem}
+.delay-0{transition-delay:0ms} .delay-120{transition-delay:120ms} .delay-240{transition-delay:240ms} .delay-360{transition-delay:360ms} .delay-480{transition-delay:480ms} .delay-600{transition-delay:600ms} .delay-720{transition-delay:720ms} .delay-840{transition-delay:840ms} .delay-960{transition-delay:960ms} .delay-1080{transition-delay:1080ms} .delay-1200{transition-delay:1200ms}
+.sw-gray{background:#e5e7eb}
+.sw-0{background:#f0f9ff} .sw-1{background:#e0f2fe} .sw-2{background:#bae6fd} .sw-3{background:#7dd3fc} .sw-4{background:#38bdf8} .sw-5{background:#0ea5e9} .sw-6{background:#0284c7} .sw-7{background:#0369a1} .sw-8{background:#075985}
+.bubble-8{width:8px;height:8px} .bubble-16{width:16px;height:16px} .bubble-24{width:24px;height:24px} .bubble-32{width:32px;height:32px} .bubble-40{width:40px;height:40px} .bubble-48{width:48px;height:48px} .bubble-56{width:56px;height:56px} .bubble-64{width:64px;height:64px}
+.img-flag{height:16px;vertical-align:middle;margin-left:6px}

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -1,3 +1,5 @@
+import { setClass } from '../css-classes.js';
+
 // --- Build id ---
 window.__AMA_BUILD_ID = document.querySelector('meta[name="build-id"]')?.content || String(Date.now());
 
@@ -32,7 +34,7 @@ if (AMA.flags.disableMarkerIcons && typeof L !== 'undefined' && L && L.Marker &&
   try {
     const el = document.createElement('div');
     el.id = 'ama-ui-probe';
-    el.style.cssText = 'position:fixed;left:8px;top:8px;z-index:9999;background:#111;color:#0ff;padding:4px 8px;border-radius:8px;font:12px/1 Vazirmatn,system-ui';
+    setClass(el, ['debug-chip']);
     el.textContent = 'AMA UI • ' + window.__AMA_UI_VERSION;
     document.addEventListener('DOMContentLoaded',()=>document.body.appendChild(el));
     setTimeout(()=>{ const n=document.getElementById('ama-ui-probe'); n && n.remove(); }, 3000);
@@ -59,6 +61,21 @@ function keyOf(s=''){
     .toLowerCase();
 }
 const sameCounty = (a,b)=> keyOf(a) === keyOf(b);
+
+const SWATCH_PALETTE = ['#f0f9ff','#e0f2fe','#bae6fd','#7dd3fc','#38bdf8','#0ea5e9','#0284c7','#0369a1','#075985'];
+function swClass(color){
+  if(!color) return 'sw-gray';
+  const hex = color.toLowerCase();
+  const parse = h => {
+    const n = h.replace('#','');
+    return [parseInt(n.slice(0,2),16), parseInt(n.slice(2,4),16), parseInt(n.slice(4,6),16)];
+  };
+  const [r,g,b] = parse(hex);
+  let idx=0,min=Infinity;
+  SWATCH_PALETTE.forEach((c,i)=>{ const [cr,cg,cb]=parse(c); const d=(r-cr)**2+(g-cg)**2+(b-cb)**2; if(d<min){min=d;idx=i;} });
+  return `sw-${idx}`;
+}
+function bubbleSizeClass(r){ const size=Math.min(64,Math.max(8,Math.round((r*2)/8)*8)); return `bubble-${size}`; }
 // === County & Province helpers (tolerant) ===
 const ACTIVE_PROVINCE = 'خراسان رضوی';
 
@@ -148,8 +165,8 @@ function showToast(msg){
     if(!el){
       el = document.createElement('div');
       el.id = 'ama-toast';
-      el.style.cssText = 'position:absolute;top:8px;right:8px;z-index:9999;background:#2b2b2b;color:#fff;padding:8px 10px;border-radius:10px;font-size:12px;box-shadow:0 6px 24px rgba(0,0,0,.2)';
-      host.style.position = host.style.position || 'relative';
+      setClass(el, ['toast']);
+      setClass(host, ['relative']);
       host.appendChild(el);
     }
     el.textContent = msg;
@@ -830,18 +847,17 @@ async function joinWindWeightsOnAll(){
   function showInfo(html){
     if (!infoCtl || !infoCtl._div) return;
     infoCtl._div.innerHTML = html;
-    infoCtl._div.style.display = 'block';
+    setClass(infoCtl._div, [], ['hidden']);
   }
   function hideInfo(){
     if (!infoCtl || !infoCtl._div) return;
-    infoCtl._div.style.display = 'none';
+    setClass(infoCtl._div, ['hidden']);
     infoCtl._div.innerHTML = '';
   }
 
   infoCtl = L.control({ position: 'topleft' });
   infoCtl.onAdd = function(map){
-    const div = L.DomUtil.create('div','ama-infox');
-    div.style.cssText = 'background:rgba(17,24,39,.9);color:#e5e7eb;padding:8px 10px;border-radius:10px;font:12px Vazirmatn, sans-serif;display:none;backdrop-filter:blur(2px)';
+    const div = L.DomUtil.create('div','ama-infox info-popup hidden');
     div.setAttribute('dir','rtl');
     return (infoCtl._div = div);
   };
@@ -1064,7 +1080,7 @@ async function actuallyLoadManifest(){
     if(sidepanelEl) return;
     sidepanelOverlay = document.createElement('div');
     sidepanelOverlay.id = 'ama-sp-overlay';
-    sidepanelOverlay.style.cssText = 'position:fixed;inset:0;background:rgba(0,0,0,.3);display:none;z-index:999;';
+    sidepanelOverlay.className = 'overlay hidden';
     document.body.appendChild(sidepanelOverlay);
     sidepanelOverlay.addEventListener('click', closeSidepanel);
 
@@ -1079,7 +1095,7 @@ async function actuallyLoadManifest(){
   }
 
   function closeSidepanel(){
-    if(sidepanelOverlay) sidepanelOverlay.style.display='none';
+    if(sidepanelOverlay) setClass(sidepanelOverlay, ['hidden']);
     sidepanelEl?.classList.remove('open');
   }
 
@@ -1100,7 +1116,7 @@ async function actuallyLoadManifest(){
     body.innerHTML = `${kpiHtml}${sites.length?`<div><b>سایت‌های این شهرستان:</b><ul class="sp-sites">${list}</ul></div>`:''}<div style="margin-top:8px"><button id="ama-sp-dl">دانلود CSV شهرستان</button></div>`;
     sidepanelEl.querySelector('#ama-sp-name').textContent = name;
     sidepanelEl.classList.add('open');
-    if(sidepanelOverlay) sidepanelOverlay.style.display='block';
+    if(sidepanelOverlay) setClass(sidepanelOverlay, [], ['hidden']);
     const btn = sidepanelEl.querySelector('.close-btn');
     btn.focus();
     sidepanelEl.onkeydown = e=>{
@@ -1415,8 +1431,8 @@ async function actuallyLoadManifest(){
             const el=document.getElementById('ama-top10');
             const panel=el?el.closest('.ama-panel'):null;
             if(!panel||!el) return;
-            if(window.__WIND_WEIGHTS_MISSING){ panel.style.display='none'; return; }
-            panel.style.display='block';
+            if(window.__WIND_WEIGHTS_MISSING){ setClass(panel, ['hidden']); return; }
+            setClass(panel, [], ['hidden']);
             if(!window.__WIND_DATA_READY){ el.innerHTML = '<div class="ama-loading">در حال بارگذاری…</div>'; return; }
             const rows=polysFC.features.map(f=>f.properties).filter(p=>p.__hasWindData);
             rows.sort((a,b)=>(b[windKpiKey]||0)-(a[windKpiKey]||0));
@@ -1456,9 +1472,9 @@ async function actuallyLoadManifest(){
               `${nf.format(br[2])}–${nf.format(br[3])}`,
               `>${nf.format(br[3])}`
             ];
-            let html='<div class="lg"><span class="sw" style="background:#e5e7eb"></span>بدون داده</div>';
+            let html='<div class="lg"><span class="sw sw-gray"></span>بدون داده</div>';
             for(let i=0;i<labels.length;i++){
-              html += `<div class="lg"><span class="sw" style="background:${ramp[i]}"></span>${labels[i]}</div>`;
+              html += `<div class="lg"><span class="sw ${swClass(ramp[i])}"></span>${labels[i]}</div>`;
             }
             el.innerHTML = html;
           },300);
@@ -1506,7 +1522,7 @@ async function actuallyLoadManifest(){
       const d = L.DomUtil.create('div','ama-infra');
       d.innerHTML = `
         <button class="chip" id="btn-infra">زیرساخت ▾</button>
-        <div id="infra-box" class="box" style="display:none">
+        <div id="infra-box" class="box hidden">
           <label><input type="checkbox" data-layer="electricity"> خطوط انتقال برق</label>
           <label><input type="checkbox" data-layer="water"> شبکه آب‌رسانی</label>
           <label><input type="checkbox" data-layer="gas"> خطوط انتقال گاز</label>
@@ -1515,7 +1531,7 @@ async function actuallyLoadManifest(){
       L.DomEvent.disableClickPropagation(d);
       d.querySelector('#btn-infra').onclick = ()=> {
         const el = d.querySelector('#infra-box');
-        el.style.display = (el.style.display==='none'?'block':'none');
+        el.classList.toggle('hidden');
       };
       d.querySelectorAll('input[type=checkbox]').forEach(ch=>{
         ch.addEventListener('change', ()=>{
@@ -1571,7 +1587,7 @@ async function actuallyLoadManifest(){
         ${g.sub?`<div class="subhead text-[10px] opacity-70">${g.sub}</div>`:''}
         <ul class="swatches">${g.classes.map(c=>`
           <li data-min="${c.min}" data-max="${c.max}" aria-label="از ${fmt(c.min)} تا ${fmt(c.max)}">
-            <span class="sw" style="background:${c.color}"></span>
+            <span class="sw ${swClass(c.color)}"></span>
             <span class="lbl">${c.label || (`${fmt(c.min)}–${fmt(c.max)}`)}</span>
           </li>`).join('')}
         </ul>`;
@@ -1583,11 +1599,11 @@ async function actuallyLoadManifest(){
         <div class="subhead">رنگ = درصد پرشدگی</div>
         <ul class="swatches">${g.classes.map(c=>`
           <li data-min="${c.min}" data-max="${c.max}">
-            <span class="sw" style="background:${c.color}"></span><span class="lbl">${c.label}</span>
+            <span class="sw ${swClass(c.color)}"></span><span class="lbl">${c.label}</span>
           </li>`).join('')}
         </ul>
         <div class="subhead" style="margin-top:8px">اندازه = ظرفیت مخزن (میلیون m³)</div>
-        <div class="bubbles">${g.samples.map(s=>`<span class="bubble" style="width:${s.r*2}px;height:${s.r*2}px"></span><span class="lbl">${s.v}</span>`).join('')}</div>`;
+        <div class="bubbles">${g.samples.map(s=>`<span class="bubble ${bubbleSizeClass(s.r)}"></span><span class="lbl">${s.v}</span>`).join('')}</div>`;
           }
           const meta = `<div class="legend-meta"><span>منبع: ${g.source||'—'}</span><span>اعتماد داده: ${g.confidence||'—'}</span></div>`;
           body.insertAdjacentHTML('beforeend', meta);
@@ -1719,8 +1735,7 @@ async function actuallyLoadManifest(){
 
           const body = L.DomUtil.create('div', 'ld-body', container);
           const dataPane = L.DomUtil.create('div', 'ld-pane', body);
-          const displayPane = L.DomUtil.create('div', 'ld-pane', body);
-          displayPane.style.display = 'none';
+          const displayPane = L.DomUtil.create('div', 'ld-pane hidden', body);
 
           const overlaySwitches = [];
           function makeSwitch(parent, label, layer, disabled, {track=false}={}){
@@ -1779,8 +1794,8 @@ async function actuallyLoadManifest(){
             tabDispBtn.setAttribute('aria-selected', !isData?'true':'false');
             tabDataBtn.tabIndex = isData?0:-1;
             tabDispBtn.tabIndex = !isData?0:-1;
-            dataPane.style.display = isData?'block':'none';
-            displayPane.style.display = isData?'none':'block';
+            dataPane.classList.toggle('hidden', !isData);
+            displayPane.classList.toggle('hidden', isData);
           }
           tabDataBtn.addEventListener('click', ()=>activate('data'));
           tabDispBtn.addEventListener('click', ()=>activate('disp'));
@@ -2107,9 +2122,9 @@ async function ama_bootstrap(){
   }
   map.setView([36.3,59.6],7);
 
-  map.createPane('polygons');  map.getPane('polygons').style.zIndex = 400;
-  map.createPane('points');    map.getPane('points').style.zIndex   = 500;
-  map.createPane('boundary');  map.getPane('boundary').style.zIndex = 650;
+map.createPane('polygons');  setClass(map.getPane('polygons'), ['z-400']);
+map.createPane('points');    setClass(map.getPane('points'), ['z-500']);
+map.createPane('boundary');  setClass(map.getPane('boundary'), ['z-650']);
   if (window.AMA_DEBUG) console.log('[AHA] panes zIndex=', {
     polygons: getComputedStyle(map.getPane('polygons')).zIndex,
     points:   getComputedStyle(map.getPane('points')).zIndex,

--- a/docs/assets/water-cld.controls-meta.js
+++ b/docs/assets/water-cld.controls-meta.js
@@ -1,3 +1,5 @@
+import { setClass } from './css-classes.js';
+
 // ===== Controls Meta & Grouping (singleton, CSP-safe, no interference) =====
 (function(){
   if (window.__CTL_META_BOUND__) return;
@@ -51,6 +53,7 @@
     pop.className = 'controls-help-pop';
     pop.innerHTML = '<ul></ul>';
     card.appendChild(pop);
+    setClass(pop, ['hidden']);
 
     // جمع‌آوری همه «؟»های پراکنده داخل کارت → به لیست راهنما
     const helpItems = [];
@@ -60,22 +63,22 @@
         const item = el.dataset?.help || el.getAttribute('title') || 'راهنمای این کنترل';
         helpItems.push(item);
         // پنهان کن تا مزاحم نباشد (دست نزدن به کنترل‌های واقعی)
-        el.style.display = 'none';
+        setClass(el, ['hidden']);
       }
     });
     if (helpItems.length){
       const ul = pop.querySelector('ul');
       helpItems.forEach(s => { const li = document.createElement('li'); li.textContent = s; ul.appendChild(li); });
     }else{
-      btn.style.display = 'none';
+      setClass(btn, ['hidden']);
     }
 
     // باز/بسته کردن پاپ‌اور
     btn.addEventListener('click', (e)=>{
       e.stopPropagation();
-      pop.style.display = (pop.style.display === 'block') ? 'none' : 'block';
+      pop.classList.toggle('hidden');
     });
-    document.addEventListener('click', ()=> pop.style.display='none');
+    document.addEventListener('click', ()=> setClass(pop, ['hidden']));
   }
 
   // خواندن متادیتای کنترل

--- a/docs/assets/water-cld.extras-readability.js
+++ b/docs/assets/water-cld.extras-readability.js
@@ -1,3 +1,5 @@
+import { setClass } from './css-classes.js';
+
 // ===== CLD Readability (singleton, CSP-safe, no interference) =====
 /* global graphStore */
 (function(){
@@ -152,7 +154,7 @@
       host.insertBefore(sticky, container); // قبل از بوم تا بیرون آن قرار گیرد
 
       // Legend شناور قبلی را پنهان کن تا دوبل نشود
-      if (floatLegend) floatLegend.style.display = 'none';
+      if (floatLegend) setClass(floatLegend, ['hidden']);
     })();
   }
 

--- a/docs/assets/water-cld.provenance.js
+++ b/docs/assets/water-cld.provenance.js
@@ -1,3 +1,5 @@
+import { setClass } from './css-classes.js';
+
 // ===== Provenance & Model/Policy Card (singleton, CSP-safe, no interference) =====
 (function(){
   if (window.__PROVENANCE_BOUND__) return; window.__PROVENANCE_BOUND__ = true;
@@ -170,9 +172,9 @@
     $('#prov-A').textContent = (Array.isArray(A) && A.length) ? A.join('؛ ') : '—';
     $('#prov-L').textContent = (Array.isArray(L) && L.length) ? L.join('؛ ') : '—';
 
-    $('#prov-modal').style.display='block';
+    setClass($('#prov-modal'), [], ['hidden']);
   }
-  function closeModal(){ const m=$('#prov-modal'); if (m) m.style.display='none'; }
+  function closeModal(){ const m=$('#prov-modal'); if (m) setClass(m, ['hidden']); }
   function copyJSON(){ navigator.clipboard?.writeText(JSON.stringify(currentCard(), null, 2)); }
   function exportJSON(){
     const blob = new Blob([JSON.stringify(currentCard(), null, 2)], {type:'application/json'});
@@ -198,7 +200,7 @@
       badge.className = 'prov-badge';
       badge.dir='rtl';
       badge.innerHTML = `<span>ⓘ منشأ</span><span style="opacity:.7">نسخه ${p.version}</span>`;
-      host.style.position = host.style.position || 'relative';
+      setClass(host, ['relative']);
       host.appendChild(badge);
 
       // Tooltip
@@ -216,6 +218,7 @@
         </div>
       `;
       document.body.appendChild(tip);
+      setClass(tip, ['hidden']);
 
       // Positioning
       function place(){
@@ -229,11 +232,12 @@
 
       let open=false;
       function toggle(){
-        open = !open; tip.style.display = open ? 'block' : 'none';
+        open = !open;
+        tip.classList.toggle('hidden', !open);
         if (open) place();
       }
       badge.addEventListener('click', (e)=>{ e.stopPropagation(); toggle(); });
-      document.addEventListener('click', ()=>{ if (open){ open=false; tip.style.display='none'; } });
+      document.addEventListener('click', ()=>{ if (open){ open=false; setClass(tip, ['hidden']); } });
 
       // Downloads
       tip.addEventListener('click', (e)=>{

--- a/docs/assets/water-efficiency.js
+++ b/docs/assets/water-efficiency.js
@@ -1,3 +1,5 @@
+import { setClass } from './css-classes.js';
+
 document.addEventListener('DOMContentLoaded', () => {
   const svgNS = 'http://www.w3.org/2000/svg';
   const svg = document.getElementById('cld-svg');
@@ -5,7 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const width = 600;
     const height = 420;
     svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
-    svg.style.userSelect = 'none';
+    setClass(svg, ['select-none']);
 
     const defs = document.createElementNS(svgNS, 'defs');
     const marker = document.createElementNS(svgNS, 'marker');
@@ -45,14 +47,14 @@ document.addEventListener('DOMContentLoaded', () => {
       line.setAttribute('stroke', '#999');
       line.setAttribute('stroke-width', '2');
       line.setAttribute('marker-end', 'url(#arrow)');
-      line.style.pointerEvents = 'none';
+      setClass(line, ['pe-none']);
       svg.appendChild(line);
 
       const label = document.createElementNS(svgNS, 'text');
       label.setAttribute('font-size', '12');
       label.setAttribute('fill', '#000');
       label.setAttribute('text-anchor', 'middle');
-      label.style.pointerEvents = 'none';
+      setClass(label, ['pe-none']);
       label.textContent = l.sign;
       svg.appendChild(label);
 
@@ -64,7 +66,7 @@ document.addEventListener('DOMContentLoaded', () => {
     nodes.forEach(n => {
       const g = document.createElementNS(svgNS, 'g');
       g.setAttribute('transform', `translate(${n.x},${n.y})`);
-      g.style.cursor = 'move';
+      setClass(g, ['cursor-move']);
 
       const circle = document.createElementNS(svgNS, 'circle');
       circle.setAttribute('r', '30');

--- a/docs/index.js
+++ b/docs/index.js
@@ -1,3 +1,4 @@
+import { setClass } from './assets/css-classes.js';
 'use strict';
 (function () {
   const debug = new URLSearchParams(location.search).get('debug-curtain') === '1';
@@ -174,7 +175,8 @@
   if (!hero) return;
   const cards = hero.querySelectorAll('.dash-card');
   cards.forEach((card, i) => {
-    card.style.transitionDelay = `${i * 120}ms`;
+    const delay = Math.min(1200, Math.round((i * 120) / 120) * 120);
+    setClass(card, [`delay-${delay}`]);
     requestAnimationFrame(() => card.classList.add('is-visible'));
   });
   window.addEventListener('scroll', () => {


### PR DESCRIPTION
## Summary
- add reusable `setClass` helper for DOM class toggling
- replace inline style mutations with utility classes across docs and AMA map
- introduce delay, swatch, bubble and badge classes in `inline-migration.css`
- move footer flag styling to shared CSS class and import utility stylesheet

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be8f63078c8328beb40f17be85f7fb