### PR TITLE
A5: Fix Persian mojibake (UTF-8) and ensure <meta charset="utf-8">

### DIFF
--- a/docs/water/cld/index.html
+++ b/docs/water/cld/index.html
@@ -1,9 +1,9 @@
-﻿<!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Ù…Ø¯Ù„ Ù¾ÙˆÛŒØ§ÛŒÛŒ Ø¨Ù‡Ø±Ù‡â€ŒÙˆØ±ÛŒ Ø¢Ø¨ Ø¯Ø± Ú©Ø´Ø§ÙˆØ±Ø²ÛŒ</title>
+  <title>مدل پویایی بهره‌وری آب در کشاورزی</title>
 
   <link rel="canonical" href="https://wesh360.ir/water/cld/" />
   <link rel="icon" type="image/webp" href="/page/landing/logo2.webp" />
@@ -23,31 +23,31 @@
   <!-- ===== HERO KPI BAR (start) ===== -->
   <section id="hero-kpi" class="hero-kpi">
     <div class="hero-left">
-      <h2 class="problem-title">Ù…Ø³Ø¦Ù„Ù‡â€ŒÛŒ Ù…ÙˆØ±Ø¯ Ø¨Ø±Ø±Ø³ÛŒ</h2>
+      <h2 class="problem-title">مسئله‌ی مورد بررسی</h2>
       <p class="problem-text" id="problem-text">
-        Ù‡Ø¯Ù: Ú©Ø§Ù‡Ø´ Ù†Ø§Ù¾Ø§ÛŒØ¯Ø§Ø±ÛŒ ØªØ±Ø§Ø² Ø¢Ø¨ Ø¨Ø§ ØªÙ…Ø±Ú©Ø² Ø¨Ø± Ø¨Ù‡Ø¨ÙˆØ¯ Ø¨Ù‡Ø±Ù‡â€ŒÙˆØ±ÛŒ Ùˆ Ù…Ø¯ÛŒØ±ÛŒØª ØªÙ‚Ø§Ø¶Ø§.
+        هدف: کاهش ناپایداری تراز آب با تمرکز بر بهبود بهره‌وری و مدیریت تقاضا.
       </p>
       <div class="baseline-row">
         <span id="hero-baseline" class="badge">Baseline v1.0</span>
-        <button id="btn-run-sample" class="btn btn-primary">Ø§Ø¬Ø±Ø§ÛŒ Ø³Ù†Ø§Ø±ÛŒÙˆÛŒ Ù†Ù…ÙˆÙ†Ù‡: Ú©Ø§Ù‡Ø´ ØªÙ„ÙØ§Øª Û³Û°â†’Û²Û°Ùª</button>
-        <button id="btn-reset-baseline" class="btn btn-soft">Ø¨Ø§Ø²Ú¯Ø´Øª Ø¨Ù‡ Baseline</button>
+        <button id="btn-run-sample" class="btn btn-primary">اجرای سناریوی نمونه: کاهش تلفات ۳۰→۲۰٪</button>
+        <button id="btn-reset-baseline" class="btn btn-soft">بازگشت به Baseline</button>
       </div>
     </div>
 
     <div class="hero-kpis">
       <div class="kpi" data-kpi="supply_demand_gap">
-        <div class="kpi-title">Ø´Ú©Ø§Ù Ø¹Ø±Ø¶Ù‡â€“ØªÙ‚Ø§Ø¶Ø§</div>
-        <div class="kpi-value"><span class="val">â€”</span><span class="unit">%</span></div>
+        <div class="kpi-title">شکاف عرضه–تقاضا</div>
+        <div class="kpi-value"><span class="val">—</span><span class="unit">%</span></div>
         <div class="kpi-rag rag-neutral"></div>
       </div>
       <div class="kpi" data-kpi="per_capita_use">
-        <div class="kpi-title">Ù…ØµØ±Ù Ø³Ø±Ø§Ù†Ù‡</div>
-        <div class="kpi-value"><span class="val">â€”</span><span class="unit">L/day</span></div>
+        <div class="kpi-title">مصرف سرانه</div>
+        <div class="kpi-value"><span class="val">—</span><span class="unit">L/day</span></div>
         <div class="kpi-rag rag-neutral"></div>
       </div>
       <div class="kpi" data-kpi="leakage_rate">
-        <div class="kpi-title">Ù†Ø±Ø® ØªÙ„ÙØ§Øª Ø´Ø¨Ú©Ù‡</div>
-        <div class="kpi-value"><span class="val">â€”</span><span class="unit">%</span></div>
+        <div class="kpi-title">نرخ تلفات شبکه</div>
+        <div class="kpi-value"><span class="val">—</span><span class="unit">%</span></div>
         <div class="kpi-rag rag-neutral"></div>
       </div>
     </div>
@@ -57,33 +57,33 @@
   <div class="board">
     <section class="card" id="left-panel">
       <div class="tabs">
-        <button id="tab-param" class="btn tab active">Ù¾Ø§Ø±Ø§Ù…ØªØ±</button>
-        <button id="tab-formula" class="btn tab">ÙØ±Ù…ÙˆÙ„</button>
+        <button id="tab-param" class="btn tab active">پارامتر</button>
+        <button id="tab-formula" class="btn tab">فرمول</button>
       </div>
 
       <div id="panel-param">
         <div class="controls">
           <div class="slider">
-            <label for="p-eff">Ø¨Ù‡Ø±Ù‡â€ŒÙˆØ±ÛŒ Ø¢Ø¨ÛŒØ§Ø±ÛŒ <span id="val-eff">0.3</span></label>
+            <label for="p-eff">بهره‌وری آبیاری <span id="val-eff">0.3</span></label>
             <input id="p-eff" type="range" min="0" max="1" step="0.05" value="0.3" />
-            <span class="hint" data-tippy-content="ØªÙ†Ø¸ÛŒÙ… Ø¨Ù‡Ø±Ù‡â€ŒÙˆØ±ÛŒ Ø¢Ø¨ÛŒØ§Ø±ÛŒ Ø¯Ø± Ø³Ù†Ø§Ø±ÛŒÙˆ">â”</span>
+            <span class="hint" data-tippy-content="تنظیم بهره‌وری آبیاری در سناریو">❔</span>
           </div>
           <div class="slider">
-            <label for="p-dem">Ø´Ø¯Øª ØªÙ‚Ø§Ø¶Ø§ <span id="val-dem">0.6</span></label>
+            <label for="p-dem">شدت تقاضا <span id="val-dem">0.6</span></label>
             <input id="p-dem" type="range" min="0" max="1" step="0.05" value="0.6" />
-            <span class="hint" data-tippy-content="Ù…ÛŒØ²Ø§Ù† Ø´Ø¯Øª ØªÙ‚Ø§Ø¶Ø§ÛŒ Ø¢Ø¨ Ø¯Ø± Ø³Ù†Ø§Ø±ÛŒÙˆ">â”</span>
+            <span class="hint" data-tippy-content="میزان شدت تقاضای آب در سناریو">❔</span>
           </div>
           <div class="slider">
-            <label for="p-delay">ØªØ§Ø®ÛŒØ± (Ø³Ø§Ù„) <span id="val-delay">1</span></label>
+            <label for="p-delay">تأخیر (سال) <span id="val-delay">1</span></label>
             <input id="p-delay" type="range" min="0" max="5" step="1" value="1" />
-            <span class="hint" data-tippy-content="ØªØ£Ø®ÛŒØ± Ø²Ù…Ø§Ù†ÛŒ ÙˆØ§Ú©Ù†Ø´ Ø³ÛŒØ³ØªÙ… Ø¨Ø± Ø­Ø³Ø¨ Ø³Ø§Ù„">â”</span>
+            <span class="hint" data-tippy-content="تأخیر زمانی واکنش سیستم بر حسب سال">❔</span>
           </div>
         </div>
 
         <div class="actions">
-          <button id="btn-run" class="btn">Ø§Ø¬Ø±Ø§ÛŒ Ø³Ù†Ø§Ø±ÛŒÙˆ</button>
-          <span class="hint" data-tippy-content="Ø³Ù†Ø§Ø±ÛŒÙˆ/Ú†Ø§Ø±Øª: Ø¨Ø§ Ø§Ø¬Ø±Ø§ÛŒ Ø³Ù†Ø§Ø±ÛŒÙˆØŒ Ù†Ù…ÙˆØ¯Ø§Ø± Ù†ØªØ§ÛŒØ¬ Ø¨Ù‡â€ŒØ±ÙˆØ²Ø±Ø³Ø§Ù†ÛŒ Ù…ÛŒâ€ŒØ´ÙˆØ¯.">â”</span>
-          <button id="btn-reset" class="btn outline">Ø¨Ø§Ø²Ù†Ø´Ø§Ù†ÛŒ</button>
+          <button id="btn-run" class="btn">اجرای سناریو</button>
+          <span class="hint" data-tippy-content="سناریو/چارت: با اجرای سناریو، نمودار نتایج به‌روزرسانی می‌شود.">❔</span>
+          <button id="btn-reset" class="btn outline">بازنشانی</button>
           <button id="btn-export-csv" class="btn outline">Export CSV</button>
         </div>
 
@@ -100,7 +100,7 @@
           </div>
           <table id="sc-table">
             <thead>
-              <tr><th>Ù†Ø§Ù…</th><th>eff</th><th>dem</th><th>delay</th></tr>
+              <tr><th>نام</th><th>eff</th><th>dem</th><th>delay</th></tr>
             </thead>
             <tbody></tbody>
           </table>
@@ -108,7 +108,7 @@
 
         <div id="sens-panel" class="mt-12">
           <div class="slider">
-            <label>Ø­Ø³Ø§Ø³ÛŒØª Ù¾Ø§Ø±Ø§Ù…ØªØ±</label>
+            <label>حساسیت پارامتر</label>
             <select id="sens-param" class="btn outline flex-1">
               <option value="eff">eff</option>
               <option value="dem">dem</option>
@@ -136,14 +136,14 @@
     </section>
 
     <section class="card" id="right-panel">
-      <section id="cld-control-hub" class="cld-control-hub" aria-label="Ú©Ù†ØªØ±Ù„â€ŒÙ‡Ø§ÛŒ Ù†Ù…ÙˆØ¯Ø§Ø±">
+      <section id="cld-control-hub" class="cld-control-hub" aria-label="کنترل‌های نمودار">
         <details class="ac-card mode" open>
-          <summary>Ø­Ø§Ù„Øªâ€ŒÙ‡Ø§ (Mode)</summary>
+          <summary>حالت‌ها (Mode)</summary>
           <div id="group-mode" class="ac-body"></div>
         </details>
 
         <details class="ac-card filter" open>
-          <summary>ÙÛŒÙ„ØªØ±Ù‡Ø§ (Filter)</summary>
+          <summary>فیلترها (Filter)</summary>
           <div id="group-filter" class="ac-body"></div>
           <details class="ac-adv">
             <summary>Advanced</summary>
@@ -152,38 +152,38 @@
         </details>
 
         <details class="ac-card layout">
-          <summary>Ú†ÛŒØ¯Ù…Ø§Ù† (Layout)</summary>
+          <summary>چیدمان (Layout)</summary>
           <div id="group-layout" class="ac-body"></div>
         </details>
       </section>
 
       <div class="toolbar filters">
         <label class="ctrl">
-          <span>Ø­Ø¯Ø§Ù‚Ù„ ÙˆØ²Ù† Ø±Ø§Ø¨Ø·Ù‡</span>
+          <span>حداقل وزن رابطه</span>
           <input id="flt-weight-min" type="range" min="0" max="1" step="0.05" value="0" />
           <output id="flt-weight-min-val">0</output>
-          <span class="hint" data-tippy-content="Ú©Ù…ØªØ±ÛŒÙ† Ù…Ù‚Ø¯Ø§Ø± Ù‚Ø¯Ø±Øª Ø±Ø§Ø¨Ø·Ù‡ Ø¨Ø±Ø§ÛŒ Ù†Ù…Ø§ÛŒØ´ Ø¯Ø± Ù†Ù…ÙˆØ¯Ø§Ø±">â”</span>
+          <span class="hint" data-tippy-content="کمترین مقدار قدرت رابطه برای نمایش در نمودار">❔</span>
         </label>
 
         <label class="ctrl">
-          <span>Ø­Ø¯Ø§Ú©Ø«Ø± ØªØ§Ø®ÛŒØ± (Ø³Ø§Ù„)</span>
+          <span>حداکثر تأخیر (سال)</span>
           <input id="flt-delay-max" type="range" min="0" max="5" step="1" value="5" />
           <output id="flt-delay-max-val">5</output>
-          <span class="hint" data-tippy-content="Ø­Ø¯Ø§Ú©Ø«Ø± ØªØ£Ø®ÛŒØ± Ø²Ù…Ø§Ù†ÛŒ (Ø³Ø§Ù„)">â”</span>
+          <span class="hint" data-tippy-content="حداکثر تأخیر زمانی (سال)">❔</span>
         </label>
 
-        <button id="f-pos" class="btn outline">Ø±ÙˆØ§Ø¨Ø· Ù…Ø«Ø¨Øª</button><span class="hint" data-tippy-content="Ù†Ù…Ø§ÛŒØ´ ØªÙ†Ù‡Ø§ ÛŒØ§Ù„â€ŒÙ‡Ø§ÛŒ Ø¯Ø§Ø±Ø§ÛŒ Ø§Ø«Ø± Ù…Ø«Ø¨Øª.">â”</span>
-        <button id="f-neg" class="btn outline">Ø±ÙˆØ§Ø¨Ø· Ù…Ù†ÙÛŒ</button><span class="hint" data-tippy-content="Ù†Ù…Ø§ÛŒØ´ ØªÙ†Ù‡Ø§ ÛŒØ§Ù„â€ŒÙ‡Ø§ÛŒ Ø¯Ø§Ø±Ø§ÛŒ Ø§Ø«Ø± Ù…Ù†ÙÛŒ.">â”</span>
+        <button id="f-pos" class="btn outline">روابط مثبت</button><span class="hint" data-tippy-content="نمایش تنها یال‌های دارای اثر مثبت.">❔</span>
+        <button id="f-neg" class="btn outline">روابط منفی</button><span class="hint" data-tippy-content="نمایش تنها یال‌های دارای اثر منفی.">❔</span>
 
-        <select id="f-group" class="btn outline"><option value="">Ù‡Ù…Ù‡ Ú¯Ø±ÙˆÙ‡â€ŒÙ‡Ø§</option></select><span class="hint" data-tippy-content="Ù†Ù…Ø§ÛŒØ´ Ú¯Ø±ÙˆÙ‡ Ø®Ø§ØµÛŒ Ø§Ø² Ù…ØªØºÛŒØ±Ù‡Ø§">â”</span>
+        <select id="f-group" class="btn outline"><option value="">همه گروه‌ها</option></select><span class="hint" data-tippy-content="نمایش گروه خاصی از متغیرها">❔</span>
 
-        <input id="q" class="btn outline" placeholder="Ø¬Ø³Øªâ€ŒÙˆØ¬Ùˆ" value="" /><span class="hint" data-tippy-content="Ø¬Ø³Øªâ€ŒÙˆØ¬ÙˆÛŒ Ù†Ø§Ù… Ú¯Ø±Ù‡â€ŒÙ‡Ø§">â”</span>
+        <input id="q" class="btn outline" placeholder="جست‌وجو" value="" /><span class="hint" data-tippy-content="جست‌وجوی نام گره‌ها">❔</span>
 
         <label class="btn outline flex items-center gap-1">
-          <input type="checkbox" id="f-delay" />ØªØ§Ø®ÛŒØ±
-        </label><span class="hint" data-tippy-content="Ù†Ù…Ø§ÛŒØ´ Ø±ÙˆØ§Ø¨Ø· Ø¯Ø§Ø±Ø§ÛŒ ØªØ£Ø®ÛŒØ± Ø²Ù…Ø§Ù†ÛŒ">â”</span>
+          <input type="checkbox" id="f-delay" />تأخیر
+        </label><span class="hint" data-tippy-content="نمایش روابط دارای تأخیر زمانی">❔</span>
 
-        <select id="model-switch" aria-label="Ø§Ù†ØªØ®Ø§Ø¨ Ù…Ø¯Ù„">
+        <select id="model-switch" aria-label="انتخاب مدل">
           <option value="../data/water-cld-poster.json?v=1" selected>Poster</option>
           <option value="../data/water-cld.json?v=1">Simple</option>
         </select>
@@ -191,16 +191,16 @@
         <select id="layout" class="btn outline">
           <option value="elk" selected>ELK</option>
           <option value="dagre">Dagre</option>
-        </select><span class="hint" data-tippy-content="Ø§Ù†ØªØ®Ø§Ø¨ Ø§Ù„Ú¯ÙˆØ±ÛŒØªÙ… Ú†ÛŒØ¯Ù…Ø§Ù† (ELK ÛŒØ§ Dagre)">â”</span>
+        </select><span class="hint" data-tippy-content="انتخاب الگوریتم چیدمان (ELK یا Dagre)">❔</span>
 
         <select id="layout-preset" class="btn outline">
-          <option value="">Ù¾ÛŒØ´â€ŒÙØ±Ø¶</option>
+          <option value="">پیش‌فرض</option>
           <option value="grid">Grid</option>
           <option value="radial">Radial</option>
           <option value="hierarchical">Hierarchical</option>
-        </select><span class="hint" data-tippy-content="Ú†ÛŒØ¯Ù…Ø§Ù†â€ŒÙ‡Ø§ÛŒ Ø¢Ù…Ø§Ø¯Ù‡ (Grid, Radial, Hierarchical)">â”</span>
+        </select><span class="hint" data-tippy-content="چیدمان‌های آماده (Grid, Radial, Hierarchical)">❔</span>
 
-        <button id="btn-loops" class="btn outline">Ø­Ù„Ù‚Ù‡â€ŒÙ‡Ø§</button><span class="hint" data-tippy-content="Ø´Ù†Ø§Ø³Ø§ÛŒÛŒ Ø­Ù„Ù‚Ù‡â€ŒÙ‡Ø§ÛŒ Ø¨Ø§Ø²Ø®ÙˆØ±Ø¯">â”</span>
+        <button id="btn-loops" class="btn outline">حلقه‌ها</button><span class="hint" data-tippy-content="شناسایی حلقه‌های بازخورد">❔</span>
       </div>
 
       <details id="panel-loops" class="my-8">
@@ -212,23 +212,23 @@
         <div id="cy-wrap">
           <div id="cy"></div>
 
-          <div id="cld-legend" class="cld-legend" aria-label="Ø±Ø§Ù‡Ù†Ù…Ø§ÛŒ Ù†Ù…ÙˆØ¯Ø§Ø± Ø¹Ù„Ù‘ÛŒ">
+          <div id="cld-legend" class="cld-legend" aria-label="راهنمای نمودار علّی">
             <div class="legend-row">
               <span class="legend-line line-pos" aria-hidden="true"></span>
-              <span class="legend-text">Ø±Ø§Ø¨Ø·Ù‡ Ù…Ø«Ø¨Øª (+)</span>
+              <span class="legend-text">رابطه مثبت (+)</span>
             </div>
             <div class="legend-row">
               <span class="legend-line line-neg" aria-hidden="true"></span>
-              <span class="legend-text">Ø±Ø§Ø¨Ø·Ù‡ Ù…Ù†ÙÛŒ (âˆ’)</span>
+              <span class="legend-text">رابطه منفی (−)</span>
             </div>
             <div class="legend-row">
               <span class="legend-line line-delay" aria-hidden="true"></span>
-              <span class="legend-text">ØªØ£Ø®ÛŒØ± (Ø®Ø·â€ŒÚ†ÛŒÙ†)</span>
+              <span class="legend-text">تأخیر (خط‌چین)</span>
             </div>
             <div class="legend-row">
               <span class="badge badge-r" aria-hidden="true">R</span>
               <span class="badge badge-b" aria-hidden="true">B</span>
-              <span class="legend-text">Ø­Ù„Ù‚Ù‡â€ŒÙ‡Ø§: R (ØªÙ‚ÙˆÛŒØªÛŒ)ØŒ B (Ù…ÙˆØ§Ø²Ù†Ù‡â€ŒØ§ÛŒ)</span>
+              <span class="legend-text">حلقه‌ها: R (تقویتی)، B (موازنه‌ای)</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- restore proper Persian text across water CLD page and ensure UTF-8 meta tag
- standardize delay-related labels to "تأخیر" spelling

## Testing
- `npm test` *(fails: libXdamage.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c517108f14832889d8c59b915f989b