### PR TITLE
fix: avoid undefined versions in model switcher

### DIFF
--- a/docs/assets/water-cld.init.js
+++ b/docs/assets/water-cld.init.js
@@ -194,11 +194,21 @@
           }
         }());
       }
+      function selectedUrl(){
+        try{
+          var opt = sw.options[sw.selectedIndex];
+          var base = opt ? opt.value : sw.value;
+          var ver = opt && opt.dataset ? opt.dataset.version : null;
+          var full = ver ? base + '?v=' + ver : base;
+          return norm(full);
+        }catch(_){ return norm(sw.value); }
+      }
       if (!sw.__CLD_PATCHED__){
-        sw.addEventListener('change', function(){ loadModelAndMount(norm(sw.value)); });
+        sw.addEventListener('change', function(){ loadModelAndMount(selectedUrl()); });
         sw.__CLD_PATCHED__ = true;
       }
-      if (sw.value) loadModelAndMount(norm(sw.value));
+      var initUrl = selectedUrl();
+      if (initUrl) loadModelAndMount(initUrl);
     }catch(_){ }
   }
   if (document.readyState === 'loading'){

--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -1706,10 +1706,17 @@ function cldToCyElements(graph){ return toCyElements(graph); }
         var last = localStorage.getItem('waterCLD.activeModel');
         if (last) sw.value = last;
       } catch(e){}
+      function selectedUrl(){
+        var opt = sw.options[sw.selectedIndex];
+        var base = opt ? opt.value : sw.value;
+        var ver = opt && opt.dataset ? opt.dataset.version : null;
+        return ver ? base + '?v=' + ver : base;
+      }
       sw.addEventListener('change', function(){
-        window.loadModelFromUrl(sw.value);
+        window.loadModelFromUrl(selectedUrl());
       });
-      if (sw.value) window.loadModelFromUrl(sw.value);
+      var initUrl = selectedUrl();
+      if (initUrl) window.loadModelFromUrl(initUrl);
     }
     if (document.readyState === 'loading') {
       document.addEventListener('DOMContentLoaded', initSwitcher);

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -183,8 +183,8 @@
         </label><span class="hint" data-tippy-content="Ù†Ù…Ø§ÛŒØ´ Ø±ÙˆØ§Ø¨Ø· Ø¯Ø§Ø±Ø§ÛŒ ØªØ£Ø®ÛŒØ± Ø²Ù…Ø§Ù†ÛŒ">â”</span>
 
         <select id="model-switch" aria-label="Ø§Ù†ØªØ®Ø§Ø¨ Ù…Ø¯Ù„">
-          <option value="../data/water-cld-poster.json?v=1" selected>Poster</option>
-          <option value="../data/water-cld.json?v=1">Simple</option>
+          <option value="/data/water-cld-poster.json" data-version="1" selected>Poster</option>
+          <option value="/data/water-cld.json" data-version="1">Simple</option>
         </select>
 
         <select id="layout" class="btn outline">

--- a/docs/water/cld/index.html
+++ b/docs/water/cld/index.html
@@ -184,8 +184,8 @@
         </label><span class="hint" data-tippy-content="Ù†Ù…Ø§ÛŒØ´ Ø±ÙˆØ§Ø¨Ø· Ø¯Ø§Ø±Ø§ÛŒ ØªØ£Ø®ÛŒØ± Ø²Ù…Ø§Ù†ÛŒ">â”</span>
 
         <select id="model-switch" aria-label="Ø§Ù†ØªØ®Ø§Ø¨ Ù…Ø¯Ù„">
-          <option value="/data/water-cld-poster.json?v=1" selected>Poster</option>
-          <option value="/data/water-cld.json?v=1">Simple</option>
+          <option value="/data/water-cld-poster.json" data-version="1" selected>Poster</option>
+          <option value="/data/water-cld.json" data-version="1">Simple</option>
         </select>
 
         <select id="layout" class="btn outline">


### PR DESCRIPTION
## Summary
- use absolute model URLs with version metadata in switcher options
- append `?v=` only when a data-version is present
- allow model switching without generating `?v=undefined`

## Testing
- `curl -I http://localhost:5173/data/water-cld-poster.json?v=1`
- `curl -I http://localhost:5173/data/water-cld.json?v=1`
- `npm test` *(fails: hangs after mapper test)*

------
https://chatgpt.com/codex/tasks/task_e_68c650d4cee08328a0de4647c14057f2