### PR TITLE
Avoid duplicate Cytoscape plugin loads

### DIFF
--- a/docs/assets/cld-loader.js
+++ b/docs/assets/cld-loader.js
@@ -28,11 +28,15 @@
   // Helper: add a <script> with onload/onerror and return a Promise
   function loadScript(url){
     return new Promise(function(resolve){
+      var abs = new URL(url, location.href).href;
+      if (document.querySelector('script[src="'+abs+'"]')) {
+        return resolve({ ok:true, url:abs, skipped:true });
+      }
       var s = document.createElement('script');
       s.defer = true;
-      s.src = url;
-      s.onload = function(){ resolve({ ok:true, url:url }); };
-      s.onerror = function(){ resolve({ ok:false, url:url }); };
+      s.src = abs;
+      s.onload = function(){ resolve({ ok:true, url:abs }); };
+      s.onerror = function(){ resolve({ ok:false, url:abs }); };
       document.head.appendChild(s);
     });
   }

--- a/package.json
+++ b/package.json
@@ -67,5 +67,9 @@
     "qrcode-generator": "^2.0.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
-  }
+  },
+  "sideEffects": [
+    "docs/assets/vendor/cytoscape-elk.js",
+    "docs/assets/vendor/cytoscape-dagre.js"
+  ]
 }


### PR DESCRIPTION
## Summary
- Prevent `cld-loader` from inserting duplicate Cytoscape scripts by checking for existing tags
- Mark Cytoscape plugin vendor files as side effects so bundlers keep their registration

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c65dbf2e608328a6e2534420a0397f