### PR TITLE
chore(netlify): /api proxy + scoped CSP for CLD + redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -36,8 +36,9 @@
 
 [[redirects]]
   from = "/api/*"
-  to = "/.netlify/functions/:splat"
+  to = "https://api.wesh360.ir/:splat"
   status = 200
+  force = true
 
 # --- Ensure SPA rewrite does not catch data files ---
 # If there is a catch-all like /* -> /index.html 200, keep it LAST,


### PR DESCRIPTION
## Summary
- proxy /api/* traffic directly to https://api.wesh360.ir to eliminate CORS issues
- scope CLD content security policy headers to allow API connectivity
- redirect the water CLD test path to the main CLD route

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3c1d247e08328920b5de5a5c155cf