### PR TITLE
fix: robust CLD data loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,28 @@ jobs:
       - name: Unit (mapper)
         run: npm run test:unit:mapper
 
+      - name: Start static server
+        run: |
+          npx http-server docs -a 127.0.0.1 -p 5173 -c-1 >/dev/null 2>&1 & echo $! > /tmp/http-server.pid
+          for i in {1..60}; do
+            if curl -sfI http://127.0.0.1:5173/ >/dev/null; then echo "Server up"; break; fi
+            sleep 1
+          done
+          echo "Probe candidates:"
+          curl -sI http://127.0.0.1:5173/water/cld/ || true
+          curl -sI http://127.0.0.1:5173/test/water-cld || true
+        shell: bash
+
       - name: E2E smoke
+        env:
+          BASE_URL_CANDIDATES: "http://127.0.0.1:5173/water/cld/,http://127.0.0.1:5173/test/water-cld"
         run: npm run e2e:smoke
+
+      - name: Stop static server
+        if: always()
+        run: |
+          kill $(cat /tmp/http-server.pid) || true
+        shell: bash
 
       - name: E2E CSP (no violations, fast)
         env:

--- a/docs/assets/cld/core/net.js
+++ b/docs/assets/cld/core/net.js
@@ -1,0 +1,55 @@
+/* global fetch, location */
+// @ts-check
+// Resolve JSON from the first reachable candidate URL.
+(function (global) {
+  let __cldErrCount = 0;
+  let __cldErrWindowTs = 0;
+  function circuitOpen() {
+    const now = Date.now();
+    if (now - __cldErrWindowTs > 5000) { __cldErrWindowTs = now; __cldErrCount = 0; }
+    __cldErrCount++;
+    if (__cldErrCount >= 3) {
+      try { /** @type {any} */ (global).__cldFetchLocked = true; } catch (_) {}
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * @typedef {{ timeoutMs?: number, maxAttempts?: number, fetchFn?: typeof fetch }} FetchOpts
+   * @param {string[]} candidates
+   * @param {FetchOpts} [opt]
+   * @returns {Promise<{json: any, url: string}>}
+   */
+  async function fetchFirstJSON(candidates, opt = {}) {
+    if (/** @type {any} */ (global).__cldFetchLocked) throw new Error('CLD fetch locked by circuit breaker');
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort('timeout'), opt.timeoutMs ?? 10000);
+    const tried = [];
+    const base = typeof location === 'object' && location ? location.origin : 'http://localhost';
+    const fetcher = opt.fetchFn || fetch;
+    try {
+      const uniq = [...new Set(candidates)].filter(Boolean);
+      const attempts = opt.maxAttempts ?? 1;
+      for (const p of uniq) {
+        const url = new URL(p, base).toString();
+        for (let i = 0; i < attempts; i++) {
+          tried.push(url);
+          try {
+            const res = await fetcher(url, { cache: 'no-store', signal: ctrl.signal });
+            if (!res.ok) { console.warn('[CLD boot] fetch not ok', res.status, url); break; }
+            const json = await res.json();
+            return { json, url };
+          } catch (e) {
+            console.warn('[CLD boot] fetch error', String(e), url);
+            if (circuitOpen()) throw new Error('CLD circuit open: too many fetch errors');
+          }
+        }
+      }
+      throw new Error('all candidates failed: ' + tried.join(' | '));
+    } finally {
+      clearTimeout(t);
+    }
+  }
+  /** @type {any} */ (global).fetchFirstJSON = fetchFirstJSON;
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -183,8 +183,8 @@
         </label><span class="hint" data-tippy-content="Ù†Ù…Ø§ÛŒØ´ Ø±ÙˆØ§Ø¨Ø· Ø¯Ø§Ø±Ø§ÛŒ ØªØ£Ø®ÛŒØ± Ø²Ù…Ø§Ù†ÛŒ">â”</span>
 
         <select id="model-switch" aria-label="Ø§Ù†ØªØ®Ø§Ø¨ Ù…Ø¯Ù„">
-          <option value="../data/water-cld-poster.json?v=1" selected>Poster</option>
-          <option value="../data/water-cld.json?v=1">Simple</option>
+          <option value="/data/water-cld-poster.json?v=1" selected>Poster</option>
+          <option value="/data/water-cld.json?v=1">Simple</option>
         </select>
 
         <select id="layout" class="btn outline">
@@ -270,6 +270,7 @@
     };
   </script>
   <script src="/assets/cld/ui/bridge-init.js"></script>
+  <script src="/assets/cld/core/net.js"></script>
   <script src="/assets/water-cld.defer.js"></script>
   <script src="/assets/water-cld.init.js"></script>
   <!-- DEBUG: after bridge, sample counts from different sources -->

--- a/docs/water/cld/index.html
+++ b/docs/water/cld/index.html
@@ -184,8 +184,8 @@
         </label><span class="hint" data-tippy-content="نمایش روابط دارای تأخیر زمانی">❔</span>
 
         <select id="model-switch" aria-label="انتخاب مدل">
-          <option value="../data/water-cld-poster.json?v=1" selected>Poster</option>
-          <option value="../data/water-cld.json?v=1">Simple</option>
+          <option value="/data/water-cld-poster.json?v=1" selected>Poster</option>
+          <option value="/data/water-cld.json?v=1">Simple</option>
         </select>
 
         <select id="layout" class="btn outline">
@@ -248,6 +248,7 @@
   <script src="/assets/cld/core/layout.js"></script>
   <script src="/assets/cld/core/index.js"></script>
   <script src="/assets/cld/ui/bridge-init.js"></script>
+  <script src="/assets/cld/core/net.js"></script>
   <script src="/assets/water-cld.defer.js" data-bundle="/assets/dist/water-cld.bundle.js?v=3" defer></script>
   <script type="module" src="/assets/cld/page-model-load.js"></script>
   <script src="/assets/water-cld.init.js"></script>

--- a/tests/e2e/cld-smoke.js
+++ b/tests/e2e/cld-smoke.js
@@ -1,35 +1,142 @@
-const http=require('http');const path=require('path');const fs=require('fs');const puppeteer=require('puppeteer');
-const PORT=process.env.TEST_PORT?parseInt(process.env.TEST_PORT,10):9099;const ROOT=path.resolve(__dirname,'../../docs');
-function serve(){const s=http.createServer((req,res)=>{const u=req.url.split('?')[0];let p=path.join(ROOT,u);if(u==='/'||u.startsWith('/test'))p=path.join(ROOT,'test','water-cld.html');fs.readFile(p,(e,d)=>{if(e){try{console.log('[srv 404]',u,'->',p);}catch(_){ }res.statusCode=404;return res.end('Not Found')}try{if(u!=='/favicon.ico')console.log('[srv 200]',u);}catch(_){ }const ext=path.extname(p).toLowerCase();const ct=ext==='.html'?'text/html':ext==='.js'?'application/javascript':ext==='.css'?'text/css':ext==='.json'?'application/json':'text/plain';res.setHeader('Content-Type',ct+'; charset=utf-8');res.statusCode=200;res.end(d);});});return new Promise((ok,ko)=>{s.on('error',ko);s.listen(PORT,'0.0.0.0',()=>ok(s));});}
-(async()=>{let server;try{server=await serve();}catch(e){console.error(e);process.exit(1);}const browser=await puppeteer.launch({headless:'new',args:['--no-sandbox']});const page=await browser.newPage();const logs=[];page.on('console',m=>logs.push(m.text()));page.on('pageerror',e=>logs.push('PAGEERR:'+e.message));
-await page.goto(`http://localhost:${PORT}/test/water-cld.html`,{waitUntil:'domcontentloaded'});
+// @ts-check
+// Smoke test ensuring CLD graph renders and data loads without 404s.
+const puppeteer = require('puppeteer');
+let pptr = null;
+try { pptr = require('puppeteer'); } catch { pptr = puppeteer; }
 
-// اول منتظر شو Bridge شمارش را ثبت کند
-await page.waitForFunction(()=>!!(window.__lastSetModelCounts && window.__lastSetModelCounts.nodes>0),{timeout:30000}).catch(()=>{});
+(async () => {
+  const primary = process.env.BASE_URL || '';
+  const csv = process.env.BASE_URL_CANDIDATES || 'http://127.0.0.1:5173/water/cld/,http://127.0.0.1:5173/test/water-cld';
+  const candidates = [...new Set([primary, ...csv.split(',').map(s => s.trim())].filter(Boolean))];
+  const SELECTORS = ['#graph', '#cy', '#cld-graph', '.cytoscape-container'];
+  const isCI = !!process.env.CI;
 
-// اگر به هر دلیل متغیر نبود، fallback: از cy بخوان
-const counts = await page.evaluate(()=>{
-  try {
-    if (window.CLD_CORE && typeof window.CLD_CORE.runLayout==='function') {
-      window.CLD_CORE.runLayout('elk', {});
+  if (pptr.configure) { pptr.configure({ protocolTimeout: 120000 }); }
+  const browser = await pptr.launch({
+    headless: 'new',
+    defaultViewport: { width: 1280, height: 900 },
+    args: isCI ? ['--no-sandbox', '--disable-setuid-sandbox'] : []
+  });
+  const page = await browser.newPage();
+
+  page.setDefaultNavigationTimeout(90000);
+  page.setDefaultTimeout(60000);
+
+  await page.setRequestInterception(true);
+  page.on('request', req => {
+    try {
+      const u = new URL(req.url());
+      const isHttp = u.protocol === 'http:' || u.protocol === 'https:';
+      const isLocal = u.hostname === 'localhost' || u.hostname === '127.0.0.1';
+      if (!isHttp) return req.continue();
+      if (isLocal) return req.continue();
+      return req.abort();
+    } catch {
+      req.continue();
     }
-  } catch(_){ }
-  if (window.__lastSetModelCounts && window.__lastSetModelCounts.nodes>0) return window.__lastSetModelCounts;
-  const pick=()=> (window.__cy) || (window.CLD_CORE&&typeof window.CLD_CORE.getCy==='function'&&window.CLD_CORE.getCy()) || ((window.cy&&typeof window.cy.nodes==='function')?window.cy:null);
-  const C=pick(); return C?{nodes:C.nodes().length,edges:C.edges().length}:{nodes:0,edges:0};
-});
-const debugInfo = await page.evaluate(()=>({
-  ready: document.readyState,
-  hasCLD: !!window.CLD_CORE,
-  cldKeys: (window.CLD_CORE && Object.keys(window.CLD_CORE))||[],
-  hasCy: !!(window.cy && typeof window.cy.nodes==='function')
-}));
+  });
 
-if(!counts||!counts.nodes||counts.nodes<=0){
-  console.error('E2E FAIL: nodes not rendered',counts,logs.slice(-30),debugInfo);
-  await browser.close(); server.close(); process.exit(1);
-}else{
-  console.log('E2E OK:',counts);
-  await browser.close(); server.close();
-}
+  const consoleErrors = [];
+  page.on('console', msg => {
+    const t = msg.type();
+    const txt = msg.text();
+    if (t === 'error' || /fetch.*(404|5\d\d)|CSP/i.test(txt)) consoleErrors.push(txt);
+  });
+  page.on('pageerror', e => consoleErrors.push('pageerror: ' + String(e)));
+  page.on('error', e => consoleErrors.push('error: ' + String(e)));
+
+  async function tryUrl(url) {
+    const before = consoleErrors.length;
+    const res = await page
+      .goto(url, { waitUntil: 'domcontentloaded', timeout: 60000 })
+      .catch(e => ({ _err: e }));
+    if (res && res._err) {
+      return { ok: false, url, navError: String(res._err), errors: consoleErrors.slice(before) };
+    }
+    await page
+      .waitForFunction(() => document.readyState !== 'loading', { timeout: 10000 })
+      .catch(() => {});
+    for (const sel of SELECTORS) {
+      try {
+        await page.waitForSelector(sel, { timeout: 20000 });
+        return {
+          ok: true,
+          url,
+          selector: sel,
+          status: res && res.status(),
+          errors: consoleErrors.slice(before)
+        };
+      } catch {}
+    }
+    let title = 'n/a';
+    let snippet = 'n/a';
+    try { title = await page.title(); } catch {}
+    try {
+      const content = await Promise.race([
+        page.content(),
+        new Promise(r => setTimeout(() => r('<!-- timeout content -->'), 3000))
+      ]);
+      snippet = String(content).replace(/\s+/g, ' ').slice(0, 250);
+    } catch {}
+    return {
+      ok: false,
+      url,
+      status: res && res.status(),
+      title,
+      snippet,
+      errors: consoleErrors.slice(before)
+    };
+  }
+
+  let matched = null;
+  const attempts = [];
+  for (const u of candidates) {
+    const r = await tryUrl(u);
+    attempts.push(r);
+    if (r.ok) {
+      matched = r;
+      break;
+    }
+  }
+
+  if (!matched) {
+    console.error(
+      'No selector matched on any candidate URL.\nAttempts:',
+      attempts.map(a => ({
+        url: a.url,
+        status: a.status,
+        title: a.title,
+        snippetStart: a.snippet?.slice(0, 80) || '',
+        consoleErrorsCount: a.errors.length,
+        navError: a.navError
+      }))
+    );
+    if (consoleErrors.length)
+      console.error('Console errors:\n' + consoleErrors.join('\n'));
+    throw new Error('CLD smoke: container not found on all candidates');
+  }
+
+  const { url, selector } = matched;
+  await page.waitForFunction(
+    () => window.cy && window.cy.nodes && window.cy.nodes().length > 0,
+    { timeout: 50000 }
+  );
+
+  const height = await page.$eval(selector, el => el.getBoundingClientRect().height);
+  if (height < 40) throw new Error('Graph container height < 40px');
+
+  const data404 = consoleErrors.filter(t =>
+    /water-cld-poster\.json|model\.json/i.test(t) && /404/.test(t)
+  );
+  if (data404.length) throw new Error('Data 404:\n' + data404.join('\n'));
+  if (consoleErrors.length) {
+    if (consoleErrors.some(x => /Maximum call stack size exceeded/i.test(x))) {
+      throw new Error('Console errors include RangeError (loop detected).');
+    }
+    throw new Error('Console errors:\n' + consoleErrors.join('\n'));
+  }
+
+  await browser.close();
+  console.log('CLD smoke ✅', { url, selector });
 })();
+


### PR DESCRIPTION
## Summary
- add circuit breaker and original-fetch support to `fetchFirstJSON`
- guard CLD boot, narrow poster/model path candidates, and avoid recursive fetch patching
- widen smoke-test selector wait and flag RangeError loops

## Testing
- `npx tsc -p tsconfig.json`
- `npm test` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c51a19a088832887b7e87f9e95ab94