### PR TITLE
A4: Load CLD model from /data/water/cld-model.json (no inline data)

### DIFF
--- a/docs/assets/cld/page-model-load.js
+++ b/docs/assets/cld/page-model-load.js
@@ -1,0 +1,6 @@
+export async function loadModel(){
+  const res = await fetch('/data/water/cld-model.json', { cache: 'no-cache' });
+  if (!res.ok) throw new Error('model fetch failed: '+res.status);
+  return await res.json();
+}
+window.CLD_LOAD_MODEL = loadModel;

--- a/docs/assets/cld/page-model.js
+++ b/docs/assets/cld/page-model.js
@@ -1,9 +1,0 @@
-window.DATA_MODEL = {
-  nodes: [
-    { id: "A", label: "Alpha" },
-    { id: "B", label: "Beta" }
-  ],
-  edges: [
-    { source: "A", target: "B", sign: "+" }
-  ]
-};

--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -1723,11 +1723,17 @@ window.CLDSim = { simulate, runLayout: function(name, dir){ return window.runLay
 
 
 // Optional bootstrap via CLD_LOADER (non-breaking; legacy path remains)
-(function(){
+(async function(){
   try {
-    var LOADER = (typeof window!=='undefined' && window.CLD_LOADER) ? window.CLD_LOADER : {};
-    if (LOADER.bootstrap && window.cy && (window.__cldModel || window.__MODEL__ || window.rawModel)){
-      LOADER.bootstrap({ cy: window.cy, layout: null, model: (window.__cldModel || window.__MODEL__ || window.rawModel) });
+    var LOADER = (typeof window!== 'undefined' && window.CLD_LOADER) ? window.CLD_LOADER : {};
+    if (LOADER.bootstrap && window.cy){
+      const model = window.CLD_LOAD_MODEL
+        ? await window.CLD_LOAD_MODEL()
+        : (window.DATA_MODEL || null);
+      if (model){
+        try { window.rawModel = window.rawModel || model; } catch(_){ }
+        LOADER.bootstrap({ cy: window.cy, layout: null, model: model });
+      }
     }
   } catch (e) { /* keep legacy behavior */ }
 })();

--- a/docs/data/water/cld-model.json
+++ b/docs/data/water/cld-model.json
@@ -1,0 +1,9 @@
+{
+  "nodes": [
+    { "id": "A", "label": "Alpha" },
+    { "id": "B", "label": "Beta" }
+  ],
+  "edges": [
+    { "source": "A", "target": "B", "sign": "+" }
+  ]
+}

--- a/docs/water/cld/index.html
+++ b/docs/water/cld/index.html
@@ -249,10 +249,10 @@
   <script src="/assets/cld/core/index.js"></script>
   <script src="/assets/cld/ui/bridge-init.js"></script>
   <script src="/assets/water-cld.defer.js" data-bundle="/assets/dist/water-cld.bundle.js?v=3" defer></script>
+  <script type="module" src="/assets/cld/page-model-load.js"></script>
   <script src="/assets/water-cld.init.js"></script>
   <script src="/assets/cld/page-debug.js" defer></script>
   <script src="/assets/cld/page-probe.js" defer></script>
-  <script src="/assets/cld/page-model.js" defer></script>
 
   <!-- Direct CLD bundle (after core is ready) -->
   </body>


### PR DESCRIPTION
## Summary
- move CLD sample data into `docs/data/water/cld-model.json`
- add module loader that fetches model JSON and exposes `window.CLD_LOAD_MODEL`
- bootstrap CLD with fetched model and remove inline `page-model.js`

## Testing
- `npm test` *(fails: error while loading shared libraries: libXcomposite.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_68c5132d07f08328b67ab2e088f06526