### PR TITLE
chore: load amaayesh map module

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -61,7 +61,7 @@
   <script defer src="/assets/vendor/leaflet/leaflet.js"></script>
   <script defer src="/assets/js/leaflet-icon-patch.js"></script>
   <script defer src="/assets/vendor/leaflet.polylineDecorator.min.js"></script>
-  <script defer src="/assets/js/amaayesh-map.js"></script>
+  <script type="module" src="/assets/js/amaayesh-map.js"></script>
   <script defer src="/assets/js/panel-direct-wire.js"></script>
   <script defer src="/assets/js/ama-diag.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- load `amaayesh-map.js` as an ES module to resolve import errors in Amaayesh map page

## Testing
- `node tests/mapper.test.js`
- `node tests/e2e-cld.test.js` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68be9bc0b9608328b82d8c70a8d386f6