### PR TITLE
chore: add CSP inline style gate

### DIFF
--- a/.github/workflows/csp-inline-style-check.yml
+++ b/.github/workflows/csp-inline-style-check.yml
@@ -1,0 +1,23 @@
+name: CSP Inline Style Gate
+on:
+  pull_request:
+jobs:
+  csp-inline-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i -g npm@latest || true
+      - run: |
+          set -o pipefail
+          output=$(npm run -s csp:scan)
+          echo "$output"
+          count=$(printf "%s" "$output" | sed '/^$/d' | wc -l)
+          echo "Found $count potential inline-style matches"
+          if [ -n "$output" ]; then
+            echo "CSP violation: Inline styles are not allowed (style=\" or .style. or style={{}}). Use classes from docs/assets/inline-migration.css and class toggling."
+            exit 1
+          fi
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "vendor:supercluster": "node tools/vendorize_supercluster.js",
     "audit:ama": "node tools/audit_amaayesh.js",
     "verify:publish": "node tools/verify_publish_paths.js https://wesh360.ir/data/layers.config.json https://wesh360.ir/data/amaayesh/counties.geojson https://wesh360.ir/data/amaayesh/wind_sites.geojson || true",
-    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL"
+    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL",
+    "csp:scan:html": "grep -RIn -F --include='*.html' --exclude-dir='dist' --exclude-dir='vendor' 'style=\"' docs || true",
+    "csp:scan:js": "grep -RIn -F --include='*.js' --exclude-dir='dist' --exclude-dir='vendor' '.style.' docs || true",
+    "csp:scan:jsx": "grep -RIn -F --include='*.{jsx,tsx}' 'style={{' dash || true",
+    "csp:scan": "npm run -s csp:scan:html; npm run -s csp:scan:js; npm run -s csp:scan:jsx"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add npm scripts to scan docs and dash for inline style usage
- add CI workflow to fail PRs when inline styles are detected
- switch grep to fixed-string matches and print inline-style match counts in CI

## Testing
- `npm run csp:scan | head -n 20`
- `apt-get install -y libatk1.0-0 libgtk-3-0 libnss3 libxss1 libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 libpangocairo-1.0-0 libgbm1` *(missing libasound2)*
- `npm test` *(fails: libasound.so.2: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68be959234088328825887c6648a0f0c