### PR TITLE
fix: load Chart.js from relative path

### DIFF
--- a/docs/electricity/peak.html
+++ b/docs/electricity/peak.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="/assets/unified-badge.css">
     <link rel="stylesheet" href="../assets/site-overrides.css">
     <link rel="stylesheet" href="../assets/inline-migration.css" />
-    <script src="/assets/vendor/chart.umd.min.js"></script>
+    <script src="../assets/vendor/chart.umd.min.js"></script>
     <script src="../assets/electricity-management.js"></script>
     <script defer src="/assets/unified-badge.js"></script>
     <script defer src="/assets/global-footer.js"></script>

--- a/docs/electricity/quality.html
+++ b/docs/electricity/quality.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="../assets/tailwind.css">
 
     <!-- Chart.js: نسخه محلی پروژه -->
-    <script src="/assets/vendor/chart.umd.min.js"></script>
+    <script src="../assets/vendor/chart.umd.min.js"></script>
 
     <!-- فونت محلی Vazirmatn -->
   <link rel="stylesheet" href="../assets/fonts.css">

--- a/docs/gas/energy.html
+++ b/docs/gas/energy.html
@@ -138,7 +138,7 @@
   </div>
 
   <!-- کتابخانه‌ها و اسکریپت‌ها (محلی) -->
-  <script defer src="/assets/vendor/chart.umd.min.js"></script>
+  <script defer src="../assets/vendor/chart.umd.min.js"></script>
   <script defer src="../assets/numfmt.js"></script>
   <script defer src="./energy.js"></script>
   <script defer src="../assets/badge-updated.js"></script>

--- a/docs/gas/fuel-carbon.html
+++ b/docs/gas/fuel-carbon.html
@@ -199,7 +199,7 @@
   </div>
 
   <!-- اسکریپت اختصاصی این صفحه (JS جداگانه) -->
-  <script src="/assets/vendor/chart.umd.min.js" defer></script>
+  <script src="../assets/vendor/chart.umd.min.js" defer></script>
   <script src="../vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js" defer></script>
   <script src="../assets/js/gas-fuel-carbon.js?v=1" defer></script>
 </body>

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -129,7 +129,7 @@
   <div class="footer-note">با هر تغییر در ورودی‌ها، نتایج به‌صورت زنده محاسبه می‌شوند.</div>
 </main>
 
-  <script src="/assets/vendor/chart.umd.min.js"></script>
+  <script src="../assets/vendor/chart.umd.min.js"></script>
   <script defer src="../assets/water-cost.js"></script>
   <script defer src="../assets/water-init.js"></script>
 </body>

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -215,7 +215,7 @@
     
     
 
-    <script defer src="/assets/vendor/chart.umd.min.js"></script>
+    <script defer src="../assets/vendor/chart.umd.min.js"></script>
     <script defer src="../assets/water-init.js"></script>
     <script type="module" src="../assets/ai.js"></script>
     <script defer src="../assets/app.js"></script>


### PR DESCRIPTION
## Summary
- use relative path for Chart.js vendor script across docs pages to ensure loading

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd6bfc64083289d8f6ded5cc6efde