### PR TITLE
chore: add CSP inline style gate

### DIFF
--- a/.github/workflows/csp-inline-style-check.yml
+++ b/.github/workflows/csp-inline-style-check.yml
@@ -1,0 +1,50 @@
+name: CSP Inline Style Gate
+on:
+  pull_request:
+jobs:
+  csp-inline-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm i -g npm@latest || true
+      - name: Scan for inline styles (ratchet)
+        shell: bash
+        run: |
+          set -o pipefail
+          current="$(npm run -s csp:scan | sed '/^\s*$/d' | sort -u)"
+          base_file="tools/csp-baseline.txt"
+          if [ -f "$base_file" ]; then
+            baseline="$(sed '/^\s*$/d' "$base_file" | sort -u)"
+          else
+            baseline=""
+          fi
+
+          # write to temp files for comm
+          tmp_cur="$(mktemp)"; tmp_base="$(mktemp)"
+          printf "%s\n" "$current"  > "$tmp_cur"
+          printf "%s\n" "$baseline" > "$tmp_base"
+
+          echo "----- CSP Inline Style Scan (filenames only) -----"
+          cur_count="$(wc -l < "$tmp_cur" | tr -d ' ')"
+          base_count="$(wc -l < "$tmp_base" | tr -d ' ')"
+          echo "Baseline files: $base_count"
+          echo "Current files : $cur_count"
+
+          # new = current minus baseline (lines unique to current)
+          new_files="$(comm -23 "$tmp_cur" "$tmp_base")"
+          new_count="$(printf "%s\n" "$new_files" | sed '/^\s*$/d' | wc -l | tr -d ' ')"
+
+          if [ "$new_count" -gt 0 ]; then
+            echo ""
+            echo "NEW offending files (not in baseline):"
+            echo "$new_files"
+            echo ""
+            echo "CSP violation: new inline-style usages detected (style=\" or .style. or style={{}})."
+            echo "Fix by moving styles into docs/assets/inline-migration.css and toggling classes."
+            exit 1
+          else
+            echo "No NEW offending files. (Baseline still contains known debt; burn it down over time.)"
+          fi

--- a/package.json
+++ b/package.json
@@ -23,7 +23,11 @@
     "vendor:supercluster": "node tools/vendorize_supercluster.js",
     "audit:ama": "node tools/audit_amaayesh.js",
     "verify:publish": "node tools/verify_publish_paths.js https://wesh360.ir/data/layers.config.json https://wesh360.ir/data/amaayesh/counties.geojson https://wesh360.ir/data/amaayesh/wind_sites.geojson || true",
-    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL"
+    "rca:publish": "node tools/rca_publish.js --base=$SITE_URL",
+    "csp:scan:html": "grep -RlIF --include='*.html' --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.html' 'style=\"' docs || true",
+    "csp:scan:js":   "grep -RlIF --include='*.js'   --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.js' --exclude='*.bundle.js' --exclude='*.umd.js' --exclude='*plugin*.js' '.style.' docs || true",
+    "csp:scan:jsx":  "grep -RlIF --include='*.{jsx,tsx}' 'style={{' dash || true",
+    "csp:scan":      "{ npm run -s csp:scan:html; npm run -s csp:scan:js; npm run -s csp:scan:jsx; } | sort -u"
   },
   "keywords": [],
   "author": "",

--- a/tools/csp-baseline.txt
+++ b/tools/csp-baseline.txt
@@ -1,0 +1,10 @@
+docs/assets/parallax.js
+docs/assets/power-tariff.js
+docs/assets/water-cld.aha.js
+docs/assets/water-cld.ghost-delta.js
+docs/assets/water-cld.js
+docs/assets/water-cld.provenance.js
+docs/assets/water-cld.scenarios.js
+docs/assets/water-cld.tour.js
+docs/assets/water-sfd.js
+docs/index.js


### PR DESCRIPTION
## Summary
- track known inline style offenders in a baseline file
- run CI gate that compares current offenders against baseline and fails only on new ones

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run -s csp:scan`


------
https://chatgpt.com/codex/tasks/task_e_68bee94c41b08328a486a5544c07ae4a