### PR TITLE
chore: add CSP inline style gate

### DIFF
--- a/.github/workflows/csp-inline-style-check.yml
+++ b/.github/workflows/csp-inline-style-check.yml
@@ -1,0 +1,21 @@
+name: CSP Inline Style Gate
+on:
+  pull_request:
+jobs:
+  csp-inline-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i -g npm@latest || true
+      - run: |
+          set -o pipefail
+          output=$(npm run -s csp:scan)
+          echo "$output"
+          if [ -n "$output" ]; then
+            echo "CSP violation: Inline styles are not allowed (style=\" or .style. or style={{}}). Use classes from docs/assets/inline-migration.css and class toggling."
+            exit 1
+          fi
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "vendor:supercluster": "node tools/vendorize_supercluster.js",
     "audit:ama": "node tools/audit_amaayesh.js",
     "verify:publish": "node tools/verify_publish_paths.js https://wesh360.ir/data/layers.config.json https://wesh360.ir/data/amaayesh/counties.geojson https://wesh360.ir/data/amaayesh/wind_sites.geojson || true",
-    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL"
+    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL",
+    "csp:scan:html": "grep -RIn --include='*.html' --exclude-dir='dist' --exclude-dir='vendor' 'style=\"' docs || true",
+    "csp:scan:js": "grep -RIn --include='*.js' --exclude-dir='dist' --exclude-dir='vendor' '\\.style\\.' docs || true",
+    "csp:scan:jsx": "grep -RIn --include='*.{jsx,tsx}' 'style={{' dash || true",
+    "csp:scan": "npm run -s csp:scan:html; npm run -s csp:scan:js; npm run -s csp:scan:jsx"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add npm scripts to scan docs and dash for inline style usage
- add CI workflow to fail PRs when inline styles are detected

## Testing
- `npm run csp:scan | head -n 20`
- `npm test` *(fails: Error: Failed to launch the browser process! ... libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68be959234088328825887c6648a0f0c