### PR TITLE
fix(front): keep /api/gemini on site origin to avoid FastAPI conflict

### DIFF
--- a/docs/assets/js/api.js
+++ b/docs/assets/js/api.js
@@ -25,8 +25,8 @@ function isServerFailure(response){
 }
 
 export async function apiFetch(path, init={}){
-  if (path.startsWith('/api/gemini')) return fetch(path, init);
-  const base = await resolveBaseUrl();
+  const useSiteOrigin = path.startsWith('/api/gemini');
+  const base = useSiteOrigin ? window.location.origin : await resolveBaseUrl();
   const url = new URL(path, base).toString();
   const cldAction = isCldActionPath(path);
   try {


### PR DESCRIPTION
## Summary
- ensure `/api/gemini` API requests always use the site origin instead of a remote API base

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3d16747b48328a4ef2c459f6fc2d5