### PR TITLE
chore: add CSP inline style gate

### DIFF
--- a/.github/workflows/csp-inline-style-check.yml
+++ b/.github/workflows/csp-inline-style-check.yml
@@ -1,0 +1,24 @@
+name: CSP Inline Style Gate
+on:
+  pull_request:
+jobs:
+  csp-inline-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i -g npm@latest || true
+      - run: |
+          set -o pipefail
+          output=$(npm run -s csp:scan)
+          count=$(printf "%s" "$output" | sed '/^$/d' | wc -l)
+          echo "$output"
+          echo "Found $count files with potential inline-style usage."
+          if [ "$count" -gt 0 ]; then
+            echo "CSP violation: Inline styles are not allowed (style=\" or .style. or style={{}})."
+            echo "Fix by moving styles into docs/assets/inline-migration.css and toggling classes."
+            exit 1
+          fi
+

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "vendor:supercluster": "node tools/vendorize_supercluster.js",
     "audit:ama": "node tools/audit_amaayesh.js",
     "verify:publish": "node tools/verify_publish_paths.js https://wesh360.ir/data/layers.config.json https://wesh360.ir/data/amaayesh/counties.geojson https://wesh360.ir/data/amaayesh/wind_sites.geojson || true",
-    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL"
+    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL",
+    "csp:scan:html": "grep -RlIF --include='*.html' --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.html' 'style=\"' docs || true",
+    "csp:scan:js": "grep -RlIF --include='*.js' --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.js' --exclude='*.bundle.js' --exclude='*.umd.js' --exclude='*plugin*.js' '.style.' docs || true",
+    "csp:scan:jsx": "grep -RlIF --include='*.{jsx,tsx}' 'style={{' dash || true",
+    "csp:scan": "npm run -s csp:scan:html; npm run -s csp:scan:js; npm run -s csp:scan:jsx"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- tighten CSP scan to only flag authored HTML/JS/JSX files, skipping dist/vendor/minified/bundled assets and listing violating filenames
- update CI gate to count violating files and fail with guidance when any inline styles are found

## Testing
- `npm run csp:scan | head -n 20`
- `sudo apt-get install -y libatk1.0-0 libgtk-3-0 libnss3 libxss1 libx11-xcb1 libxcomposite1 libxdamage1 libxrandr2 libpangocairo-1.0-0 libgbm1 libasound2t64`
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68be959234088328825887c6648a0f0c