### PR TITLE
A7: add TypeScript check-only for CLD core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install (clean)
         run: npm ci
 
+      - name: TS check (core)
+        run: npm run ts:check
+
       - name: Unit (mapper)
         run: npm run test:unit:mapper
 

--- a/docs/assets/cld/core/index.js
+++ b/docs/assets/cld/core/index.js
@@ -1,3 +1,5 @@
+/** @typedef {import('./types').CLDNode} CLDNode */
+/** @typedef {import('./types').CLDEdge} CLDEdge */
 /* UMD-safe CLD Core Facade (no ES exports) */
 (function(global){
   // deps expected: validate.js, mapper.js, inject.js already loaded

--- a/docs/assets/cld/core/mapper.js
+++ b/docs/assets/cld/core/mapper.js
@@ -1,3 +1,6 @@
+/** @typedef {import('./types').CLDNode} CLDNode */
+/** @typedef {import('./types').CLDEdge} CLDEdge */
+
 (function (root, factory) {
   if (typeof module === 'object' && module.exports) {
     module.exports = factory();
@@ -15,6 +18,10 @@
   // Contract (min):
   //  Node: { id, label, group? }
   //  Edge: { id?, source, target, sign:(+|-)?, weight?:number, delay?:number }
+  /**
+   * @param {{nodes?: CLDNode[]; edges?: CLDEdge[]; [k:string]: any}} model
+   * @returns {Array<{group:'nodes'|'edges'; data: any}>}
+   */
   function mapModelToElements(model) {
     var nodes = (model && (model.nodes || model.Vertices || model.NODES)) || [];
     var edges = (model && (model.edges || model.Links || model.EDGES)) || [];

--- a/docs/assets/cld/core/types.d.ts
+++ b/docs/assets/cld/core/types.d.ts
@@ -1,0 +1,3 @@
+export type CLDNode = { id: string; label: string; group?: string };
+export type CLDEdge = { id?: string; source: string; target: string; sign?: '+' | '-'; weight?: number; delay?: number };
+

--- a/docs/assets/cld/core/validate.js
+++ b/docs/assets/cld/core/validate.js
@@ -1,3 +1,6 @@
+/** @typedef {import('./types').CLDNode} CLDNode */
+/** @typedef {import('./types').CLDEdge} CLDEdge */
+
 (function (root, factory) {
   if (typeof module === 'object' && module.exports) {
     module.exports = factory();
@@ -11,6 +14,10 @@
     } catch (_) {}
   }
 }(typeof self !== 'undefined' ? self : this, function () {
+  /**
+   * @param {{nodes?: CLDNode[]; edges?: CLDEdge[]; [k:string]: any}} model
+   * @returns {{ ok: boolean; errs: string[]; nodes: CLDNode[]; edges: CLDEdge[] }}
+   */
   function validateModel(model) {
     var errs = [];
     if (!model) errs.push('model is null/undefined');

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@babel/cli": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
+        "@tsconfig/recommended": "^1.0.10",
         "clean-css": "^5.3.3",
         "cross-env": "^10.0.0",
         "fs-extra": "^11.3.1",
@@ -28,7 +29,11 @@
         "puppeteer": "^24.10.2",
         "supercluster": "^7.1.5",
         "tailwindcss": "^3.4.17",
-        "terser": "^5.43.1"
+        "terser": "^5.43.1",
+        "typescript": "^5.9.2"
+      },
+      "engines": {
+        "node": ">=18 <23"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1569,6 +1574,13 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
       "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/recommended": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@tsconfig/recommended/-/recommended-1.0.10.tgz",
+      "integrity": "sha512-cGvydvg03lONp5Z9yaplW493Vw9/um7k588mvDkm+VFPF2PZUVPx0uswq4PFpeEySsLbQRETrDRhzh4Dmxaslw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test:unit:mapper": "node tests/unit/mapper.test.js",
     "e2e:smoke:fixed": "cross-env TEST_PORT=9099 node tests/e2e/cld-smoke.js",
     "e2e:csp:fast": "node tests/e2e/csp-violations.js",
-    "e2e:csp:fast:env": "cross-env TEST_FAST=1 NAV_TIMEOUT=15000 node tests/e2e/csp-violations.js"
+    "e2e:csp:fast:env": "cross-env TEST_FAST=1 NAV_TIMEOUT=15000 node tests/e2e/csp-violations.js",
+    "ts:check": "tsc -p tsconfig.json"
   },
   "keywords": [],
   "author": "",
@@ -45,6 +46,7 @@
   "devDependencies": {
     "@babel/cli": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
+    "@tsconfig/recommended": "^1.0.10",
     "clean-css": "^5.3.3",
     "cross-env": "^10.0.0",
     "fs-extra": "^11.3.1",
@@ -53,7 +55,8 @@
     "puppeteer": "^24.10.2",
     "supercluster": "^7.1.5",
     "tailwindcss": "^3.4.17",
-    "terser": "^5.43.1"
+    "terser": "^5.43.1",
+    "typescript": "^5.9.2"
   },
   "dependencies": {
     "@netlify/blobs": "^10.0.8",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/recommended/tsconfig.json",
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "baseUrl": ".",
+    "paths": {}
+  },
+  "include": ["docs/assets/cld/core/**/*.js"]
+}
+


### PR DESCRIPTION
Adds TypeScript in check-only mode for CLD core:\n- tsconfig extends @tsconfig/recommended with allowJs/checkJs/noEmit\n- Types declared in docs/assets/cld/core/types.d.ts\n- JSDoc typedef wiring in mapper/validate/index\n- CI runs 'npm run ts:check' before unit tests\n\nNo build outputs are produced; errors will be addressed incrementally in follow-up PRs.