### PR TITLE
feat: add CLD data architecture audit

### DIFF
--- a/reports/cld-data-architecture-audit.json
+++ b/reports/cld-data-architecture-audit.json
@@ -1,0 +1,34 @@
+{
+  "models": [
+    {
+      "domain": "water",
+      "file": "docs/data/water/cld-model.json",
+      "nodes": 2,
+      "edges": 1,
+      "ratio": 0.5,
+      "score": 3.5
+    },
+    {
+      "domain": "water",
+      "file": "docs/data/water-cld-poster.json",
+      "nodes": 41,
+      "edges": 54,
+      "ratio": 1.3170731707317074,
+      "score": 96.3170731707317
+    },
+    {
+      "domain": "water",
+      "file": "docs/data/water-cld.json",
+      "nodes": 5,
+      "edges": 4,
+      "ratio": 0.8,
+      "score": 9.8
+    }
+  ],
+  "recommended": {
+    "water": {
+      "file": "docs/data/water-cld-poster.json",
+      "score": 96.3170731707317
+    }
+  }
+}

--- a/reports/cld-data-architecture-audit.md
+++ b/reports/cld-data-architecture-audit.md
@@ -1,0 +1,11 @@
+# CLD Data Architecture Audit
+
+| domain | file | nodes | edges | ratio | score |
+|--------|------|------:|------:|------:|------:|
+| water | docs/data/water/cld-model.json | 2 | 1 | 0.50 | 3.50 |
+| water | docs/data/water-cld-poster.json | 41 | 54 | 1.32 | 96.32 |
+| water | docs/data/water-cld.json | 5 | 4 | 0.80 | 9.80 |
+
+## Recommended Models
+
+- water: docs/data/water-cld-poster.json (score 96.32)

--- a/tools/cld-data-architecture-audit.js
+++ b/tools/cld-data-architecture-audit.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = process.cwd();
+const REPORT_DIR = path.join(ROOT, 'reports');
+const INVENTORY_PATH = path.join(REPORT_DIR, 'cld-inventory.json');
+fs.mkdirSync(REPORT_DIR, { recursive: true });
+
+function getDomain(file){
+  const parts = file.split('/');
+  const dataIdx = parts.indexOf('data');
+  if (dataIdx === -1) return 'unknown';
+  const after = parts.slice(dataIdx + 1);
+  if (!after.length) return 'unknown';
+  if (after.length > 1) return after[0];
+  const base = after[0].split('.')[0];
+  return base.split('-')[0];
+}
+
+function scoreModel(nodes, edges){
+  const n = Number(nodes)||0;
+  const e = Number(edges)||0;
+  const ratio = n>0 ? e/n : 0;
+  return n + e + ratio; // simple additive scoring
+}
+
+function main(){
+  let inventory;
+  try {
+    inventory = JSON.parse(fs.readFileSync(INVENTORY_PATH,'utf8'));
+  } catch(err){
+    console.error('Failed to read cld-inventory.json:', err.message);
+    process.exit(1);
+  }
+  const rows = [];
+  const recommended = {};
+  for (const item of inventory){
+    if(item.role !== 'Data') continue;
+    const nodes = item.nodes || 0;
+    const edges = item.edges || 0;
+    const ratio = nodes>0 ? edges/nodes : 0;
+    const score = scoreModel(nodes, edges);
+    const domain = getDomain(item.file);
+    const row = { domain, file: item.file, nodes, edges, ratio, score };
+    rows.push(row);
+    if(!recommended[domain] || score > recommended[domain].score){
+      recommended[domain] = { file: item.file, score };
+    }
+  }
+
+  // Markdown report
+  const md = [];
+  md.push('# CLD Data Architecture Audit\n');
+  md.push('| domain | file | nodes | edges | ratio | score |');
+  md.push('|--------|------|------:|------:|------:|------:|');
+  rows.forEach(r => {
+    md.push(`| ${r.domain} | ${r.file} | ${r.nodes} | ${r.edges} | ${r.ratio.toFixed(2)} | ${r.score.toFixed(2)} |`);
+  });
+  md.push('\n## Recommended Models\n');
+  Object.entries(recommended).forEach(([domain, rec]) => {
+    md.push(`- ${domain}: ${rec.file} (score ${rec.score.toFixed(2)})`);
+  });
+  fs.writeFileSync(path.join(REPORT_DIR, 'cld-data-architecture-audit.md'), md.join('\n'), 'utf8');
+
+  // JSON report
+  const jsonReport = { models: rows, recommended };
+  fs.writeFileSync(path.join(REPORT_DIR, 'cld-data-architecture-audit.json'), JSON.stringify(jsonReport, null, 2), 'utf8');
+  console.log(`CLD data architecture audit written to reports/cld-data-architecture-audit.{md,json} (${rows.length} models)`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `cld-data-architecture-audit.js` to score CLD data models and produce reports
- generate `cld-data-architecture-audit` markdown and json reports with per-domain recommendations

## Testing
- `npm test` *(fails: libatk-1.0.so.0 missing)*
- `npm run flag:test` *(fails: libatk-1.0.so.0 missing)*
- `npm run check:no-binary`


------
https://chatgpt.com/codex/tasks/task_e_68c67b493c808328969b757d73d88eaf