### PR TITLE
Add mobile bottom sheet and map breakpoints

### DIFF
--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -53,6 +53,7 @@
         <tbody id="ama-top10"></tbody>
       </table>
     </aside>
+    <button id="infoToggle" class="info-toggle" aria-controls="ama-top-dock" aria-expanded="false" title="نمایش اطلاعات">ℹ️</button>
   </main>
 
   <footer class="mt-6 py-6 text-center text-slate-400 text-xs">WESH360 • Energy Spatial Planning • Leaflet</footer>

--- a/docs/assets/css/map-inline.css
+++ b/docs/assets/css/map-inline.css
@@ -1,6 +1,8 @@
 html, body { height:100% }
+.leaflet-container{ touch-action:pan-x pan-y; }
 .label{ font-family: Vazirmatn, sans-serif; font-size:12px; text-shadow:0 0 6px #fff }
 .map-wrap{ height:calc(100vh - 110px) }
+body,html{overflow-x:hidden;}
 #map{ height:100vh; width:100%; }
 
 .ama-main{ isolation:isolate; }
@@ -26,3 +28,29 @@ html, body { height:100% }
 .ama-top-table{ width:100%; font:500 12px system-ui; color:#374151; }
 .ama-top-thead{ background:#f9fafb; color:#4b5563; }
 .ama-top-th{ padding:6px; }
+
+@media (max-width:640px){
+  #ama-top-dock{
+    position:fixed;
+    top:auto;
+    left:0;
+    right:0;
+    bottom:0;
+    width:100%;
+    border-radius:12px 12px 0 0;
+    transform:translateY(100%);
+    transition:transform .3s ease-in-out;
+  }
+  #ama-top-dock.open{ transform:translateY(0); }
+  .info-toggle{
+    position:fixed;
+    bottom:16px;
+    left:16px;
+    z-index:1002;
+    background:rgba(255,255,255,.9);
+    backdrop-filter:saturate(150%) blur(4px);
+    border-radius:9999px;
+    padding:8px;
+    color:#000;
+  }
+}

--- a/docs/assets/js/amaayesh-map.js
+++ b/docs/assets/js/amaayesh-map.js
@@ -2133,10 +2133,17 @@ async function ama_bootstrap(){
   window.__combinedGeo = provinceFC;
   if (window.AMA_DEBUG) console.log('[AHA] all-counties.features =', (countiesFC?.features||[]).length);
 
-  const map = window.__AMA_MAP || AMA.map || L.map('map', { preferCanvas:true, zoomControl:true });
+  const map = window.__AMA_MAP || AMA.map || L.map('map', {
+    preferCanvas: true,
+    zoomControl: false,
+    touchZoom: true,
+    dragging: true
+  });
   window.__AMA_MAP = map;
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',{ attribution:'© OpenStreetMap' }).addTo(map);
-  if (map.zoomControl && typeof map.zoomControl.setPosition==='function') map.zoomControl.setPosition('bottomleft');
+  L.control.zoom({ position: 'bottomright' }).addTo(map);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '© OpenStreetMap'
+  }).addTo(map);
   if (map.attributionControl && typeof map.attributionControl.setPosition === 'function') {
     map.attributionControl.setPosition('bottomleft');
   }
@@ -2214,3 +2221,14 @@ map.createPane('boundary');  setClass(map.getPane('boundary'), ['z-650']);
 }
 
 ama_bootstrap();
+
+document.addEventListener('DOMContentLoaded', () => {
+  const panel = document.getElementById('ama-top-dock');
+  const btn = document.getElementById('infoToggle');
+  if (panel && btn) {
+    btn.addEventListener('click', () => {
+      const open = panel.classList.toggle('open');
+      btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+    });
+  }
+});

--- a/src/styles/responsive.css
+++ b/src/styles/responsive.css
@@ -1,0 +1,12 @@
+/* Responsive breakpoints for small displays */
+@media (max-width: 360px) {
+  body {
+    font-size: 14px;
+  }
+}
+
+@media (min-width: 361px) and (max-width: 640px) {
+  body {
+    font-size: 16px;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,14 @@
 module.exports = {
   content: ['./docs/**/*.html', './docs/**/*.js'],
+  theme: {
+    screens: {
+      xs: '360px',
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1536px'
+    }
+  },
   safelist: [/curtain/, 'open', 'left', 'right']
 };


### PR DESCRIPTION
## Summary
- define explicit Tailwind and CSS breakpoints for small devices
- add bottom sheet info panel with toggle button on energy map
- move zoom controls to bottom right for mobile-friendly use

## Testing
- `npm run build:css`
- `npm test` *(fails: libdrm.so.2 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bef0e74e34832886e54e4de6aa775f