### PR TITLE
Add CLD inventory and runtime audit tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,11 @@
     "e2e:csp:fast": "node tests/e2e/csp-violations.js",
     "e2e:csp:fast:env": "cross-env TEST_FAST=1 NAV_TIMEOUT=15000 node tests/e2e/csp-violations.js",
     "ts:check": "tsc -p tsconfig.json",
-    "diag:cld": "node tests/e2e/cld-diagnose.js"
+    "diag:cld": "node tests/e2e/cld-diagnose.js",
+    "audit:cld:files": "node tools/cld-inventory.js",
+    "audit:cld:runtime": "node tests/e2e/cld-runtime-inventory.js",
+    "audit:cld:rewire": "node tools/cld-rewire-plan.js",
+    "audit:cld:all": "npm run audit:cld:files && npm run audit:cld:runtime && npm run audit:cld:rewire"
   },
   "keywords": [],
   "author": "",

--- a/reports/cld-inventory.json
+++ b/reports/cld-inventory.json
@@ -1,0 +1,1078 @@
+[
+  {
+    "file": "ARCHITECTURE.md",
+    "role": "Other",
+    "size": 568
+  },
+  {
+    "file": "Plan.md",
+    "role": "Other",
+    "size": 1877
+  },
+  {
+    "file": "diagnostics/cld-diagnose.png",
+    "role": "Other",
+    "size": 101177
+  },
+  {
+    "file": "diagnostics/cld-report.json",
+    "role": "JSON-other",
+    "size": 2178
+  },
+  {
+    "file": "docs/DEV_NOTES.md",
+    "role": "Other",
+    "size": 517
+  },
+  {
+    "file": "docs/_headers",
+    "role": "Other",
+    "size": 1377
+  },
+  {
+    "file": "docs/agrivoltaics/app.js",
+    "role": "Loader-candidate",
+    "size": 44722
+  },
+  {
+    "file": "docs/agrivoltaics/app.jsx",
+    "role": "Other",
+    "size": 34467
+  },
+  {
+    "file": "docs/agrivoltaics/index.dev.html",
+    "role": "HTML-host",
+    "size": 32828,
+    "scripts": [
+      "https://unpkg.com/react@18/umd/react.production.min.js",
+      "https://unpkg.com/react-dom@18/umd/react-dom.production.min.js",
+      "https://unpkg.com/@babel/standalone/babel.min.js",
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js"
+    ]
+  },
+  {
+    "file": "docs/agrivoltaics/index.html",
+    "role": "HTML-host",
+    "size": 905,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "/agrivoltaics/vendor/react.production.min.js",
+      "/agrivoltaics/vendor/react-dom.production.min.js",
+      "/agrivoltaics/vendor/qrcode.js",
+      "/agrivoltaics/vendor/jspdf.umd.min.js",
+      "/agrivoltaics/app.js"
+    ]
+  },
+  {
+    "file": "docs/agrivoltaics/vendor/jspdf.umd.min.js",
+    "role": "Loader-candidate",
+    "size": 365760
+  },
+  {
+    "file": "docs/agrivoltaics/vendor/qrcode.js",
+    "role": "Loader-candidate",
+    "size": 56694
+  },
+  {
+    "file": "docs/agrivoltaics/vendor/react-dom.production.min.js",
+    "role": "Loader-candidate",
+    "size": 131835
+  },
+  {
+    "file": "docs/agrivoltaics/vendor/react.production.min.js",
+    "role": "Loader-candidate",
+    "size": 10751
+  },
+  {
+    "file": "docs/amaayesh/index.html",
+    "role": "HTML-host",
+    "size": 3427,
+    "scripts": [
+      "/assets/vendor/leaflet/leaflet.js",
+      "/assets/js/leaflet-icon-patch.js",
+      "/assets/vendor/leaflet.polylineDecorator.min.js",
+      "/assets/js/amaayesh-map.js",
+      "/assets/js/panel-direct-wire.js",
+      "/assets/js/ama-diag.js"
+    ]
+  },
+  {
+    "file": "docs/amaayesh/layers.config.json",
+    "role": "JSON-other",
+    "size": 266
+  },
+  {
+    "file": "docs/assets/app.js",
+    "role": "Loader-candidate",
+    "size": 15837
+  },
+  {
+    "file": "docs/assets/badge-updated.js",
+    "role": "UI-candidate",
+    "size": 3158
+  },
+  {
+    "file": "docs/assets/chart.autofix.css",
+    "role": "Other",
+    "size": 444
+  },
+  {
+    "file": "docs/assets/chart.guard.js",
+    "role": "Loader-candidate",
+    "size": 1791
+  },
+  {
+    "file": "docs/assets/cld/core/globals.d.ts",
+    "role": "Other",
+    "size": 185
+  },
+  {
+    "file": "docs/assets/cld/core/guards/batch-guard.js",
+    "role": "Core-candidate",
+    "size": 1763
+  },
+  {
+    "file": "docs/assets/cld/core/guards/collection-guard.js",
+    "role": "Core-candidate",
+    "size": 5676
+  },
+  {
+    "file": "docs/assets/cld/core/index.js",
+    "role": "Loader-candidate",
+    "size": 5950
+  },
+  {
+    "file": "docs/assets/cld/core/inject.js",
+    "role": "Core-candidate",
+    "size": 1219
+  },
+  {
+    "file": "docs/assets/cld/core/kernel/adapter.js",
+    "role": "Core-candidate",
+    "size": 799
+  },
+  {
+    "file": "docs/assets/cld/core/layout.js",
+    "role": "Core-candidate",
+    "size": 1493
+  },
+  {
+    "file": "docs/assets/cld/core/loop-detect.js",
+    "role": "Core-candidate",
+    "size": 2294
+  },
+  {
+    "file": "docs/assets/cld/core/mapper.js",
+    "role": "Core-candidate",
+    "size": 3540
+  },
+  {
+    "file": "docs/assets/cld/core/store.js",
+    "role": "Loader-candidate",
+    "size": 5415
+  },
+  {
+    "file": "docs/assets/cld/core/validate.js",
+    "role": "Core-candidate",
+    "size": 1964
+  },
+  {
+    "file": "docs/assets/cld/loader/init.js",
+    "role": "Loader-candidate",
+    "size": 2263
+  },
+  {
+    "file": "docs/assets/cld/loader/model-fetch.js",
+    "role": "Loader-candidate",
+    "size": 1741
+  },
+  {
+    "file": "docs/assets/cld/loader/paths.js",
+    "role": "Core-candidate",
+    "size": 12592
+  },
+  {
+    "file": "docs/assets/cld/loader/runtime-guards.js",
+    "role": "Core-candidate",
+    "size": 1309
+  },
+  {
+    "file": "docs/assets/cld/page-model-load.js",
+    "role": "Loader-candidate",
+    "size": 347
+  },
+  {
+    "file": "docs/assets/cld/ui/bridge-init.js",
+    "role": "Loader-candidate",
+    "size": 5511
+  },
+  {
+    "file": "docs/assets/cld/ui/controls.js",
+    "role": "Core-candidate",
+    "size": 815
+  },
+  {
+    "file": "docs/assets/cld/ui/legend.js",
+    "role": "UI-candidate",
+    "size": 448
+  },
+  {
+    "file": "docs/assets/cld/ui/search.js",
+    "role": "UI-candidate",
+    "size": 387
+  },
+  {
+    "file": "docs/assets/cld-loader.js",
+    "role": "Loader-candidate",
+    "size": 4750
+  },
+  {
+    "file": "docs/assets/cld-mapper.js",
+    "role": "Loader-candidate",
+    "size": 4639
+  },
+  {
+    "file": "docs/assets/cld-validate.js",
+    "role": "Core-candidate",
+    "size": 2022
+  },
+  {
+    "file": "docs/assets/cost-calculator.js",
+    "role": "UI-candidate",
+    "size": 10616
+  },
+  {
+    "file": "docs/assets/css/amaayesh.css",
+    "role": "Other",
+    "size": 8002
+  },
+  {
+    "file": "docs/assets/css/map-inline.css",
+    "role": "Other",
+    "size": 1928
+  },
+  {
+    "file": "docs/assets/debug/sentinel.js",
+    "role": "Core-candidate",
+    "size": 2718
+  },
+  {
+    "file": "docs/assets/dist/water-cld.bundle.css",
+    "role": "Other",
+    "size": 20536
+  },
+  {
+    "file": "docs/assets/dist/water-cld.bundle.js",
+    "role": "Loader-candidate",
+    "size": 116755
+  },
+  {
+    "file": "docs/assets/dist/water-cld.manifest.json",
+    "role": "JSON-other",
+    "size": 1629
+  },
+  {
+    "file": "docs/assets/electricity-management.js",
+    "role": "Loader-candidate",
+    "size": 4506
+  },
+  {
+    "file": "docs/assets/electricity-peak.js",
+    "role": "Loader-candidate",
+    "size": 4795
+  },
+  {
+    "file": "docs/assets/electricity-quality.js",
+    "role": "UI-candidate",
+    "size": 13021
+  },
+  {
+    "file": "docs/assets/emoji-flag.js",
+    "role": "Loader-candidate",
+    "size": 694
+  },
+  {
+    "file": "docs/assets/inline-migration.css",
+    "role": "Other",
+    "size": 3447
+  },
+  {
+    "file": "docs/assets/js/ama-diag.js",
+    "role": "UI-candidate",
+    "size": 1798
+  },
+  {
+    "file": "docs/assets/js/ama-wire-buttons.js",
+    "role": "UI-candidate",
+    "size": 2488
+  },
+  {
+    "file": "docs/assets/js/amaayesh-map.js",
+    "role": "Loader-candidate",
+    "size": 99331
+  },
+  {
+    "file": "docs/assets/js/gas-fuel-carbon.js",
+    "role": "Loader-candidate",
+    "size": 8454
+  },
+  {
+    "file": "docs/assets/js/panel-direct-wire.js",
+    "role": "Loader-candidate",
+    "size": 2477
+  },
+  {
+    "file": "docs/assets/layout-presets.js",
+    "role": "Core-candidate",
+    "size": 1994
+  },
+  {
+    "file": "docs/assets/legend.css",
+    "role": "Other",
+    "size": 3280
+  },
+  {
+    "file": "docs/assets/libs/chartjs-adapter-date-fns.bundle.min.js",
+    "role": "Core-candidate",
+    "size": 50650
+  },
+  {
+    "file": "docs/assets/libs/chartjs-plugin-annotation.min.js",
+    "role": "Loader-candidate",
+    "size": 38359
+  },
+  {
+    "file": "docs/assets/model-bridge.js",
+    "role": "UI-candidate",
+    "size": 5400
+  },
+  {
+    "file": "docs/assets/numfmt.js",
+    "role": "Loader-candidate",
+    "size": 2841
+  },
+  {
+    "file": "docs/assets/peak-electricity.js",
+    "role": "Loader-candidate",
+    "size": 8072
+  },
+  {
+    "file": "docs/assets/persian-digits.js",
+    "role": "UI-candidate",
+    "size": 524
+  },
+  {
+    "file": "docs/assets/power-tariff.js",
+    "role": "Loader-candidate",
+    "size": 7279
+  },
+  {
+    "file": "docs/assets/sim-worker.js",
+    "role": "Loader-candidate",
+    "size": 4959
+  },
+  {
+    "file": "docs/assets/tailwind.css",
+    "role": "Other",
+    "size": 42616
+  },
+  {
+    "file": "docs/assets/vendor/chart.umd.min.js",
+    "role": "Loader-candidate",
+    "size": 205637
+  },
+  {
+    "file": "docs/assets/vendor/cytoscape-dagre.js",
+    "role": "Loader-candidate",
+    "size": 12665
+  },
+  {
+    "file": "docs/assets/vendor/cytoscape-elk.js",
+    "role": "Loader-candidate",
+    "size": 11301
+  },
+  {
+    "file": "docs/assets/vendor/cytoscape.min.js",
+    "role": "Loader-candidate",
+    "size": 434037
+  },
+  {
+    "file": "docs/assets/vendor/dagre.min.js",
+    "role": "Loader-candidate",
+    "size": 283803
+  },
+  {
+    "file": "docs/assets/vendor/elk.bundled.js",
+    "role": "Loader-candidate",
+    "size": 1585569
+  },
+  {
+    "file": "docs/assets/vendor/expr-eval.min.js",
+    "role": "Loader-candidate",
+    "size": 25276
+  },
+  {
+    "file": "docs/assets/vendor/leaflet/leaflet.css",
+    "role": "Other",
+    "size": 14806
+  },
+  {
+    "file": "docs/assets/vendor/leaflet/leaflet.js",
+    "role": "Loader-candidate",
+    "size": 147552
+  },
+  {
+    "file": "docs/assets/vendor/leaflet-control-geocoder/Control.Geocoder.css",
+    "role": "Other",
+    "size": 3320
+  },
+  {
+    "file": "docs/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js",
+    "role": "Loader-candidate",
+    "size": 25371
+  },
+  {
+    "file": "docs/assets/vendor/leaflet.polylineDecorator.min.js",
+    "role": "Loader-candidate",
+    "size": 6827
+  },
+  {
+    "file": "docs/assets/vendor/popper.min.js",
+    "role": "UI-candidate",
+    "size": 20122
+  },
+  {
+    "file": "docs/assets/vendor/tippy.umd.min.js",
+    "role": "Loader-candidate",
+    "size": 24074
+  },
+  {
+    "file": "docs/assets/vendor/turf.min.js",
+    "role": "Loader-candidate",
+    "size": 604610
+  },
+  {
+    "file": "docs/assets/water-cld.a11y.css",
+    "role": "Other",
+    "size": 2521
+  },
+  {
+    "file": "docs/assets/water-cld.a11y.js",
+    "role": "Loader-candidate",
+    "size": 5841
+  },
+  {
+    "file": "docs/assets/water-cld.aha-metrics.js",
+    "role": "JS-other",
+    "size": 1128
+  },
+  {
+    "file": "docs/assets/water-cld.aha.css",
+    "role": "Other",
+    "size": 927
+  },
+  {
+    "file": "docs/assets/water-cld.aha.js",
+    "role": "Loader-candidate",
+    "size": 9958
+  },
+  {
+    "file": "docs/assets/water-cld.controls-meta.css",
+    "role": "Other",
+    "size": 1310
+  },
+  {
+    "file": "docs/assets/water-cld.controls-meta.js",
+    "role": "Loader-candidate",
+    "size": 8739
+  },
+  {
+    "file": "docs/assets/water-cld.css",
+    "role": "Other",
+    "size": 9994
+  },
+  {
+    "file": "docs/assets/water-cld.cy-addclass-patch.js",
+    "role": "Core-candidate",
+    "size": 904
+  },
+  {
+    "file": "docs/assets/water-cld.cy-alias.js",
+    "role": "JS-other",
+    "size": 1471
+  },
+  {
+    "file": "docs/assets/water-cld.cy-safe-add.js",
+    "role": "Core-candidate",
+    "size": 5956
+  },
+  {
+    "file": "docs/assets/water-cld.cy-stub.js",
+    "role": "UI-candidate",
+    "size": 6023
+  },
+  {
+    "file": "docs/assets/water-cld.defer.js",
+    "role": "Loader-candidate",
+    "size": 1362
+  },
+  {
+    "file": "docs/assets/water-cld.delta-kpi.css",
+    "role": "Other",
+    "size": 273
+  },
+  {
+    "file": "docs/assets/water-cld.delta-kpi.js",
+    "role": "Loader-candidate",
+    "size": 2376
+  },
+  {
+    "file": "docs/assets/water-cld.explain-10s.js",
+    "role": "JS-other",
+    "size": 1736
+  },
+  {
+    "file": "docs/assets/water-cld.extras-controls.js",
+    "role": "Core-candidate",
+    "size": 5981
+  },
+  {
+    "file": "docs/assets/water-cld.extras-hero.js",
+    "role": "Loader-candidate",
+    "size": 4411
+  },
+  {
+    "file": "docs/assets/water-cld.extras-readability.js",
+    "role": "Loader-candidate",
+    "size": 7777
+  },
+  {
+    "file": "docs/assets/water-cld.fix-hints.css",
+    "role": "Other",
+    "size": 331
+  },
+  {
+    "file": "docs/assets/water-cld.fix-hints.js",
+    "role": "UI-candidate",
+    "size": 3405
+  },
+  {
+    "file": "docs/assets/water-cld.ghost-delta.js",
+    "role": "JS-other",
+    "size": 1876
+  },
+  {
+    "file": "docs/assets/water-cld.init.js",
+    "role": "Loader-candidate",
+    "size": 10063
+  },
+  {
+    "file": "docs/assets/water-cld.js",
+    "role": "Loader-candidate",
+    "size": 72632
+  },
+  {
+    "file": "docs/assets/water-cld.kernel.js",
+    "role": "Loader-candidate",
+    "size": 3309
+  },
+  {
+    "file": "docs/assets/water-cld.param-chips.css",
+    "role": "Other",
+    "size": 186
+  },
+  {
+    "file": "docs/assets/water-cld.param-chips.js",
+    "role": "UI-candidate",
+    "size": 1227
+  },
+  {
+    "file": "docs/assets/water-cld.paths.css",
+    "role": "Other",
+    "size": 1672
+  },
+  {
+    "file": "docs/assets/water-cld.presets.css",
+    "role": "Other",
+    "size": 651
+  },
+  {
+    "file": "docs/assets/water-cld.presets.js",
+    "role": "JS-other",
+    "size": 8664
+  },
+  {
+    "file": "docs/assets/water-cld.provenance.css",
+    "role": "Other",
+    "size": 2411
+  },
+  {
+    "file": "docs/assets/water-cld.provenance.js",
+    "role": "Loader-candidate",
+    "size": 12373
+  },
+  {
+    "file": "docs/assets/water-cld.quick-preset.css",
+    "role": "Other",
+    "size": 341
+  },
+  {
+    "file": "docs/assets/water-cld.quick-preset.js",
+    "role": "JS-other",
+    "size": 1886
+  },
+  {
+    "file": "docs/assets/water-cld.readability.css",
+    "role": "Other",
+    "size": 867
+  },
+  {
+    "file": "docs/assets/water-cld.scenarios.css",
+    "role": "Other",
+    "size": 1635
+  },
+  {
+    "file": "docs/assets/water-cld.scenarios.js",
+    "role": "Loader-candidate",
+    "size": 14573
+  },
+  {
+    "file": "docs/assets/water-cld.spotlight.css",
+    "role": "Other",
+    "size": 90
+  },
+  {
+    "file": "docs/assets/water-cld.spotlight.js",
+    "role": "JS-other",
+    "size": 261
+  },
+  {
+    "file": "docs/assets/water-cld.toast.css",
+    "role": "Other",
+    "size": 366
+  },
+  {
+    "file": "docs/assets/water-cld.tour.css",
+    "role": "Other",
+    "size": 1670
+  },
+  {
+    "file": "docs/assets/water-cld.tour.js",
+    "role": "UI-candidate",
+    "size": 7656
+  },
+  {
+    "file": "docs/assets/water-cost-calculator.js",
+    "role": "Loader-candidate",
+    "size": 5787
+  },
+  {
+    "file": "docs/assets/water-cost.css",
+    "role": "Other",
+    "size": 3284
+  },
+  {
+    "file": "docs/assets/water-cost.js",
+    "role": "UI-candidate",
+    "size": 5294
+  },
+  {
+    "file": "docs/assets/water-efficiency.js",
+    "role": "UI-candidate",
+    "size": 5546
+  },
+  {
+    "file": "docs/assets/water-insights.js",
+    "role": "Loader-candidate",
+    "size": 9493
+  },
+  {
+    "file": "docs/assets/water-sfd.js",
+    "role": "Loader-candidate",
+    "size": 2664
+  },
+  {
+    "file": "docs/data/layers.config.json",
+    "role": "JSON-other",
+    "size": 454
+  },
+  {
+    "file": "docs/data/water/cld-model.json",
+    "role": "Data",
+    "size": 161,
+    "nodes": 2,
+    "edges": 1
+  },
+  {
+    "file": "docs/data/water-cld-poster.json",
+    "role": "Data",
+    "size": 11973,
+    "nodes": 41,
+    "edges": 54
+  },
+  {
+    "file": "docs/data/water-cld.json",
+    "role": "Data",
+    "size": 1776,
+    "nodes": 5,
+    "edges": 4
+  },
+  {
+    "file": "docs/debug/ADDME.md",
+    "role": "Other",
+    "size": 392
+  },
+  {
+    "file": "docs/electricity/index.html",
+    "role": "HTML-host",
+    "size": 3164,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/shamsi-date.js",
+      "index.js",
+      "../assets/numfmt.js"
+    ]
+  },
+  {
+    "file": "docs/electricity/peak.html",
+    "role": "HTML-host",
+    "size": 7774,
+    "scripts": [
+      "../assets/vendor/chart.umd.min.js",
+      "../assets/electricity-management.js",
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/electricity-peak.js",
+      "../assets/badge-updated.js"
+    ]
+  },
+  {
+    "file": "docs/electricity/power-tariff.html",
+    "role": "HTML-host",
+    "size": 21686,
+    "scripts": [
+      "../assets/power-tariff.js",
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js"
+    ]
+  },
+  {
+    "file": "docs/electricity/quality.html",
+    "role": "HTML-host",
+    "size": 11901,
+    "scripts": [
+      "../assets/vendor/chart.umd.min.js",
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/electricity-quality.js",
+      "../assets/badge-updated.js"
+    ]
+  },
+  {
+    "file": "docs/gas/energy.html",
+    "role": "HTML-host",
+    "size": 8321,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/vendor/chart.umd.min.js",
+      "../assets/numfmt.js",
+      "./energy.js",
+      "../assets/badge-updated.js"
+    ]
+  },
+  {
+    "file": "docs/gas/energy.js",
+    "role": "UI-candidate",
+    "size": 12509
+  },
+  {
+    "file": "docs/gas/fuel-carbon.html",
+    "role": "HTML-host",
+    "size": 14767,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/vendor/chart.umd.min.js",
+      "../vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js",
+      "../assets/js/gas-fuel-carbon.js?v=1"
+    ]
+  },
+  {
+    "file": "docs/gas/index.html",
+    "role": "HTML-host",
+    "size": 2518,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "index.js",
+      "../assets/numfmt.js",
+      "../assets/badge-updated.js"
+    ]
+  },
+  {
+    "file": "docs/guide/cld-style.md",
+    "role": "Other",
+    "size": 1955
+  },
+  {
+    "file": "docs/index.html",
+    "role": "HTML-host",
+    "size": 25474,
+    "scripts": [
+      "./assets/unified-badge.js",
+      "./assets/global-footer.js",
+      "./assets/parallax.js",
+      "index.js?v=1",
+      "assets/numfmt.js?v=1",
+      "./assets/cld-loader.js"
+    ]
+  },
+  {
+    "file": "docs/index.js",
+    "role": "Loader-candidate",
+    "size": 6834
+  },
+  {
+    "file": "docs/metrics/panel-kpis.md",
+    "role": "Other",
+    "size": 952
+  },
+  {
+    "file": "docs/page/landing/file_00000000b59462439107e38c78cfbccf.png",
+    "role": "Other",
+    "size": 4011478
+  },
+  {
+    "file": "docs/page/landing/landing.css",
+    "role": "Other",
+    "size": 2096
+  },
+  {
+    "file": "docs/research/index.html",
+    "role": "HTML-host",
+    "size": 24386,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "index.js"
+    ]
+  },
+  {
+    "file": "docs/research/index.js",
+    "role": "UI-candidate",
+    "size": 5043
+  },
+  {
+    "file": "docs/test/water-cld.html",
+    "role": "HTML-host",
+    "size": 15603,
+    "scripts": [
+      "../assets/vendor/cytoscape.min.js",
+      "../assets/vendor/elk.bundled.js",
+      "../assets/vendor/cytoscape-elk.js",
+      "../assets/vendor/dagre.min.js",
+      "../assets/vendor/cytoscape-dagre.js",
+      "../assets/vendor/chart.umd.min.js",
+      "/assets/cld/core/validate.js",
+      "/assets/cld/core/mapper.js",
+      "/assets/cld/core/inject.js",
+      "/assets/cld/core/layout.js",
+      "/assets/cld/core/index.js",
+      "/assets/cld/ui/bridge-init.js",
+      "/assets/water-cld.defer.js",
+      "/assets/water-cld.init.js"
+    ]
+  },
+  {
+    "file": "docs/vendor/chart.js/chart.umd.js",
+    "role": "Loader-candidate",
+    "size": 205363
+  },
+  {
+    "file": "docs/vendor/chart.umd.min.js",
+    "role": "Loader-candidate",
+    "size": 205637
+  },
+  {
+    "file": "docs/vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js",
+    "role": "Core-candidate",
+    "size": 220817
+  },
+  {
+    "file": "docs/water/cld/index.html",
+    "role": "HTML-host",
+    "size": 14319,
+    "scripts": [
+      "/assets/vendor/cytoscape.min.js",
+      "/assets/vendor/elk.bundled.js",
+      "/assets/vendor/cytoscape-elk.js",
+      "/assets/vendor/dagre.min.js",
+      "/assets/vendor/cytoscape-dagre.js",
+      "/assets/vendor/chart.umd.min.js",
+      "/assets/cld/core/validate.js",
+      "/assets/cld/core/mapper.js",
+      "/assets/cld/core/inject.js",
+      "/assets/cld/core/layout.js",
+      "/assets/cld/core/index.js",
+      "/assets/cld/ui/bridge-init.js",
+      "/assets/water-cld.defer.js",
+      "/assets/cld/page-model-load.js",
+      "/assets/water-cld.init.js",
+      "/assets/cld/page-debug.js",
+      "/assets/cld/page-probe.js"
+    ]
+  },
+  {
+    "file": "docs/water/cost-calculator.html",
+    "role": "HTML-host",
+    "size": 6110,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/vendor/chart.umd.min.js",
+      "../assets/water-cost.js",
+      "../assets/water-init.js"
+    ]
+  },
+  {
+    "file": "docs/water/cost-calculator.js",
+    "role": "UI-candidate",
+    "size": 10633
+  },
+  {
+    "file": "docs/water/hub.html",
+    "role": "HTML-host",
+    "size": 6025,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/water-init.js"
+    ]
+  },
+  {
+    "file": "docs/water/insights.html",
+    "role": "HTML-host",
+    "size": 20407,
+    "scripts": [
+      "/assets/unified-badge.js",
+      "/assets/global-footer.js",
+      "../assets/vendor/chart.umd.min.js",
+      "../assets/water-init.js",
+      "../assets/ai.js",
+      "../assets/app.js",
+      "../assets/water-insights.js",
+      "../assets/emoji-flag.js",
+      "../assets/numfmt.js",
+      "../assets/js/insights-waffle.js"
+    ]
+  },
+  {
+    "file": "netlify.toml",
+    "role": "Other",
+    "size": 2827
+  },
+  {
+    "file": "package-lock.json",
+    "role": "JSON-other",
+    "size": 274065
+  },
+  {
+    "file": "package.json",
+    "role": "JSON-other",
+    "size": 4060
+  },
+  {
+    "file": "scripts/build-cld.js",
+    "role": "Loader-candidate",
+    "size": 3751
+  },
+  {
+    "file": "tests/artifacts/cld-render.png",
+    "role": "Other",
+    "size": 95150
+  },
+  {
+    "file": "tests/artifacts/render-run.log",
+    "role": "Other",
+    "size": 1763
+  },
+  {
+    "file": "tests/e2e/cld-diagnose.js",
+    "role": "Loader-candidate",
+    "size": 3604
+  },
+  {
+    "file": "tests/e2e/cld-runtime-inventory.js",
+    "role": "Core-candidate",
+    "size": 3421
+  },
+  {
+    "file": "tests/e2e/cld-smoke.js",
+    "role": "Core-candidate",
+    "size": 2760
+  },
+  {
+    "file": "tests/e2e-cld.test.js",
+    "role": "JS-other",
+    "size": 1275
+  },
+  {
+    "file": "tests/e2e-water-cld.behaviors.test.js",
+    "role": "UI-candidate",
+    "size": 5424
+  },
+  {
+    "file": "tests/mapper.test.js",
+    "role": "Core-candidate",
+    "size": 1427
+  },
+  {
+    "file": "tests/unit/mapper.test.js",
+    "role": "Core-candidate",
+    "size": 2568
+  },
+  {
+    "file": "tools/audit_amaayesh.js",
+    "role": "UI-candidate",
+    "size": 3290
+  },
+  {
+    "file": "tools/build-wind-weights.mjs",
+    "role": "Other",
+    "size": 8309
+  },
+  {
+    "file": "tools/check-cld-html.sh",
+    "role": "Other",
+    "size": 1286
+  },
+  {
+    "file": "tools/check-no-binary.js",
+    "role": "UI-candidate",
+    "size": 631
+  },
+  {
+    "file": "tools/cld-inventory.js",
+    "role": "Loader-candidate",
+    "size": 3223
+  },
+  {
+    "file": "tools/cld-rewire-plan.js",
+    "role": "Loader-candidate",
+    "size": 1616
+  },
+  {
+    "file": "tools/report-tests-csp.js",
+    "role": "Loader-candidate",
+    "size": 8564
+  },
+  {
+    "file": "tools/validate_layers.js",
+    "role": "Core-candidate",
+    "size": 705
+  }
+]

--- a/reports/cld-inventory.md
+++ b/reports/cld-inventory.md
@@ -1,0 +1,189 @@
+# CLD Inventory
+
+| file | role | size | nodes | edges | scripts |
+|------|------|------:|------:|------:|---------|
+| ARCHITECTURE.md | Other | 568 |  |  |  |
+| Plan.md | Other | 1877 |  |  |  |
+| diagnostics/cld-diagnose.png | Other | 101177 |  |  |  |
+| diagnostics/cld-report.json | JSON-other | 2178 |  |  |  |
+| docs/DEV_NOTES.md | Other | 517 |  |  |  |
+| docs/_headers | Other | 1377 |  |  |  |
+| docs/agrivoltaics/app.js | Loader-candidate | 44722 |  |  |  |
+| docs/agrivoltaics/app.jsx | Other | 34467 |  |  |  |
+| docs/agrivoltaics/index.dev.html | HTML-host | 32828 |  |  | https://unpkg.com/react@18/umd/react.production.min.js<br>https://unpkg.com/react-dom@18/umd/react-dom.production.min.js<br>https://unpkg.com/@babel/standalone/babel.min.js<br>/assets/unified-badge.js<br>/assets/global-footer.js |
+| docs/agrivoltaics/index.html | HTML-host | 905 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>/agrivoltaics/vendor/react.production.min.js<br>/agrivoltaics/vendor/react-dom.production.min.js<br>/agrivoltaics/vendor/qrcode.js<br>/agrivoltaics/vendor/jspdf.umd.min.js<br>/agrivoltaics/app.js |
+| docs/agrivoltaics/vendor/jspdf.umd.min.js | Loader-candidate | 365760 |  |  |  |
+| docs/agrivoltaics/vendor/qrcode.js | Loader-candidate | 56694 |  |  |  |
+| docs/agrivoltaics/vendor/react-dom.production.min.js | Loader-candidate | 131835 |  |  |  |
+| docs/agrivoltaics/vendor/react.production.min.js | Loader-candidate | 10751 |  |  |  |
+| docs/amaayesh/index.html | HTML-host | 3427 |  |  | /assets/vendor/leaflet/leaflet.js<br>/assets/js/leaflet-icon-patch.js<br>/assets/vendor/leaflet.polylineDecorator.min.js<br>/assets/js/amaayesh-map.js<br>/assets/js/panel-direct-wire.js<br>/assets/js/ama-diag.js |
+| docs/amaayesh/layers.config.json | JSON-other | 266 |  |  |  |
+| docs/assets/app.js | Loader-candidate | 15837 |  |  |  |
+| docs/assets/badge-updated.js | UI-candidate | 3158 |  |  |  |
+| docs/assets/chart.autofix.css | Other | 444 |  |  |  |
+| docs/assets/chart.guard.js | Loader-candidate | 1791 |  |  |  |
+| docs/assets/cld/core/globals.d.ts | Other | 185 |  |  |  |
+| docs/assets/cld/core/guards/batch-guard.js | Core-candidate | 1763 |  |  |  |
+| docs/assets/cld/core/guards/collection-guard.js | Core-candidate | 5676 |  |  |  |
+| docs/assets/cld/core/index.js | Loader-candidate | 5950 |  |  |  |
+| docs/assets/cld/core/inject.js | Core-candidate | 1219 |  |  |  |
+| docs/assets/cld/core/kernel/adapter.js | Core-candidate | 799 |  |  |  |
+| docs/assets/cld/core/layout.js | Core-candidate | 1493 |  |  |  |
+| docs/assets/cld/core/loop-detect.js | Core-candidate | 2294 |  |  |  |
+| docs/assets/cld/core/mapper.js | Core-candidate | 3540 |  |  |  |
+| docs/assets/cld/core/store.js | Loader-candidate | 5415 |  |  |  |
+| docs/assets/cld/core/validate.js | Core-candidate | 1964 |  |  |  |
+| docs/assets/cld/loader/init.js | Loader-candidate | 2263 |  |  |  |
+| docs/assets/cld/loader/model-fetch.js | Loader-candidate | 1741 |  |  |  |
+| docs/assets/cld/loader/paths.js | Core-candidate | 12592 |  |  |  |
+| docs/assets/cld/loader/runtime-guards.js | Core-candidate | 1309 |  |  |  |
+| docs/assets/cld/page-model-load.js | Loader-candidate | 347 |  |  |  |
+| docs/assets/cld/ui/bridge-init.js | Loader-candidate | 5511 |  |  |  |
+| docs/assets/cld/ui/controls.js | Core-candidate | 815 |  |  |  |
+| docs/assets/cld/ui/legend.js | UI-candidate | 448 |  |  |  |
+| docs/assets/cld/ui/search.js | UI-candidate | 387 |  |  |  |
+| docs/assets/cld-loader.js | Loader-candidate | 4750 |  |  |  |
+| docs/assets/cld-mapper.js | Loader-candidate | 4639 |  |  |  |
+| docs/assets/cld-validate.js | Core-candidate | 2022 |  |  |  |
+| docs/assets/cost-calculator.js | UI-candidate | 10616 |  |  |  |
+| docs/assets/css/amaayesh.css | Other | 8002 |  |  |  |
+| docs/assets/css/map-inline.css | Other | 1928 |  |  |  |
+| docs/assets/debug/sentinel.js | Core-candidate | 2718 |  |  |  |
+| docs/assets/dist/water-cld.bundle.css | Other | 20536 |  |  |  |
+| docs/assets/dist/water-cld.bundle.js | Loader-candidate | 116755 |  |  |  |
+| docs/assets/dist/water-cld.manifest.json | JSON-other | 1629 |  |  |  |
+| docs/assets/electricity-management.js | Loader-candidate | 4506 |  |  |  |
+| docs/assets/electricity-peak.js | Loader-candidate | 4795 |  |  |  |
+| docs/assets/electricity-quality.js | UI-candidate | 13021 |  |  |  |
+| docs/assets/emoji-flag.js | Loader-candidate | 694 |  |  |  |
+| docs/assets/inline-migration.css | Other | 3447 |  |  |  |
+| docs/assets/js/ama-diag.js | UI-candidate | 1798 |  |  |  |
+| docs/assets/js/ama-wire-buttons.js | UI-candidate | 2488 |  |  |  |
+| docs/assets/js/amaayesh-map.js | Loader-candidate | 99331 |  |  |  |
+| docs/assets/js/gas-fuel-carbon.js | Loader-candidate | 8454 |  |  |  |
+| docs/assets/js/panel-direct-wire.js | Loader-candidate | 2477 |  |  |  |
+| docs/assets/layout-presets.js | Core-candidate | 1994 |  |  |  |
+| docs/assets/legend.css | Other | 3280 |  |  |  |
+| docs/assets/libs/chartjs-adapter-date-fns.bundle.min.js | Core-candidate | 50650 |  |  |  |
+| docs/assets/libs/chartjs-plugin-annotation.min.js | Loader-candidate | 38359 |  |  |  |
+| docs/assets/model-bridge.js | UI-candidate | 5400 |  |  |  |
+| docs/assets/numfmt.js | Loader-candidate | 2841 |  |  |  |
+| docs/assets/peak-electricity.js | Loader-candidate | 8072 |  |  |  |
+| docs/assets/persian-digits.js | UI-candidate | 524 |  |  |  |
+| docs/assets/power-tariff.js | Loader-candidate | 7279 |  |  |  |
+| docs/assets/sim-worker.js | Loader-candidate | 4959 |  |  |  |
+| docs/assets/tailwind.css | Other | 42616 |  |  |  |
+| docs/assets/vendor/chart.umd.min.js | Loader-candidate | 205637 |  |  |  |
+| docs/assets/vendor/cytoscape-dagre.js | Loader-candidate | 12665 |  |  |  |
+| docs/assets/vendor/cytoscape-elk.js | Loader-candidate | 11301 |  |  |  |
+| docs/assets/vendor/cytoscape.min.js | Loader-candidate | 434037 |  |  |  |
+| docs/assets/vendor/dagre.min.js | Loader-candidate | 283803 |  |  |  |
+| docs/assets/vendor/elk.bundled.js | Loader-candidate | 1585569 |  |  |  |
+| docs/assets/vendor/expr-eval.min.js | Loader-candidate | 25276 |  |  |  |
+| docs/assets/vendor/leaflet/leaflet.css | Other | 14806 |  |  |  |
+| docs/assets/vendor/leaflet/leaflet.js | Loader-candidate | 147552 |  |  |  |
+| docs/assets/vendor/leaflet-control-geocoder/Control.Geocoder.css | Other | 3320 |  |  |  |
+| docs/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js | Loader-candidate | 25371 |  |  |  |
+| docs/assets/vendor/leaflet.polylineDecorator.min.js | Loader-candidate | 6827 |  |  |  |
+| docs/assets/vendor/popper.min.js | UI-candidate | 20122 |  |  |  |
+| docs/assets/vendor/tippy.umd.min.js | Loader-candidate | 24074 |  |  |  |
+| docs/assets/vendor/turf.min.js | Loader-candidate | 604610 |  |  |  |
+| docs/assets/water-cld.a11y.css | Other | 2521 |  |  |  |
+| docs/assets/water-cld.a11y.js | Loader-candidate | 5841 |  |  |  |
+| docs/assets/water-cld.aha-metrics.js | JS-other | 1128 |  |  |  |
+| docs/assets/water-cld.aha.css | Other | 927 |  |  |  |
+| docs/assets/water-cld.aha.js | Loader-candidate | 9958 |  |  |  |
+| docs/assets/water-cld.controls-meta.css | Other | 1310 |  |  |  |
+| docs/assets/water-cld.controls-meta.js | Loader-candidate | 8739 |  |  |  |
+| docs/assets/water-cld.css | Other | 9994 |  |  |  |
+| docs/assets/water-cld.cy-addclass-patch.js | Core-candidate | 904 |  |  |  |
+| docs/assets/water-cld.cy-alias.js | JS-other | 1471 |  |  |  |
+| docs/assets/water-cld.cy-safe-add.js | Core-candidate | 5956 |  |  |  |
+| docs/assets/water-cld.cy-stub.js | UI-candidate | 6023 |  |  |  |
+| docs/assets/water-cld.defer.js | Loader-candidate | 1362 |  |  |  |
+| docs/assets/water-cld.delta-kpi.css | Other | 273 |  |  |  |
+| docs/assets/water-cld.delta-kpi.js | Loader-candidate | 2376 |  |  |  |
+| docs/assets/water-cld.explain-10s.js | JS-other | 1736 |  |  |  |
+| docs/assets/water-cld.extras-controls.js | Core-candidate | 5981 |  |  |  |
+| docs/assets/water-cld.extras-hero.js | Loader-candidate | 4411 |  |  |  |
+| docs/assets/water-cld.extras-readability.js | Loader-candidate | 7777 |  |  |  |
+| docs/assets/water-cld.fix-hints.css | Other | 331 |  |  |  |
+| docs/assets/water-cld.fix-hints.js | UI-candidate | 3405 |  |  |  |
+| docs/assets/water-cld.ghost-delta.js | JS-other | 1876 |  |  |  |
+| docs/assets/water-cld.init.js | Loader-candidate | 10063 |  |  |  |
+| docs/assets/water-cld.js | Loader-candidate | 72632 |  |  |  |
+| docs/assets/water-cld.kernel.js | Loader-candidate | 3309 |  |  |  |
+| docs/assets/water-cld.param-chips.css | Other | 186 |  |  |  |
+| docs/assets/water-cld.param-chips.js | UI-candidate | 1227 |  |  |  |
+| docs/assets/water-cld.paths.css | Other | 1672 |  |  |  |
+| docs/assets/water-cld.presets.css | Other | 651 |  |  |  |
+| docs/assets/water-cld.presets.js | JS-other | 8664 |  |  |  |
+| docs/assets/water-cld.provenance.css | Other | 2411 |  |  |  |
+| docs/assets/water-cld.provenance.js | Loader-candidate | 12373 |  |  |  |
+| docs/assets/water-cld.quick-preset.css | Other | 341 |  |  |  |
+| docs/assets/water-cld.quick-preset.js | JS-other | 1886 |  |  |  |
+| docs/assets/water-cld.readability.css | Other | 867 |  |  |  |
+| docs/assets/water-cld.scenarios.css | Other | 1635 |  |  |  |
+| docs/assets/water-cld.scenarios.js | Loader-candidate | 14573 |  |  |  |
+| docs/assets/water-cld.spotlight.css | Other | 90 |  |  |  |
+| docs/assets/water-cld.spotlight.js | JS-other | 261 |  |  |  |
+| docs/assets/water-cld.toast.css | Other | 366 |  |  |  |
+| docs/assets/water-cld.tour.css | Other | 1670 |  |  |  |
+| docs/assets/water-cld.tour.js | UI-candidate | 7656 |  |  |  |
+| docs/assets/water-cost-calculator.js | Loader-candidate | 5787 |  |  |  |
+| docs/assets/water-cost.css | Other | 3284 |  |  |  |
+| docs/assets/water-cost.js | UI-candidate | 5294 |  |  |  |
+| docs/assets/water-efficiency.js | UI-candidate | 5546 |  |  |  |
+| docs/assets/water-insights.js | Loader-candidate | 9493 |  |  |  |
+| docs/assets/water-sfd.js | Loader-candidate | 2664 |  |  |  |
+| docs/data/layers.config.json | JSON-other | 454 |  |  |  |
+| docs/data/water/cld-model.json | Data | 161 | 2 | 1 |  |
+| docs/data/water-cld-poster.json | Data | 11973 | 41 | 54 |  |
+| docs/data/water-cld.json | Data | 1776 | 5 | 4 |  |
+| docs/debug/ADDME.md | Other | 392 |  |  |  |
+| docs/electricity/index.html | HTML-host | 3164 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/shamsi-date.js<br>index.js<br>../assets/numfmt.js |
+| docs/electricity/peak.html | HTML-host | 7774 |  |  | ../assets/vendor/chart.umd.min.js<br>../assets/electricity-management.js<br>/assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/electricity-peak.js<br>../assets/badge-updated.js |
+| docs/electricity/power-tariff.html | HTML-host | 21686 |  |  | ../assets/power-tariff.js<br>/assets/unified-badge.js<br>/assets/global-footer.js |
+| docs/electricity/quality.html | HTML-host | 11901 |  |  | ../assets/vendor/chart.umd.min.js<br>/assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/electricity-quality.js<br>../assets/badge-updated.js |
+| docs/gas/energy.html | HTML-host | 8321 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/vendor/chart.umd.min.js<br>../assets/numfmt.js<br>./energy.js<br>../assets/badge-updated.js |
+| docs/gas/energy.js | UI-candidate | 12509 |  |  |  |
+| docs/gas/fuel-carbon.html | HTML-host | 14767 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/vendor/chart.umd.min.js<br>../vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js<br>../assets/js/gas-fuel-carbon.js?v=1 |
+| docs/gas/index.html | HTML-host | 2518 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>index.js<br>../assets/numfmt.js<br>../assets/badge-updated.js |
+| docs/guide/cld-style.md | Other | 1955 |  |  |  |
+| docs/index.html | HTML-host | 25474 |  |  | ./assets/unified-badge.js<br>./assets/global-footer.js<br>./assets/parallax.js<br>index.js?v=1<br>assets/numfmt.js?v=1<br>./assets/cld-loader.js |
+| docs/index.js | Loader-candidate | 6834 |  |  |  |
+| docs/metrics/panel-kpis.md | Other | 952 |  |  |  |
+| docs/page/landing/file_00000000b59462439107e38c78cfbccf.png | Other | 4011478 |  |  |  |
+| docs/page/landing/landing.css | Other | 2096 |  |  |  |
+| docs/research/index.html | HTML-host | 24386 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>index.js |
+| docs/research/index.js | UI-candidate | 5043 |  |  |  |
+| docs/test/water-cld.html | HTML-host | 15603 |  |  | ../assets/vendor/cytoscape.min.js<br>../assets/vendor/elk.bundled.js<br>../assets/vendor/cytoscape-elk.js<br>../assets/vendor/dagre.min.js<br>../assets/vendor/cytoscape-dagre.js<br>../assets/vendor/chart.umd.min.js<br>/assets/cld/core/validate.js<br>/assets/cld/core/mapper.js<br>/assets/cld/core/inject.js<br>/assets/cld/core/layout.js<br>/assets/cld/core/index.js<br>/assets/cld/ui/bridge-init.js<br>/assets/water-cld.defer.js<br>/assets/water-cld.init.js |
+| docs/vendor/chart.js/chart.umd.js | Loader-candidate | 205363 |  |  |  |
+| docs/vendor/chart.umd.min.js | Loader-candidate | 205637 |  |  |  |
+| docs/vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js | Core-candidate | 220817 |  |  |  |
+| docs/water/cld/index.html | HTML-host | 14319 |  |  | /assets/vendor/cytoscape.min.js<br>/assets/vendor/elk.bundled.js<br>/assets/vendor/cytoscape-elk.js<br>/assets/vendor/dagre.min.js<br>/assets/vendor/cytoscape-dagre.js<br>/assets/vendor/chart.umd.min.js<br>/assets/cld/core/validate.js<br>/assets/cld/core/mapper.js<br>/assets/cld/core/inject.js<br>/assets/cld/core/layout.js<br>/assets/cld/core/index.js<br>/assets/cld/ui/bridge-init.js<br>/assets/water-cld.defer.js<br>/assets/cld/page-model-load.js<br>/assets/water-cld.init.js<br>/assets/cld/page-debug.js<br>/assets/cld/page-probe.js |
+| docs/water/cost-calculator.html | HTML-host | 6110 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/vendor/chart.umd.min.js<br>../assets/water-cost.js<br>../assets/water-init.js |
+| docs/water/cost-calculator.js | UI-candidate | 10633 |  |  |  |
+| docs/water/hub.html | HTML-host | 6025 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/water-init.js |
+| docs/water/insights.html | HTML-host | 20407 |  |  | /assets/unified-badge.js<br>/assets/global-footer.js<br>../assets/vendor/chart.umd.min.js<br>../assets/water-init.js<br>../assets/ai.js<br>../assets/app.js<br>../assets/water-insights.js<br>../assets/emoji-flag.js<br>../assets/numfmt.js<br>../assets/js/insights-waffle.js |
+| netlify.toml | Other | 2827 |  |  |  |
+| package-lock.json | JSON-other | 274065 |  |  |  |
+| package.json | JSON-other | 4060 |  |  |  |
+| scripts/build-cld.js | Loader-candidate | 3751 |  |  |  |
+| tests/artifacts/cld-render.png | Other | 95150 |  |  |  |
+| tests/artifacts/render-run.log | Other | 1763 |  |  |  |
+| tests/e2e/cld-diagnose.js | Loader-candidate | 3604 |  |  |  |
+| tests/e2e/cld-runtime-inventory.js | Core-candidate | 3421 |  |  |  |
+| tests/e2e/cld-smoke.js | Core-candidate | 2760 |  |  |  |
+| tests/e2e-cld.test.js | JS-other | 1275 |  |  |  |
+| tests/e2e-water-cld.behaviors.test.js | UI-candidate | 5424 |  |  |  |
+| tests/mapper.test.js | Core-candidate | 1427 |  |  |  |
+| tests/unit/mapper.test.js | Core-candidate | 2568 |  |  |  |
+| tools/audit_amaayesh.js | UI-candidate | 3290 |  |  |  |
+| tools/build-wind-weights.mjs | Other | 8309 |  |  |  |
+| tools/check-cld-html.sh | Other | 1286 |  |  |  |
+| tools/check-no-binary.js | UI-candidate | 631 |  |  |  |
+| tools/cld-inventory.js | Loader-candidate | 3223 |  |  |  |
+| tools/cld-rewire-plan.js | Loader-candidate | 1616 |  |  |  |
+| tools/report-tests-csp.js | Loader-candidate | 8564 |  |  |  |
+| tools/validate_layers.js | Core-candidate | 705 |  |  |  |

--- a/reports/cld-rewire-plan.md
+++ b/reports/cld-rewire-plan.md
@@ -1,0 +1,1077 @@
+# CLD Rewire Plan (Core/UI/Loader/Data)
+
+## ARCHITECTURE.md
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## Plan.md
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## diagnostics/cld-diagnose.png
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## diagnostics/cld-report.json
+- Current role: **JSON-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/DEV_NOTES.md
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/_headers
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/agrivoltaics/app.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/agrivoltaics/app.jsx
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/agrivoltaics/index.dev.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - https://unpkg.com/react@18/umd/react.production.min.js
+    - https://unpkg.com/react-dom@18/umd/react-dom.production.min.js
+    - https://unpkg.com/@babel/standalone/babel.min.js
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+
+## docs/agrivoltaics/index.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - /agrivoltaics/vendor/react.production.min.js
+    - /agrivoltaics/vendor/react-dom.production.min.js
+    - /agrivoltaics/vendor/qrcode.js
+    - /agrivoltaics/vendor/jspdf.umd.min.js
+    - /agrivoltaics/app.js
+
+## docs/agrivoltaics/vendor/jspdf.umd.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/agrivoltaics/vendor/qrcode.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/agrivoltaics/vendor/react-dom.production.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/agrivoltaics/vendor/react.production.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/amaayesh/index.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/vendor/leaflet/leaflet.js
+    - /assets/js/leaflet-icon-patch.js
+    - /assets/vendor/leaflet.polylineDecorator.min.js
+    - /assets/js/amaayesh-map.js
+    - /assets/js/panel-direct-wire.js
+    - /assets/js/ama-diag.js
+
+## docs/amaayesh/layers.config.json
+- Current role: **JSON-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/app.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/badge-updated.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/chart.autofix.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/chart.guard.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld/core/globals.d.ts
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/cld/core/guards/batch-guard.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/core/guards/collection-guard.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/core/index.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld/core/inject.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/core/kernel/adapter.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/core/layout.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/core/loop-detect.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/core/mapper.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/core/store.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld/core/validate.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/loader/init.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld/loader/model-fetch.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld/loader/paths.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/loader/runtime-guards.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/page-model-load.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld/ui/bridge-init.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld/ui/controls.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cld/ui/legend.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/cld/ui/search.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/cld-loader.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld-mapper.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/cld-validate.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/cost-calculator.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/css/amaayesh.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/css/map-inline.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/debug/sentinel.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/dist/water-cld.bundle.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/dist/water-cld.bundle.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/dist/water-cld.manifest.json
+- Current role: **JSON-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/electricity-management.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/electricity-peak.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/electricity-quality.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/emoji-flag.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/inline-migration.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/js/ama-diag.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/js/ama-wire-buttons.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/js/amaayesh-map.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/js/gas-fuel-carbon.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/js/panel-direct-wire.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/layout-presets.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/legend.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/libs/chartjs-adapter-date-fns.bundle.min.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/libs/chartjs-plugin-annotation.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/model-bridge.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/numfmt.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/peak-electricity.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/persian-digits.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/power-tariff.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/sim-worker.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/tailwind.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/vendor/chart.umd.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/cytoscape-dagre.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/cytoscape-elk.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/cytoscape.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/dagre.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/elk.bundled.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/expr-eval.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/leaflet/leaflet.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/vendor/leaflet/leaflet.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/leaflet-control-geocoder/Control.Geocoder.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/vendor/leaflet-control-geocoder/Control.Geocoder.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/leaflet.polylineDecorator.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/popper.min.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/vendor/tippy.umd.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/vendor/turf.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.a11y.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.a11y.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.aha-metrics.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.aha.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.aha.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.controls-meta.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.controls-meta.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.cy-addclass-patch.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/water-cld.cy-alias.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.cy-safe-add.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/water-cld.cy-stub.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/water-cld.defer.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.delta-kpi.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.delta-kpi.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.explain-10s.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.extras-controls.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/assets/water-cld.extras-hero.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.extras-readability.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.fix-hints.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.fix-hints.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/water-cld.ghost-delta.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.init.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.kernel.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.param-chips.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.param-chips.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/water-cld.paths.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.presets.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.presets.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.provenance.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.provenance.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.quick-preset.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.quick-preset.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.readability.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.scenarios.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.scenarios.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cld.spotlight.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.spotlight.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.toast.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.tour.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cld.tour.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/water-cost-calculator.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-cost.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/assets/water-cost.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/water-efficiency.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/assets/water-insights.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/assets/water-sfd.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/data/layers.config.json
+- Current role: **JSON-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/data/water/cld-model.json
+- Current role: **Data**
+- Used now: ❌ no
+- Proposed layer: **Data**
+
+  - 👉 پیشنهاد: این مدل را در Loader به‌صورت `fetch('/docs/data/water/cld-model.json')` یا از طریق manifest متصل کن.
+
+## docs/data/water-cld-poster.json
+- Current role: **Data**
+- Used now: ❌ no
+- Proposed layer: **Data**
+
+  - 👉 پیشنهاد: این مدل را در Loader به‌صورت `fetch('/docs/data/water-cld-poster.json')` یا از طریق manifest متصل کن.
+
+## docs/data/water-cld.json
+- Current role: **Data**
+- Used now: ❌ no
+- Proposed layer: **Data**
+
+  - 👉 پیشنهاد: این مدل را در Loader به‌صورت `fetch('/docs/data/water-cld.json')` یا از طریق manifest متصل کن.
+
+## docs/debug/ADDME.md
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/electricity/index.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/shamsi-date.js
+    - index.js
+    - ../assets/numfmt.js
+
+## docs/electricity/peak.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - ../assets/vendor/chart.umd.min.js
+    - ../assets/electricity-management.js
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/electricity-peak.js
+    - ../assets/badge-updated.js
+
+## docs/electricity/power-tariff.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - ../assets/power-tariff.js
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+
+## docs/electricity/quality.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - ../assets/vendor/chart.umd.min.js
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/electricity-quality.js
+    - ../assets/badge-updated.js
+
+## docs/gas/energy.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/vendor/chart.umd.min.js
+    - ../assets/numfmt.js
+    - ./energy.js
+    - ../assets/badge-updated.js
+
+## docs/gas/energy.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/gas/fuel-carbon.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/vendor/chart.umd.min.js
+    - ../vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js
+    - ../assets/js/gas-fuel-carbon.js?v=1
+
+## docs/gas/index.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - index.js
+    - ../assets/numfmt.js
+    - ../assets/badge-updated.js
+
+## docs/guide/cld-style.md
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/index.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - ./assets/unified-badge.js
+    - ./assets/global-footer.js
+    - ./assets/parallax.js
+    - index.js?v=1
+    - assets/numfmt.js?v=1
+    - ./assets/cld-loader.js
+
+## docs/index.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/metrics/panel-kpis.md
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/page/landing/file_00000000b59462439107e38c78cfbccf.png
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/page/landing/landing.css
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## docs/research/index.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - index.js
+
+## docs/research/index.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/test/water-cld.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - ../assets/vendor/cytoscape.min.js
+    - ../assets/vendor/elk.bundled.js
+    - ../assets/vendor/cytoscape-elk.js
+    - ../assets/vendor/dagre.min.js
+    - ../assets/vendor/cytoscape-dagre.js
+    - ../assets/vendor/chart.umd.min.js
+    - /assets/cld/core/validate.js
+    - /assets/cld/core/mapper.js
+    - /assets/cld/core/inject.js
+    - /assets/cld/core/layout.js
+    - /assets/cld/core/index.js
+    - /assets/cld/ui/bridge-init.js
+    - /assets/water-cld.defer.js
+    - /assets/water-cld.init.js
+
+## docs/vendor/chart.js/chart.umd.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/vendor/chart.umd.min.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## docs/vendor/chartjs-adapter-date-fns/chartjs-adapter-date-fns.bundle.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## docs/water/cld/index.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/vendor/cytoscape.min.js
+    - /assets/vendor/elk.bundled.js
+    - /assets/vendor/cytoscape-elk.js
+    - /assets/vendor/dagre.min.js
+    - /assets/vendor/cytoscape-dagre.js
+    - /assets/vendor/chart.umd.min.js
+    - /assets/cld/core/validate.js
+    - /assets/cld/core/mapper.js
+    - /assets/cld/core/inject.js
+    - /assets/cld/core/layout.js
+    - /assets/cld/core/index.js
+    - /assets/cld/ui/bridge-init.js
+    - /assets/water-cld.defer.js
+    - /assets/cld/page-model-load.js
+    - /assets/water-cld.init.js
+    - /assets/cld/page-debug.js
+    - /assets/cld/page-probe.js
+
+## docs/water/cost-calculator.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/vendor/chart.umd.min.js
+    - ../assets/water-cost.js
+    - ../assets/water-init.js
+
+## docs/water/cost-calculator.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## docs/water/hub.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/water-init.js
+
+## docs/water/insights.html
+- Current role: **HTML-host**
+- Used now: ❌ no
+- Proposed layer: **Host**
+
+  - Scripts in page:
+    - /assets/unified-badge.js
+    - /assets/global-footer.js
+    - ../assets/vendor/chart.umd.min.js
+    - ../assets/water-init.js
+    - ../assets/ai.js
+    - ../assets/app.js
+    - ../assets/water-insights.js
+    - ../assets/emoji-flag.js
+    - ../assets/numfmt.js
+    - ../assets/js/insights-waffle.js
+
+## netlify.toml
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## package-lock.json
+- Current role: **JSON-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## package.json
+- Current role: **JSON-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## scripts/build-cld.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## tests/artifacts/cld-render.png
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## tests/artifacts/render-run.log
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## tests/e2e/cld-diagnose.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## tests/e2e/cld-runtime-inventory.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## tests/e2e/cld-smoke.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## tests/e2e-cld.test.js
+- Current role: **JS-other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## tests/e2e-water-cld.behaviors.test.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## tests/mapper.test.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## tests/unit/mapper.test.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**
+
+## tools/audit_amaayesh.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## tools/build-wind-weights.mjs
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## tools/check-cld-html.sh
+- Current role: **Other**
+- Used now: ❌ no
+- Proposed layer: **Unmapped**
+
+## tools/check-no-binary.js
+- Current role: **UI-candidate**
+- Used now: ❌ no
+- Proposed layer: **UI**
+
+## tools/cld-inventory.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## tools/cld-rewire-plan.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## tools/report-tests-csp.js
+- Current role: **Loader-candidate**
+- Used now: ❌ no
+- Proposed layer: **Loader**
+
+## tools/validate_layers.js
+- Current role: **Core-candidate**
+- Used now: ❌ no
+- Proposed layer: **Core**

--- a/reports/cld-runtime-usage.json
+++ b/reports/cld-runtime-usage.json
@@ -1,0 +1,26 @@
+[
+  {
+    "url": "http://localhost:8080/water/",
+    "error": "Error: Failed to launch the browser process!\n/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n"
+  },
+  {
+    "url": "http://localhost:8080/water/index.html",
+    "error": "Error: Failed to launch the browser process!\n/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n"
+  },
+  {
+    "url": "http://localhost:8080/test/water-cld.html",
+    "error": "Error: Failed to launch the browser process!\n/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n"
+  },
+  {
+    "url": "http://localhost:8080/water/cost-calculator.html",
+    "error": "Error: Failed to launch the browser process!\n/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n"
+  },
+  {
+    "url": "http://localhost:8080/water/hub.html",
+    "error": "Error: Failed to launch the browser process!\n/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n"
+  },
+  {
+    "url": "http://localhost:8080/water/insights.html",
+    "error": "Error: Failed to launch the browser process!\n/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n"
+  }
+]

--- a/reports/cld-runtime-usage.md
+++ b/reports/cld-runtime-usage.md
@@ -1,0 +1,43 @@
+# CLD Runtime Usage
+
+## http://localhost:8080/water/
+- ❌ Error: Error: Failed to launch the browser process!
+/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory
+
+
+TROUBLESHOOTING: https://pptr.dev/troubleshooting
+
+## http://localhost:8080/water/index.html
+- ❌ Error: Error: Failed to launch the browser process!
+/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory
+
+
+TROUBLESHOOTING: https://pptr.dev/troubleshooting
+
+## http://localhost:8080/test/water-cld.html
+- ❌ Error: Error: Failed to launch the browser process!
+/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory
+
+
+TROUBLESHOOTING: https://pptr.dev/troubleshooting
+
+## http://localhost:8080/water/cost-calculator.html
+- ❌ Error: Error: Failed to launch the browser process!
+/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory
+
+
+TROUBLESHOOTING: https://pptr.dev/troubleshooting
+
+## http://localhost:8080/water/hub.html
+- ❌ Error: Error: Failed to launch the browser process!
+/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory
+
+
+TROUBLESHOOTING: https://pptr.dev/troubleshooting
+
+## http://localhost:8080/water/insights.html
+- ❌ Error: Error: Failed to launch the browser process!
+/root/.cache/puppeteer/chrome/linux-140.0.7339.82/chrome-linux64/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory
+
+
+TROUBLESHOOTING: https://pptr.dev/troubleshooting

--- a/tests/e2e/cld-runtime-inventory.js
+++ b/tests/e2e/cld-runtime-inventory.js
@@ -1,0 +1,79 @@
+const { spawn } = require('child_process');
+const http = require('http'); const path = require('path'); const fs = require('fs');
+const puppeteer = require('puppeteer');
+const REPORT_DIR = path.join(process.cwd(), 'reports'); fs.mkdirSync(REPORT_DIR, {recursive:true});
+
+function waitFor(url, ms=30000){
+  const t0 = Date.now();
+  return new Promise((res, rej) => {
+    (function ping(){
+      const req = http.get(url, r=>{ r.resume(); res(); }).on('error', ()=>{
+        if (Date.now()-t0>ms) rej(new Error('server timeout')); else setTimeout(ping, 400);
+      }); req.end();
+    })();
+  });
+}
+
+async function probe(url){
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const requests = [];
+  page.on('requestfinished', req => requests.push(req.url()));
+  await page.goto(url, {waitUntil:'networkidle2', timeout:60000}).catch(()=>{});
+  const result = await page.evaluate(()=>{
+    const scripts = Array.from(document.scripts).map(s=>s.src).filter(Boolean);
+    const modelCandidates = ['__MODEL__','__cldModel','rawModel'].filter(k => window[k]!=null);
+    const cyOk = !!(window.cy);
+    const counts = cyOk ? {nodes: cy.nodes().length, edges: cy.edges().length} : null;
+    return { scripts, cyOk, counts, modelCandidates };
+  });
+  await browser.close();
+  return { url, scripts: result.scripts, cy: result.cyOk, counts: result.counts, modelVars: result.modelCandidates, requests };
+}
+
+(async ()=>{
+  const port = process.env.TEST_PORT || '8080';
+  const base = `http://localhost:${port}`;
+  const candidates = [
+    `${base}/water/`,
+    `${base}/water/index.html`,
+    `${base}/test/water-cld.html`
+  ];
+
+  // کشف HTMLهای مرتبط در docs/water
+  const waterDir = path.join(process.cwd(), 'docs','water');
+  if (fs.existsSync(waterDir)) {
+    const htmls = fs.readdirSync(waterDir).filter(f=>/\.html?$/i.test(f)).slice(0,5);
+    htmls.forEach(h => candidates.push(`${base}/water/${h}`));
+  }
+
+  const useServe = !!process.env.USE_SERVE_DOCS;
+  const cmd = useServe ? 'npm' : 'npx';
+  const args = useServe ? ['run','serve-docs'] : ['http-server','docs','-p',port,'-s','-c-1'];
+
+  const server = spawn(cmd, args, {stdio:'inherit', shell:true});
+  try{
+    await waitFor(`${base}/`);
+    const results = [];
+    for (const u of [...new Set(candidates)]) {
+      try { results.push(await probe(u)); } catch(e){ results.push({url:u, error:String(e)}); }
+    }
+    fs.writeFileSync(path.join(REPORT_DIR,'cld-runtime-usage.json'), JSON.stringify(results,null,2));
+    const md = ['# CLD Runtime Usage\n'];
+    for (const r of results) {
+      md.push(`## ${r.url}`);
+      if (r.error) { md.push(`- ❌ Error: ${r.error}`); continue; }
+      md.push(`- Scripts:\n  - ${r.scripts.join('\n  - ') || '(none)'}`);
+      md.push(`- Model Vars: ${r.modelVars?.join(', ') || '(none)'}`);
+      md.push(`- Cytoscape: ${r.cy ? '✅' : '❌'}`);
+      if (r.counts) md.push(`- Elements: nodes=${r.counts.nodes}, edges=${r.counts.edges}`);
+      const jsons = r.requests.filter(u => /\.json($|\?)/i.test(u));
+      if (jsons.length) md.push(`- JSON fetched:\n  - ${jsons.join('\n  - ')}`);
+    }
+    fs.writeFileSync(path.join(REPORT_DIR,'cld-runtime-usage.md'), md.join('\n'), 'utf8');
+    console.log('Runtime usage written to reports/cld-runtime-usage.{md,json}');
+    server.kill(); process.exit(0);
+  } catch(e){
+    console.error(e); server.kill(); process.exit(1);
+  }
+})();

--- a/tools/cld-inventory.js
+++ b/tools/cld-inventory.js
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+const fs = require('fs'); const path = require('path');
+
+const ROOT = process.cwd();
+const REPORT_DIR = path.join(ROOT, 'reports');
+fs.mkdirSync(REPORT_DIR, { recursive: true });
+
+const HINTS = {
+  core: /(cytoscape|cy\.add|cy\.json|elk|dagre|mapper|validate|initCore|setModel)/i,
+  ui: /(controls|legend|search|filter|panel)/i,
+  loader: /(bootstrap|loader|defer|init)/i
+};
+const NAME_HINTS = /(cld|water\-cld|cld\-model|layers\.config|poster)/i;
+
+function walk(dir, acc=[]) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) { walk(p, acc); }
+    else acc.push(p);
+  }
+  return acc;
+}
+
+function isLikelyCLD(p, txt) {
+  const n = path.basename(p);
+  if (NAME_HINTS.test(n)) return true;
+  if (HINTS.core.test(txt) || HINTS.ui.test(txt) || HINTS.loader.test(txt)) return true;
+  return false;
+}
+
+function read(p){ try{ return fs.readFileSync(p,'utf8'); }catch{ return ''; } }
+
+function classify(p, txt) {
+  const ext = path.extname(p).toLowerCase();
+  if (ext === '.html') return 'HTML-host';
+  if (ext === '.json') {
+    try {
+      const j = JSON.parse(txt);
+      const nodes = j?.nodes || j?.Vertices || j?.NODES;
+      const edges = j?.edges || j?.Links || j?.EDGES;
+      if (Array.isArray(nodes) && Array.isArray(edges)) return 'Data';
+    } catch {}
+    return 'JSON-other';
+  }
+  if (ext === '.js') {
+    const isCore = HINTS.core.test(txt);
+    const isLoader = HINTS.loader.test(txt);
+    const isUI = HINTS.ui.test(txt);
+    if (isLoader) return 'Loader-candidate';
+    if (isUI && !isCore) return 'UI-candidate';
+    if (isCore) return 'Core-candidate';
+    return 'JS-other';
+  }
+  return 'Other';
+}
+
+function extractHtmlScripts(html) {
+  const srcs = [];
+  const re = /<script[^>]*src=["']([^"']+)["']/ig;
+  let m; while ((m = re.exec(html))) srcs.push(m[1]);
+  return srcs;
+}
+
+function main(){
+  const files = walk(ROOT, []).filter(p => !/node_modules|\.git|reports/i.test(p));
+  const rows = [];
+  for (const f of files) {
+    const txt = read(f);
+    if (!isLikelyCLD(f, txt)) continue;
+    const role = classify(f, txt);
+    const row = { file: path.relative(ROOT, f), role, size: fs.statSync(f).size };
+    if (role === 'Data') {
+      try {
+        const j = JSON.parse(txt);
+        const nodes = j?.nodes || j?.Vertices || j?.NODES || [];
+        const edges = j?.edges || j?.Links || j?.EDGES || [];
+        row.nodes = nodes.length; row.edges = edges.length;
+      } catch {}
+    }
+    if (role === 'HTML-host') row.scripts = extractHtmlScripts(txt);
+    rows.push(row);
+  }
+
+  // Markdown
+  const md = [];
+  md.push(`# CLD Inventory\n`);
+  md.push(`| file | role | size | nodes | edges | scripts |\n|------|------|------:|------:|------:|---------|`);
+  rows.forEach(r => {
+    md.push(`| ${r.file} | ${r.role} | ${r.size} | ${r.nodes||''} | ${r.edges||''} | ${(r.scripts||[]).join('<br>')} |`);
+  });
+  fs.writeFileSync(path.join(REPORT_DIR, 'cld-inventory.md'), md.join('\n'), 'utf8');
+  fs.writeFileSync(path.join(REPORT_DIR, 'cld-inventory.json'), JSON.stringify(rows,null,2),'utf8');
+  console.log(`CLD inventory written to reports/cld-inventory.{md,json} (${rows.length} items)`);
+}
+main();

--- a/tools/cld-rewire-plan.js
+++ b/tools/cld-rewire-plan.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const fs = require('fs'); const path = require('path');
+const inv = JSON.parse(fs.readFileSync(path.join('reports','cld-inventory.json'),'utf8'));
+const run = fs.existsSync(path.join('reports','cld-runtime-usage.json'))
+  ? JSON.parse(fs.readFileSync(path.join('reports','cld-runtime-usage.json'),'utf8')) : [];
+
+const md = [];
+md.push('# CLD Rewire Plan (Core/UI/Loader/Data)\n');
+
+function usedInRuntime(p){
+  const urlPart = p.replace(/^docs[\\\/]/,'/').replace(/\\/g,'/');
+  return run.some(page =>
+    (page.scripts||[]).some(s=>s.includes(urlPart)) ||
+    (page.requests||[]).some(u=>u.includes(urlPart)) );
+}
+
+for (const r of inv) {
+  const role = r.role;
+  const file = r.file;
+  const used = usedInRuntime(file);
+  let target = 'Unmapped';
+  if (role==='Data') target = 'Data';
+  else if (role==='Core-candidate') target = 'Core';
+  else if (role==='UI-candidate') target = 'UI';
+  else if (role==='Loader-candidate') target = 'Loader';
+  else if (role==='HTML-host') target = 'Host';
+
+  md.push(`## ${file}\n- Current role: **${role}**\n- Used now: ${used?'✅ yes':'❌ no'}\n- Proposed layer: **${target}**\n`);
+  if (role==='Data' && !used) md.push(`  - 👉 پیشنهاد: این مدل را در Loader به‌صورت \`fetch('/${file.replace(/\\/g,'/')}')\` یا از طریق manifest متصل کن.\n`);
+  if (role==='HTML-host' && r.scripts?.length) md.push(`  - Scripts in page:\n    - ${r.scripts.join('\n    - ')}\n`);
+}
+
+fs.writeFileSync(path.join('reports','cld-rewire-plan.md'), md.join('\n'), 'utf8');
+console.log('Rewire plan written to reports/cld-rewire-plan.md');


### PR DESCRIPTION
## Summary
- add Node script to inventory CLD-related files and classify their roles
- add Puppeteer-based runtime audit to capture CLD scripts and model usage
- generate rewire plan report linking files to proposed architecture layers

## Testing
- `npm run audit:cld:all` *(fails: Failed to launch the browser process)*

------
https://chatgpt.com/codex/tasks/task_e_68c6612a05b88328a6391002e60379cb