### PR TITLE
fix: support cytoscape inline styles via CSP

### DIFF
--- a/docs/_headers
+++ b/docs/_headers
@@ -1,5 +1,6 @@
 /*
-  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self'; script-src 'self'; connect-src 'self';
+  Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; script-src 'self'; connect-src 'self'; style-src-elem 'self'; style-src-attr 'unsafe-inline'
+  X-Content-Security-Policy: default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; script-src 'self'; connect-src 'self'; style-src 'self' 'unsafe-inline'
   Referrer-Policy: no-referrer
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY

--- a/netlify.toml
+++ b/netlify.toml
@@ -73,16 +73,6 @@ for = "/assets/*"
   Cache-Control = "public, max-age=31536000, immutable"
 
 [[headers]]
-for = "/*"
-  [headers.values]
-  Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self'; script-src 'self'; connect-src 'self';"
-
-[[headers]]
-for = "/amaayesh/*"
-  [headers.values]
-  Content-Security-Policy = "default-src 'self'; base-uri 'self'; object-src 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self';"
-
-[[headers]]
 for = "/data/amaayesh/*"
   [headers.values]
   Cache-Control = "public, max-age=900, stale-while-revalidate=60"


### PR DESCRIPTION
## Summary
- allow Cytoscape inline styling by using CSP3 style-src-attr fallback
- drop duplicate Content-Security-Policy entries from Netlify config to avoid conflicts

## Testing
- `npm test` *(fails: TimeoutError: Waiting failed: 15000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68bfeaa94e5c832896e50abd37227538