### PR TITLE
chore: add CSP inline style gate

### DIFF
--- a/.github/workflows/csp-inline-style-check.yml
+++ b/.github/workflows/csp-inline-style-check.yml
@@ -1,0 +1,25 @@
+name: CSP Inline Style Gate
+on:
+  pull_request:
+jobs:
+  csp-inline-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i -g npm@latest || true
+      - name: Scan for inline styles (loosened)
+        shell: bash
+        run: |
+          set -o pipefail
+          output="$(npm run -s csp:scan)"
+          echo "$output"
+          count="$(printf "%s" "$output" | sed '/^\s*$/d' | wc -l)"
+          echo "Found $count files with potential inline-style usage."
+          if [ "$count" -gt 0 ]; then
+            echo "CSP violation: Inline styles are not allowed (style=\" or .style. or style={{}})."
+            echo "Fix by moving styles into docs/assets/inline-migration.css and toggling classes."
+            exit 1
+          fi

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "vendor:supercluster": "node tools/vendorize_supercluster.js",
     "audit:ama": "node tools/audit_amaayesh.js",
     "verify:publish": "node tools/verify_publish_paths.js https://wesh360.ir/data/layers.config.json https://wesh360.ir/data/amaayesh/counties.geojson https://wesh360.ir/data/amaayesh/wind_sites.geojson || true",
-    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL"
+    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL",
+    "csp:scan:html": "grep -RlIF --include='*.html' --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.html' 'style=\"' docs || true",
+    "csp:scan:js":   "grep -RlIF --include='*.js'   --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.js' --exclude='*.bundle.js' --exclude='*.umd.js' --exclude='*plugin*.js' '.style.' docs || true",
+    "csp:scan:jsx":  "grep -RlIF --include='*.{jsx,tsx}' 'style={{' dash || true",
+    "csp:scan":      "{ npm run -s csp:scan:html; npm run -s csp:scan:js; npm run -s csp:scan:jsx; } | sort -u"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add npm scripts to scan docs and dash for inline style usage
- add GitHub Action to enforce no inline styles

## Testing
- `npm test` *(fails: libdrm.so.2: cannot open shared object file)*
- `npm run -s csp:scan`


------
https://chatgpt.com/codex/tasks/task_e_68bee94c41b08328a486a5544c07ae4a