### PR TITLE
fix: stabilize CLD model loading fallback

### DIFF
--- a/docs/assets/cld/loader/model-fetch.js
+++ b/docs/assets/cld/loader/model-fetch.js
@@ -42,7 +42,7 @@ export async function loadModel(candidate) {
     return await fetchJson(primary);
   } catch (e) {
     if (String(e.message || '').includes('MODEL_HTTP_404')) {
-      const fname = (primary || '').split('/').pop();
+      const fname = ((primary || '').split('/').pop() || '').split('?')[0];
       if (fname) {
         const fb = '/data/' + fname;
         console.warn('[CLD][model] 404; fallback', fb);

--- a/docs/assets/water-cld.init.js
+++ b/docs/assets/water-cld.init.js
@@ -357,6 +357,9 @@ if (typeof MutationObserver !== 'undefined') {
           var opt = sw.options[sw.selectedIndex];
           var base = opt ? opt.value : sw.value;
           var ver = opt && opt.dataset ? opt.dataset.version : null;
+          if (ver == null || ver === '' || ver === 'undefined' || ver === 'null') {
+            ver = '1';
+          }
           var full = ver ? base + '?v=' + ver : base;
           return norm(full);
         }catch(_){ return norm(sw.value); }

--- a/docs/assets/water-cld.js
+++ b/docs/assets/water-cld.js
@@ -1710,6 +1710,9 @@ function cldToCyElements(graph){ return toCyElements(graph); }
         var opt = sw.options[sw.selectedIndex];
         var base = opt ? opt.value : sw.value;
         var ver = opt && opt.dataset ? opt.dataset.version : null;
+        if (ver == null || ver === '' || ver === 'undefined' || ver === 'null') {
+          ver = '1';
+        }
         return ver ? base + '?v=' + ver : base;
       }
       sw.addEventListener('change', function(){

--- a/docs/assets/water-cld.provenance.js
+++ b/docs/assets/water-cld.provenance.js
@@ -8,6 +8,12 @@ import { setClass } from './css-classes.js';
   const $  = (s, r=document)=> r.querySelector(s);
   const $$ = (s, r=document)=> Array.from(r.querySelectorAll(s));
   const safe = (v, d='—') => (v==null || v==='') ? d : v;
+  const sanitizeVersion = (val, fallback='1') => {
+    if (val == null) return fallback;
+    const str = String(val).trim();
+    if (!str || str === 'undefined' || str === 'null') return fallback;
+    return str;
+  };
   const meta = (name) => document.querySelector(`meta[name="${name}"]`)?.content || null;
 
   // Read versions/commit from globals or meta
@@ -51,7 +57,7 @@ import { setClass } from './css-classes.js';
         unit:  el.dataset.unit || meta('default-unit') || '',
         source: el.dataset.source || meta('data-source') || '—',
         updated: el.dataset.updated || meta('data-updated') || readVersions().UPDATED || '—',
-        version: el.dataset.version || readVersions().DATA,
+        version: sanitizeVersion(el.dataset.version, sanitizeVersion(readVersions().DATA)),
         csv: el.dataset.csv || '',   // اگر داده CSV دارید
         img: null                    // بعداً اگر canvas بود، PNG می‌سازیم
       };

--- a/docs/data/amaayesh/water-cld.json
+++ b/docs/data/amaayesh/water-cld.json
@@ -1,0 +1,1 @@
+{"version":1,"nodes":[],"edges":[]}


### PR DESCRIPTION
## Summary
- add an empty base model JSON for amaayesh CLD pages
- strip query strings when falling back to /data assets in the CLD loader
- sanitize model version query values so undefined entries default to v=1

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3c3b491c083288d8d3854ed3e159f