### PR TITLE
A2: Fix CLD defer loader (absolute bundle path) to remove 404/MIME

### DIFF
--- a/docs/assets/water-cld.defer.js
+++ b/docs/assets/water-cld.defer.js
@@ -3,10 +3,11 @@
   var existing = document.querySelector('script[data-cld-bundle]');
   if (existing) { console.log('[CLD defer] bundle tag already in DOM:', existing.src); return; }
 
-  // Allow overriding via window.CLD_BUNDLE_URLS
-  var candidates = (Array.isArray(window.CLD_BUNDLE_URLS) && window.CLD_BUNDLE_URLS.length)
-    ? window.CLD_BUNDLE_URLS
-    : ['../assets/dist/water-cld.bundle.js?v=3', './assets/dist/water-cld.bundle.js?v=3'];
+  var current = document.currentScript;
+  var candidates = ['/assets/dist/water-cld.bundle.js?v=3', '/assets/dist/water-cld.bundle.js'];
+  if (current && current.dataset && current.dataset.bundle) {
+    candidates[0] = current.dataset.bundle;
+  }
 
   function tryLoad(i) {
     if (i >= candidates.length) {
@@ -32,4 +33,3 @@
   }
   tryLoad(0);
 })();
-

--- a/docs/water/cld/index.html
+++ b/docs/water/cld/index.html
@@ -271,7 +271,7 @@
     };
   </script>
   <script src="/assets/cld/ui/bridge-init.js"></script>
-  <script src="/assets/water-cld.defer.js"></script>
+  <script src="/assets/water-cld.defer.js" data-bundle="/assets/dist/water-cld.bundle.js?v=3" defer></script>
   <script src="/assets/water-cld.init.js"></script>
   <!-- DEBUG: after bridge, sample counts from different sources -->
   <script>


### PR DESCRIPTION
## Summary
- use absolute paths and data-bundle override in CLD defer loader
- update water CLD HTML to include bundle path in loader tag

## Testing
- `node tests/mapper.test.js`
- `npm test` *(fails: Waiting failed: 20000ms exceeded)*

------
https://chatgpt.com/codex/tasks/task_e_68c50cc150708328aa3a1957c1ff1d71