### PR TITLE
feat: add collapsible resizable map panels

### DIFF
--- a/docs/assets/css/map-inline.css
+++ b/docs/assets/css/map-inline.css
@@ -5,9 +5,16 @@ html, body { height:100% }
 
 .ama-main{ isolation:isolate; }
 
-.ama-panel{ position:absolute; z-index:1001; pointer-events:auto; background:rgba(255,255,255,.9); backdrop-filter:saturate(150%) blur(4px); border-radius:12px; box-shadow:0 10px 25px rgba(0,0,0,.12); padding:12px; }
+.ama-panel{ position:absolute; z-index:1001; pointer-events:auto; background:rgba(255,255,255,.9); backdrop-filter:saturate(150%) blur(4px); border-radius:12px; box-shadow:0 10px 25px rgba(0,0,0,.12); padding:12px; overflow:hidden; display:flex; flex-direction:column; }
 .ama-layer-dock{ top:16px; right:16px; width:320px; color:#000; }
 .ama-top-dock{ top:16px; left:16px; width:280px; }
+
+.ama-panel-bd{ overflow:auto; }
+
+.ama-panel-collapsed .ama-panel-bd{ display:none; }
+.ama-panel-collapsed .ama-panel-resize-handle{ display:none; }
+
+.ama-panel-resize-handle{ height:8px; cursor:ns-resize; }
 
 .ama-panel-header{ display:flex; justify-content:space-between; align-items:center; margin-bottom:8px; border-bottom:1px solid rgba(0,0,0,.08); padding-bottom:8px; }
 .ama-panel-title{ font:600 16px system-ui; }


### PR DESCRIPTION
## Summary
- add initAmaPanel helper to toggle and resize map panels with state saved in localStorage
- support collapsible, resizable panels in Top-10 and tool panels
- define panel collapse and resize CSS styles
- avoid inline style property usage in panel resize to satisfy CSP check

## Testing
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*
- `npm run -s csp:scan`


------
https://chatgpt.com/codex/tasks/task_e_68bef249a190832881b2526c30312327