### PR TITLE
Remove default wind layer activation and show welcome alert

### DIFF
--- a/docs/assets/js/panel-direct-wire.js
+++ b/docs/assets/js/panel-direct-wire.js
@@ -84,7 +84,7 @@
   document.addEventListener('DOMContentLoaded', ()=>{
     if (document.querySelector('[data-layer-toggle]')) {
       A.initPanelDirectWire();
-      ensureOn('wind');
+      alert('\u062e\u0648\u0634 \u0622\u0645\u062f\u06cc\u062f!');
     }
   });
 })();


### PR DESCRIPTION
## Summary
- Remove automatic enabling of wind layer on load
- Display a welcome alert when layer panel initializes

## Testing
- `npm test` *(fails: TimeoutError Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68be9c5dcc488328b5dc88060e4b770b