### PR TITLE
feat: improve contrast and theme variables

### DIFF
--- a/docs/assets/site-overrides.css
+++ b/docs/assets/site-overrides.css
@@ -2,17 +2,25 @@
 @keyframes float { 0%,100%{transform:translateY(0)} 50%{transform:translateY(-6px)} }
 
 /* From electricity/peak.html */
+:root {
+    --background-color: #0a0a0a;
+    --text-color: #f9fafb;
+    --link-color: #6ee7b7;
+    --scrollbar-track: var(--background-color);
+    --scrollbar-thumb: #94a3b8;
+    --scrollbar-thumb-hover: #64748b;
+}
 body {
     font-family: 'Vazirmatn', sans-serif;
-    background-color: #f1f5f9;
+    background-color: var(--background-color);
+    color: var(--text-color);
 }
 ::-webkit-scrollbar { width: 8px; }
-::-webkit-scrollbar-track { background: #f1f5f9; }
-::-webkit-scrollbar-thumb { background: #94a3b8; border-radius: 10px; }
-::-webkit-scrollbar-thumb:hover { background: #64748b; }
+::-webkit-scrollbar-track { background: var(--scrollbar-track); }
+::-webkit-scrollbar-thumb { background: var(--scrollbar-thumb); border-radius: 10px; }
+::-webkit-scrollbar-thumb:hover { background: var(--scrollbar-thumb-hover); }
 .chart-container { position: relative; height: 350px; width: 100%; }
 
 /* From agrivoltaics/index.dev.html */
 /* استایل پشتیبان در صورت در دسترس نبودن Tailwind */
-body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial; background:#0a0a0a; color:#eee}
-a{color:#6ee7b7}
+a{color:var(--link-color)}

--- a/docs/assets/water-cost.css
+++ b/docs/assets/water-cost.css
@@ -1,6 +1,7 @@
 :root{
   --bg:#F8FAFC; --card:#FFFFFF; --muted:#64748B; --border:#E2E8F0;
   --title:#0F172A; --primary:#3B82F6; --accent:#06B6D4; --success:#10B981; --danger:#EF4444;
+  --column-bg:#F8FAFC; --progress-bg:#E5E7EB; --progress-fill:linear-gradient(90deg,var(--primary),var(--accent));
   --radius:16px; --pad:18px; --g:16px; --shadow:0 10px 24px rgba(2,6,23,.06);
 }
 [dir="rtl"] body{background:var(--bg); color:var(--title); font-family:'Vazirmatn',sans-serif;}
@@ -23,9 +24,9 @@
 
 .tbl{width:100%; border-collapse:separate; border-spacing:0 8px; font-size:.92rem;}
 .tbl th{color:var(--muted); font-weight:700; text-align:right; padding:0 8px 6px;}
-.tbl td{background:#F8FAFC; border:1px solid var(--border); padding:10px 12px; border-radius:10px;}
-.progress{height:8px; background:#E5E7EB; border-radius:999px; overflow:hidden;}
-.progress > span{display:block; height:100%; background:linear-gradient(90deg,var(--primary),var(--accent));}
+.tbl td{background:var(--column-bg); border:1px solid var(--border); padding:10px 12px; border-radius:10px;}
+.progress{height:8px; background:var(--progress-bg); border-radius:999px; overflow:hidden;}
+.progress > span{display:block; height:100%; background:var(--progress-fill);}
 
 .controls .group{display:grid; gap:10px; margin-bottom:14px;}
 .controls label{font-weight:700; font-size:.95rem;}


### PR DESCRIPTION
## Summary
- define global background/text/link colors with CSS variables and dark theme
- expose progress bar and table column colors as CSS variables for easy theming

## Testing
- `python3 - <<'PY'...` *(contrast ratio 18.95:1)*
- `python3 - <<'PY'...` *(simulate color blindness for text/bg colors)*
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbcaed4748328b047b1a97b5698ca