### PR TITLE
Add default min-height for sim chart canvas

### DIFF
--- a/docs/assets/chart.autofix.css
+++ b/docs/assets/chart.autofix.css
@@ -1,11 +1,12 @@
 /* ===== Chart AutoFix: safe defaults (non-invasive) ===== */
-#sim-panel { min-height: 260px }
+#sim-panel { min-height: 300px }
 #sim-panel canvas#sim-chart {
   width: 100% !important;
-  height: 260px !important;     /* اگر ارتفاع صفر باشد، Chart.js چیزی نمی‌کشد */
+  min-height: 300px;
+  height: 300px !important;     /* اگر ارتفاع صفر باشد، Chart.js چیزی نمی‌کشد */
   display: block;
 }
 @media (max-width: 640px){
-  #sim-panel { min-height: 220px }
-  #sim-panel canvas#sim-chart { height: 220px !important }
+  #sim-panel { min-height: 240px }
+  #sim-panel canvas#sim-chart { min-height: 240px; height: 240px !important }
 }


### PR DESCRIPTION
## Summary
- ensure the simulation chart canvas has default min-height and explicit height so it renders

## Testing
- `npm test` *(fails: TargetCloseError: Protocol error (Runtime.callFunctionOn): Target closed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd9f7b788832897832f0cd369fac6