### PR TITLE
refactor: add shared map panel style

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -23,7 +23,7 @@
     <div id="map"></div>
 
     <!-- پنل سمت راست -->
-    <aside id="ama-layer-dock" class="ama-panel ama-layer-dock">
+    <aside id="ama-layer-dock" class="ama-panel map-panel ama-layer-dock">
       <div class="ama-panel-header">
         <h2 class="ama-panel-title">لایه‌ها</h2>
         <button aria-label="تنظیمات" class="ama-settings-btn">⚙️</button>
@@ -41,7 +41,7 @@
     </aside>
 
     <!-- پنل سمت چپ -->
-    <aside id="ama-top-dock" class="ama-panel ama-top-dock">
+    <aside id="ama-top-dock" class="ama-panel map-panel ama-top-dock">
       <div class="ama-panel-header">
         <h2 class="ama-panel-title">برترین‌ها</h2>
         <span class="ama-top-badge">Top 10</span>

--- a/docs/assets/css/amaayesh.css
+++ b/docs/assets/css/amaayesh.css
@@ -1,4 +1,5 @@
-.legend-dock{background:rgba(10,15,28,.88);color:#fff;padding:12px;border-radius:14px;box-shadow:0 2px 8px rgba(0,0,0,.2);max-width:320px;font-size:14px}
+.map-panel{background:rgba(10,15,28,.88);color:#fff;padding:12px;border-radius:14px;box-shadow:0 2px 8px rgba(0,0,0,.2);font-size:14px}
+.legend-dock{max-width:320px}
 .legend-dock .legend-tabs{display:flex;gap:8px;flex-wrap:wrap;margin-bottom:8px}
 .legend-dock .chip{background:#0b1220;color:#e5e7eb;border:1px solid #324155;border-radius:16px;padding:10px 12px;cursor:pointer}
 .legend-dock .chip.muted{opacity:.65}
@@ -24,13 +25,13 @@
 .is-disabled{opacity:.5;pointer-events:none}
 
 /* === Tool Dock === */
-.tool-dock{display:flex;flex-direction:column;background:rgba(10,15,28,.88);padding:8px;border-radius:12px;box-shadow:0 4px 16px rgba(0,0,0,.25);gap:12px}
+.tool-dock{display:flex;flex-direction:column;gap:12px}
 .tool-dock .dock-btn{background:#0b1220;color:#e5e7eb;border:1px solid #324155;border-radius:9999px;width:44px;height:44px;display:flex;align-items:center;justify-content:center;cursor:pointer}
 .tool-dock .dock-btn:hover{background:#0ea5e9;color:#04121f;border-color:#0ea5e9}
 .tool-dock .dock-reset{margin-top:auto}
 
 /* === Layers Dock === */
-.layers-dock{background:rgba(10,15,28,.88);color:#fff;padding:12px;border-radius:14px;box-shadow:0 2px 8px rgba(0,0,0,.2);max-width:320px;font-size:14px}
+.layers-dock{max-width:320px}
 .layers-dock .ld-tabs{display:flex;gap:8px}
 .layers-dock .ld-tabs button{flex:1;background:#0b1220;color:#e5e7eb;border:1px solid #324155;border-radius:16px;padding:10px 12px;cursor:pointer}
 .layers-dock .ld-tabs button.active{background:#0ea5e9;color:#04121f;border-color:#0ea5e9}
@@ -49,14 +50,14 @@
 
 
 /* === KPI switcher === */
-.ama-kpi-switch{background:rgba(10,15,28,.88);color:#fff;padding:8px;border-radius:14px;box-shadow:0 2px 8px rgba(0,0,0,.2);display:flex;gap:6px}
+.ama-kpi-switch{display:flex;gap:6px}
 .ama-kpi-switch label{display:flex;align-items:center;position:relative}
 .ama-kpi-switch input{position:absolute;opacity:0}
 .ama-kpi-switch .chip{background:#0b1220;color:#e5e7eb;border:1px solid #324155;border-radius:16px;padding:10px 12px;cursor:pointer;min-width:44px;min-height:44px;display:flex;align-items:center;justify-content:center}
 .ama-kpi-switch input:checked+.chip{background:#0ea5e9;color:#04121f;border-color:#0ea5e9}
 
 /* === Sidepanel === */
-.ama-sidepanel{position:fixed;right:16px;top:96px;bottom:16px;max-width:360px;width:calc(100% - 32px);background:rgba(17,24,39,.97);color:#e5e7eb;z-index:1000;padding:20px;overflow:auto;border-radius:12px;box-shadow:0 4px 20px rgba(0,0,0,.4);display:none}
+.ama-sidepanel{position:fixed;right:16px;top:96px;bottom:16px;max-width:360px;width:calc(100% - 32px);z-index:1000;padding:20px;overflow:auto;border-radius:12px;box-shadow:0 4px 20px rgba(0,0,0,.4);display:none}
 .ama-sidepanel.open{display:block}
 .ama-sidepanel header{display:flex;justify-content:space-between;align-items:center;margin-bottom:12px}
 .ama-sidepanel .close-btn{cursor:pointer;font-size:20px;line-height:1}
@@ -69,7 +70,7 @@
 .ama-legend-warning{background:#fef3c7;color:#92400e;padding:2px 6px;border-radius:6px;font-size:12px;margin-top:6px;text-align:center}
 
 /* === Top-10 panel === */
-.ama-panel{background:rgba(10,15,28,.88);color:#fff;padding:12px;border-radius:12px;box-shadow:0 4px 16px rgba(0,0,0,.25);width:320px;font-size:14px;}
+.ama-panel{width:320px}
 .ama-panel-hd{font-weight:700;margin-bottom:8px;}
 .ama-panel-hd .sort{cursor:pointer;margin-right:6px;user-select:none;}
 .ama-panel-bd{max-height:300px;overflow-y:auto;}
@@ -105,12 +106,7 @@
 .leaflet-control-zoom{box-shadow:0 4px 16px rgba(0,0,0,.25);border-radius:12px;overflow:hidden}
 .leaflet-control-zoom a{border-radius:0}
 /* === Force dark (black) theme for guidance panels === */
-.legend-dock,
-.layers-dock,
-.tool-dock,
-.ama-panel,
-.ama-kpi-switch,
-.ama-sidepanel {
+.map-panel {
   background: #000 !important;
   color: #fff !important;
   border-color: #324155 !important;

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -1086,7 +1086,7 @@ async function actuallyLoadManifest(){
 
     const div = document.createElement('div');
     div.id = 'ama-sidepanel';
-    div.className = 'ama-sidepanel';
+    div.className = 'ama-sidepanel map-panel';
     div.innerHTML = `<header><h3 id="ama-sp-name"></h3><button class="close-btn" aria-label="بستن">×</button></header><div id="ama-sp-body"></div>`;
     document.body.appendChild(div);
     sidepanelEl = div;
@@ -1401,7 +1401,7 @@ async function actuallyLoadManifest(){
           // KPI switcher
           const kpiCtl = L.control({position:'topright'});
           kpiCtl.onAdd = function(){
-            const div=L.DomUtil.create('div','ama-kpi-switch');
+            const div=L.DomUtil.create('div','ama-kpi-switch map-panel');
             div.innerHTML = Object.entries(windKpiLabels).map(([k,v])=>`<label><input type="radio" name="ama-kpi" value="${k}" ${k===windKpiKey?'checked':''}/><span class="chip">${v}</span></label>`).join('');
             if(!window.__WIND_DATA_READY) { div.classList.add('is-disabled'); div.title='داده باد آماده نیست'; }
             L.DomEvent.disableClickPropagation(div);
@@ -1426,7 +1426,7 @@ async function actuallyLoadManifest(){
 
           // Top-10 panel
           window.__AMA_topPanel = L.control({position:"topright"});
-          window.__AMA_topPanel.onAdd = function(){ const wrap=L.DomUtil.create("div","ama-panel"); wrap.innerHTML = `<div class="ama-panel-hd">Top-10 باد</div><div class="ama-panel-bd"><div id="ama-top10"></div></div>`; return wrap; };
+          window.__AMA_topPanel.onAdd = function(){ const wrap=L.DomUtil.create("div","ama-panel map-panel"); wrap.innerHTML = `<div class="ama-panel-hd">Top-10 باد</div><div class="ama-panel-bd"><div id="ama-top10"></div></div>`; return wrap; };
           window.__AMA_renderTop10 = debounce(function(){
             const el=document.getElementById('ama-top10');
             const panel=el?el.closest('.ama-panel'):null;
@@ -1448,7 +1448,7 @@ async function actuallyLoadManifest(){
           // KPI legend panel
           window.__AMA_kpiLegend = L.control({position:"topright"});
           window.__AMA_kpiLegend.onAdd = function(){
-            const wrap = L.DomUtil.create("div","ama-panel");
+            const wrap = L.DomUtil.create("div","ama-panel map-panel");
             const body = L.DomUtil.create("div","ama-kpi-legend",wrap);
             body.id = "ama-kpi-legend";
             return wrap;
@@ -1547,7 +1547,7 @@ async function actuallyLoadManifest(){
 
       // ===== LegendDock =====
       function LegendDock(){
-        const div = L.DomUtil.create('div','legend-dock'); div.dir='rtl';
+        const div = L.DomUtil.create('div','legend-dock map-panel'); div.dir='rtl';
         div.innerHTML = `<div class="legend-tabs"></div><div class="legend-body"></div>`;
         if(localStorage.getItem('ama-legend-collapsed')==='1') div.classList.add('collapsed');
         let groups = [], onFilter = null;
@@ -1714,7 +1714,7 @@ async function actuallyLoadManifest(){
       const LayersDock = L.Control.extend({
         options: { position:'topleft', dir:'rtl' },
         onAdd: function(m){
-          const container = L.DomUtil.create('div', 'layers-dock leaflet-control');
+          const container = L.DomUtil.create('div', 'layers-dock map-panel leaflet-control');
           container.setAttribute('dir', this.options.dir);
 
           const tabsEl = L.DomUtil.create('div', 'ld-tabs', container);
@@ -1972,7 +1972,7 @@ async function actuallyLoadManifest(){
       function makePanel(title, bodyHtml){
         const ctl = L.control({position:'topleft'});
         ctl.onAdd = function(){
-          const wrap=L.DomUtil.create('div','ama-panel');
+          const wrap=L.DomUtil.create('div','ama-panel map-panel');
           wrap.innerHTML=`<div class="ama-panel-hd">${title}<button class="close-btn" aria-label="بستن">×</button></div><div class="ama-panel-bd">${bodyHtml}</div>`;
           const close=wrap.querySelector('.close-btn');
           close.onclick=()=>{ map.removeControl(ctl); };
@@ -1991,7 +1991,7 @@ async function actuallyLoadManifest(){
 
       const dockCtl=L.control({position:'topleft'});
       dockCtl.onAdd=function(){
-        const div=L.DomUtil.create('div','tool-dock');
+        const div=L.DomUtil.create('div','tool-dock map-panel');
         div.innerHTML=`<button class="dock-btn" data-panel="layers" aria-label="لایه‌ها">🗂</button>
         <button class="dock-btn" data-panel="tools" aria-label="ابزارها">🛠</button>
         <button class="dock-btn" data-panel="download" aria-label="دانلود">⬇</button>


### PR DESCRIPTION
## Summary
- add reusable `.map-panel` CSS class for common panel styling
- use `.map-panel` across legend, layer, tool, KPI, and side panels

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68bee14e44388328aa13be8b018efca8