### PR TITLE
Allow caching of map data

### DIFF
--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -211,7 +211,7 @@ async function getJSONwithFallback(relPath, timeoutMs = 30000){
     const ctl = new AbortController();
     const t = setTimeout(()=>ctl.abort(), timeoutMs);
     try {
-      const res = await fetch(url, { signal: ctl.signal, cache:'no-store' });
+      const res = await fetch(url, { signal: ctl.signal });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const ct = (res.headers.get('content-type')||'').toLowerCase();
       const txt = await res.text();
@@ -653,7 +653,7 @@ async function fetchJSONFromManifest(rel){
   let url = absFromManifest(rel);
   url = normalizeDataPath(url);
   if (__jsonCache.has(url)) return __jsonCache.get(url);
-  const res = await fetch(url, { cache: 'no-store' });
+  const res = await fetch(url);
   if (AMA_DEBUG) console.log('[ama:data]', 'GET', url, '->', res.status);
   if (!res.ok) throw new Error('data-not-found: ' + url);
   const j = await res.json();
@@ -669,7 +669,7 @@ async function fetchTextFromManifest(rel){
   const base = __LAYER_MANIFEST_BASE || '/data/';
   const cleanRel = String(rel || '').replace(/^\.?\//,'');
   const url = new URL(cleanRel, location.origin + base).pathname + qs;
-  const res = await fetch(url, { cache:'no-store' });
+  const res = await fetch(url);
   if (AMA_DEBUG) console.log('[ama:data:text] GET', url, '->', res.status);
   if (!res.ok) throw new Error('data-not-found: ' + url);
   return await res.text();
@@ -910,7 +910,7 @@ async function actuallyLoadManifest(){
   for (const b of bases){
     const url = b + 'layers.config.json' + qs;
     try{
-      const res = await fetch(url, { cache:'no-store' });
+      const res = await fetch(url);
       if (AMA_DEBUG) console.log('[ama:fetch]', 'GET', url, '->', res.status);
       if (res.ok){
         const json = await res.json();


### PR DESCRIPTION
## Summary
- remove `cache: 'no-store'` directives from AMA data fetch helpers so browsers can cache GeoJSON and CSV responses

## Testing
- `node tests/mapper.test.js`
- `node tests/e2e-cld.test.js` *(fails: TimeoutError waiting for page)*
- `curl -I http://localhost:5173/amaayesh/data/wind_sites.geojson`
- `curl -I -H "If-None-Match: W/\"3932260-8327-2025-09-08T07:38:16.489Z\"" http://localhost:5173/amaayesh/data/wind_sites.geojson`

------
https://chatgpt.com/codex/tasks/task_e_68be9ea897008328ad0abcb489849bff