### PR TITLE
feat: add cy state report script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "csp:scan:html": "grep -RlIF --include='*.html' --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.html' 'style=\"' docs || true",
     "csp:scan:js": "grep -RlIF --include='*.js'   --exclude-dir='dist' --exclude-dir='vendor' --exclude='*.min.js' --exclude='*.bundle.js' --exclude='*.umd.js' --exclude='*plugin*.js' '.style.' docs || true",
     "csp:scan:jsx": "grep -RlIF --include='*.{jsx,tsx}' 'style={{' dash || true",
-    "csp:scan": "{ npm run -s csp:scan:html; npm run -s csp:scan:js; npm run -s csp:scan:jsx; } | sort -u"
+    "csp:scan": "{ npm run -s csp:scan:html; npm run -s csp:scan:js; npm run -s csp:scan:jsx; } | sort -u",
+    "report:cy": "node scripts/cy-state-report.js"
   },
   "keywords": [],
   "author": "",

--- a/runtime-report.json
+++ b/runtime-report.json
@@ -1,0 +1,3 @@
+{
+  "cyState": null
+}

--- a/scripts/cy-state-report.js
+++ b/scripts/cy-state-report.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const path = require('path');
+const puppeteer = require('puppeteer');
+
+(async () => {
+  const browser = await puppeteer.launch({ headless: true, args: ['--no-sandbox', '--disable-setuid-sandbox'], ignoreHTTPSErrors: true });
+  try {
+    const page = await browser.newPage();
+    const url = process.env.CY_URL || 'https://wesh360.ir/water/hub';
+    await page.goto(url, { waitUntil: 'networkidle2' });
+
+    const cyState = await page.evaluate(() => {
+      const cy = window.cy;
+      try {
+        return cy && typeof cy.state === 'function' ? cy.state() : null;
+      } catch (e) {
+        return null;
+      }
+    });
+
+    const reportPath = path.join(process.cwd(), 'runtime-report.json');
+    let report = {};
+    try {
+      report = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    } catch (e) {
+      // ignore if file does not exist
+    }
+    report.cyState = cyState;
+    fs.writeFileSync(reportPath, JSON.stringify(report, null, 2));
+  } finally {
+    await browser.close();
+  }
+})();


### PR DESCRIPTION
## Summary
- add Puppeteer script to gather `cyState` and write `runtime-report.json`
- expose script via `npm run report:cy`

## Testing
- `npm run report:cy`
- `npm test` *(fails: positive edges should be visible)*

------
https://chatgpt.com/codex/tasks/task_e_68c042bcadc08328adff79be311072ae