### PR TITLE
Fix CLD resize on panel visibility

### DIFF
--- a/docs/assets/water-cld.init.js
+++ b/docs/assets/water-cld.init.js
@@ -217,3 +217,20 @@
     attachModelSwitcher();
   }
 })();
+
+// Resize/visibility hooks to keep the graph fit when container changes
+const doResize = () => {
+  const c = window.CLD_CORE?.getCy?.() || window.__cy;
+  if (c) {
+    c.resize();
+    c.fit(undefined, 24);
+  }
+};
+window.addEventListener('resize', doResize);
+document.addEventListener('transitionend', () => {
+  const el = document.getElementById('cy');
+  if (el?.offsetParent !== null) doResize();
+});
+document.addEventListener('visibilitychange', () => {
+  if (!document.hidden) doResize();
+});


### PR DESCRIPTION
## Summary
- keep CLD graph fit on window resize, panel transitions, or tab visibility changes

## Testing
- `npm test` *(fails: TimeoutError waiting for graph rendering)*

------
https://chatgpt.com/codex/tasks/task_e_68c6570284648328bcdf1d64b903f498