### PR TITLE
A3: Externalize inline scripts on /water/cld (CSP-safe)

### DIFF
--- a/docs/assets/cld/page-debug.js
+++ b/docs/assets/cld/page-debug.js
@@ -1,0 +1,8 @@
+(function(){
+  setTimeout(function(){
+    try {
+      var keys = window.CLD_CORE ? Object.keys(window.CLD_CORE) : [];
+      console.log('[DEBUG page] CLD_CORE keys', keys);
+    } catch(e){ console.error('[DEBUG page] CLD_CORE keys error', e); }
+  }, 0);
+})();

--- a/docs/assets/cld/page-model.js
+++ b/docs/assets/cld/page-model.js
@@ -1,0 +1,9 @@
+window.DATA_MODEL = {
+  nodes: [
+    { id: "A", label: "Alpha" },
+    { id: "B", label: "Beta" }
+  ],
+  edges: [
+    { source: "A", target: "B", sign: "+" }
+  ]
+};

--- a/docs/assets/cld/page-probe.js
+++ b/docs/assets/cld/page-probe.js
@@ -1,0 +1,15 @@
+(function(){
+  function pickCy(){
+    var fromFacade = (window.CLD_CORE && typeof window.CLD_CORE.getCy==='function') ? window.CLD_CORE.getCy() : null;
+    var fromHidden = window.__cy || null;
+    var fromGlobal = (window.cy && typeof window.cy.nodes==='function') ? window.cy : null;
+    return { fromFacade: fromFacade, fromHidden: fromHidden, fromGlobal: fromGlobal };
+  }
+  setTimeout(function(){
+    try {
+      var C = pickCy();
+      function cnt(x){ try { return x ? { n:x.nodes().length, e:x.edges().length } : null; } catch(_){ return null; } }
+      console.log('[DEBUG page] counts facade/hidden/global', cnt(C.fromFacade), cnt(C.fromHidden), cnt(C.fromGlobal));
+    } catch(e){ console.error('[DEBUG page] count error', e); }
+  }, 500);
+})();

--- a/docs/water/cld/index.html
+++ b/docs/water/cld/index.html
@@ -247,52 +247,14 @@
   <script src="/assets/cld/core/inject.js"></script>
   <script src="/assets/cld/core/layout.js"></script>
   <script src="/assets/cld/core/index.js"></script>
-  <!-- DEBUG: print CLD_CORE keys early -->
-  <script>
-    (function(){
-      setTimeout(function(){
-        try {
-          var keys = window.CLD_CORE ? Object.keys(window.CLD_CORE) : [];
-          console.log('[DEBUG page] CLD_CORE keys', keys);
-        } catch(e){ console.error('[DEBUG page] CLD_CORE keys error', e); }
-      }, 0);
-    })();
-  </script>
-  <!-- Inline tiny test model to make E2E independent of external data -->
-  <script>
-    window.DATA_MODEL = {
-      nodes: [
-        { id: "A", label: "Alpha" },
-        { id: "B", label: "Beta" }
-      ],
-      edges: [
-        { source: "A", target: "B", sign: "+" }
-      ]
-    };
-  </script>
   <script src="/assets/cld/ui/bridge-init.js"></script>
   <script src="/assets/water-cld.defer.js" data-bundle="/assets/dist/water-cld.bundle.js?v=3" defer></script>
   <script src="/assets/water-cld.init.js"></script>
-  <!-- DEBUG: after bridge, sample counts from different sources -->
-  <script>
-    (function(){
-      function pickCy(){
-        var fromFacade = (window.CLD_CORE && typeof window.CLD_CORE.getCy==='function') ? window.CLD_CORE.getCy() : null;
-        var fromHidden = window.__cy || null;
-        var fromGlobal = (window.cy && typeof window.cy.nodes==='function') ? window.cy : null;
-        return { fromFacade: fromFacade, fromHidden: fromHidden, fromGlobal: fromGlobal };
-      }
-      setTimeout(function(){
-        try {
-          var C = pickCy();
-          function cnt(x){ try { return x ? { n:x.nodes().length, e:x.edges().length } : null; } catch(_){ return null; } }
-          console.log('[DEBUG page] counts facade/hidden/global', cnt(C.fromFacade), cnt(C.fromHidden), cnt(C.fromGlobal));
-        } catch(e){ console.error('[DEBUG page] count error', e); }
-      }, 500);
-    })();
-  </script>
+  <script src="/assets/cld/page-debug.js" defer></script>
+  <script src="/assets/cld/page-probe.js" defer></script>
+  <script src="/assets/cld/page-model.js" defer></script>
 
   <!-- Direct CLD bundle (after core is ready) -->
   </body>
-  </html>
+</html>
 


### PR DESCRIPTION
## Summary
- move page debug, probe, and data model scripts into dedicated files
- load CLD scripts with `src` attributes for CSP compatibility

## Testing
- `npm test` *(fails: TimeoutError waiting for page)*

------
https://chatgpt.com/codex/tasks/task_e_68c50ff69d64832889977dcec1b62527