### PR TITLE
feat: register layouts safely

### DIFF
--- a/docs/assets/cld-loader.js
+++ b/docs/assets/cld-loader.js
@@ -82,6 +82,19 @@
     await tryScripts([A+'vendor/dagre.min.js', B+'vendor/dagre.min.js']);
     await tryScripts([A+'vendor/cytoscape-dagre.js', B+'vendor/cytoscape-dagre.js']);
 
+    (function registerLayouts(){
+      try{
+        if (window.cytoscape && window.elk && !window.__ELK_REGISTERED__){
+          window.cytoscape.use(window.cytoscapeElk || window.elk);
+          window.__ELK_REGISTERED__ = true;
+        }
+        if (window.cytoscape && window.dagre && !window.__DAGRE_REGISTERED__){
+          window.cytoscape.use(window.cytoscapeDagre || window.dagre);
+          window.__DAGRE_REGISTERED__ = true;
+        }
+      }catch(e){ console.warn("[CLD] layout register warn", e); }
+    }());
+
     // Load the CLD bundle (deferred loader picks the right path)
     await tryScripts([A+'water-cld.defer.js', B+'water-cld.defer.js']);
     // Init hooks / debug listeners


### PR DESCRIPTION
## Summary
- ensure cytoscape layout plugins are registered only once and gracefully fallback to dagre

## Testing
- `npm test` *(fails: Failed to launch the browser process: libatk-1.0.so.0: cannot open shared object file)*
- `node tests/mapper.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c648a936d483288cb5dd460fc94a4b