### PR TITLE
feat: validate and sanitize CLD mapper elements

### DIFF
--- a/docs/assets/cld/core/mapper.js
+++ b/docs/assets/cld/core/mapper.js
@@ -31,27 +31,51 @@
     var nodes = (model && (model.nodes || model.Vertices || model.NODES)) || [];
     var edges = (model && (model.edges || model.Links || model.EDGES)) || [];
 
+    var nodeIds = Object.create(null);
     var cyNodes = [];
     for (var i = 0; i < nodes.length; i++) {
       var n = nodes[i] || {};
+      if (n.id == null) {
+        console.warn('Node missing id', n);
+        continue;
+      }
       var id = String(n.id);
+      if (nodeIds[id]) {
+        console.warn('Duplicate node id', id);
+        continue;
+      }
       var label = (n.label != null ? n.label : (n.name != null ? n.name : (n.title != null ? n.title : id)));
       var group = n.group != null ? n.group : (n.type != null ? n.type : 'var');
       var lbl = String(label);
+      if (lbl.length > 80) {
+        console.warn('Node label too long', id);
+        lbl = lbl.slice(0, 80) + '\u2026';
+      }
+      nodeIds[id] = true;
       cyNodes.push({ group: 'nodes', data: { id: id, label: lbl, _label: lbl, group: String(group) } });
     }
 
     var edgeIdSeq = 0;
+    var edgeIds = Object.create(null);
     var cyEdges = [];
     for (var j = 0; j < edges.length; j++) {
       var e = edges[j] || {};
       var sid = e.id != null ? String(e.id) : ('e_' + (edgeIdSeq++));
+      if (edgeIds[sid] || nodeIds[sid]) {
+        console.warn('Duplicate edge id', sid);
+        continue;
+      }
       var s = e.source != null ? String(e.source) : '';
       var t = e.target != null ? String(e.target) : '';
+      if (!s || !t || !nodeIds[s] || !nodeIds[t]) {
+        console.warn('Edge missing source/target', sid);
+        continue;
+      }
       var sign = (e.sign != null ? e.sign : (e.polarity != null ? e.polarity : null));
       var signLabel = (sign === '+' ? 'positive' : (sign === '-' ? 'negative' : null));
       var weight = (e.weight != null ? Number(e.weight) : (e.w != null ? Number(e.w) : null));
       var delay = (e.delay != null ? Number(e.delay) : (e.lag != null ? Number(e.lag) : null));
+      edgeIds[sid] = true;
       cyEdges.push({ group: 'edges', data: { id: sid, source: s, target: t, sign: sign, _signLabel: signLabel, weight: weight, delay: delay } });
     }
     return /** @type {Array<{group:string; data:any}>} */ ([]).concat(

--- a/tests/unit/mapper.test.js
+++ b/tests/unit/mapper.test.js
@@ -5,9 +5,17 @@ const { mapModelToElements } = require('../../docs/assets/cld/core/mapper.js');
 (async () => {
   try{
     const raw = JSON.parse(fs.readFileSync(path.join(__dirname,'fixtures/model.json'),'utf8'));
+    const warns = [];
+    const origWarn = console.warn;
+    console.warn = (...args)=>warns.push(args);
+
     const els = mapModelToElements(raw) || [];
     const nodes = els.filter(e=>e.group==='nodes');
     const edges = els.filter(e=>e.group==='edges');
+    if (warns.length !== 0) {
+      console.error('Unit FAIL: unexpected warning for clean model', warns);
+      process.exit(1);
+    }
     if (nodes.length!==2 || edges.length!==1) {
       console.error('Unit FAIL: unexpected element counts', {nodes:nodes.length, edges:edges.length});
       process.exit(1);
@@ -23,6 +31,34 @@ const { mapModelToElements } = require('../../docs/assets/cld/core/mapper.js');
       console.error('Unit FAIL: edge _signLabel missing or unexpected', e0);
       process.exit(1);
     }
+
+    // label truncation
+    warns.length = 0;
+    const longLbl = 'x'.repeat(81);
+    const trunc = mapModelToElements({nodes:[{id:'T',label:longLbl}]});
+    const tNode = trunc[0] && trunc[0].data || {};
+    if (tNode.label !== longLbl.slice(0,80) + '\u2026' || warns.length === 0) {
+      console.error('Unit FAIL: label truncation', {lbl:tNode.label, warns:warns.length});
+      process.exit(1);
+    }
+
+    // duplicate id
+    warns.length = 0;
+    const dup = mapModelToElements({nodes:[{id:'D'},{id:'D'}]});
+    if (dup.length !== 1 || warns.length === 0) {
+      console.error('Unit FAIL: duplicate id not caught', {len:dup.length, warns:warns.length});
+      process.exit(1);
+    }
+
+    // edge with missing target
+    warns.length = 0;
+    const badEdge = mapModelToElements({nodes:[{id:'A'}],edges:[{source:'A',target:'B'}]});
+    if (badEdge.filter(e=>e.group==='edges').length !== 0 || warns.length === 0) {
+      console.error('Unit FAIL: bad edge not caught', {els:badEdge, warns:warns.length});
+      process.exit(1);
+    }
+
+    console.warn = origWarn;
     console.log('Unit OK:', {nodes:nodes.length, edges:edges.length, aliasNode:n0._label, aliasEdge:e0._signLabel});
     process.exit(0);
   }catch(e){


### PR DESCRIPTION
## Summary
- ensure node and edge IDs are unique and edges reference existing nodes
- truncate overly long labels at 80 characters with ellipsis
- expand unit tests for mapper validation and label truncation

## Testing
- `npm run test:unit:mapper`
- `npm test` *(fails: libXcomposite.so.1: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68c65b8786d88328b6601f7fe65e2297