### PR TITLE
chore: add cld audit scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "audit:cld:files": "node tools/cld-inventory.js",
     "audit:cld:runtime": "node tests/e2e/cld-runtime-inventory.js",
     "audit:cld:rewire": "node tools/cld-rewire-plan.js",
+    "audit:cld:arch": "node tools/cld-data-architecture-audit.js",
+    "audit:cld:connect": "node tools/cld-connection-audit.js",
     "audit:cld:all": "npm run audit:cld:files && npm run audit:cld:runtime && npm run audit:cld:rewire"
   },
   "keywords": [],


### PR DESCRIPTION
## Summary
- add audit scripts for CLD architecture and connection checks to package.json

## Testing
- `npm test` (fails: Failed to launch the browser process due to missing libatk)


------
https://chatgpt.com/codex/tasks/task_e_68c67f3108188328a3bb5221181a456c