### PR TITLE
Restore security policy page and update navigation

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -27,10 +27,10 @@
     <header class="site-header relative flex justify-center items-center px-4">
       <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
       <div class="absolute top-4 right-4 flex items-center gap-2">
-        <button id="policyBtn" type="button" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-haspopup="dialog" aria-controls="policySheet" title="سیاست امنیت و حکمرانی داده">
+        <a href="/security-policy" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="سیاست امنیت و حکمرانی داده">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و حکمرانی داده</span>
-        </button>
+        </a>
         <button id="securityBtn" type="button" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-haspopup="dialog" aria-controls="securitySheet" title="گزارش مسئولانهٔ آسیب‌پذیری">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
           <span>گزارش مسئولانهٔ آسیب‌پذیری</span>
@@ -207,10 +207,10 @@
     <div class="absolute inset-0 bg-black/60" data-close></div>
     <div class="fixed inset-y-0 right-0 w-64 bg-white p-6 shadow-lg overflow-y-auto flex flex-col gap-3">
       <h2 id="mobileActionsTitle" class="text-base font-semibold mb-2" tabindex="-1">سیاست و امنیت</h2>
-      <button id="mobilePolicyBtn" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-controls="policySheet">
+      <a href="/security-policy" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
         <span>سیاست امنیت و حکمرانی داده</span>
-      </button>
+      </a>
       <button id="mobileSecurityBtn" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-controls="securitySheet">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
         <span>گزارش مسئولانهٔ آسیب‌پذیری</span>

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -18,10 +18,10 @@
   <header class="relative p-4 flex justify-center items-center">
     <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
     <div class="absolute top-4 right-4 flex items-center gap-2">
-      <button id="policyBtn" type="button" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-haspopup="dialog" aria-controls="policySheet" title="سیاست امنیت و حکمرانی داده">
+      <a href="/security-policy" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="سیاست امنیت و حکمرانی داده">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
         <span>سیاست امنیت و حکمرانی داده</span>
-      </button>
+      </a>
       <button id="securityBtn" type="button" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-haspopup="dialog" aria-controls="securitySheet" title="گزارش مسئولانهٔ آسیب‌پذیری">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
         <span>گزارش مسئولانهٔ آسیب‌پذیری</span>
@@ -67,7 +67,7 @@
       <div class="bg-slate-50 border border-slate-200 rounded-xl p-4 text-sm text-slate-700 leading-6">
         <p>ما صرفاً داده‌های عملکرد زنجیرهٔ تأمین انرژی و آب را به‌صورت تجمیعی و با تاخیر ایمن مصورسازی می‌کنیم. ارائهٔ داده برای پژوهشگران نیز منطبق با همین خط قرمز است: بدون انتشار جزئیات عملیاتی/بلادرنگ. اولویت بررسی بر مبنای منفعت عمومی، امکان‌پذیری فنی و هم‌راستایی با مادهٔ ۱۰۷ است.</p>
         <div class="mt-3 flex gap-4">
-          <a href="/policy" class="text-sky-700 hover:underline">سیاست امنیت و حکمرانی داده</a>
+          <a href="/security-policy" class="text-sky-700 hover:underline">سیاست امنیت و حکمرانی داده</a>
         </div>
       </div>
     </section>
@@ -106,10 +106,10 @@
     <div class="absolute inset-0 bg-black/60" data-close></div>
     <div class="fixed inset-y-0 right-0 w-64 bg-white p-6 shadow-lg overflow-y-auto flex flex-col gap-3">
       <h2 id="mobileActionsTitle" class="text-base font-semibold mb-2" tabindex="-1">سیاست و امنیت</h2>
-      <button id="mobilePolicyBtn" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-controls="policySheet">
+      <a href="/security-policy" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
         <span>سیاست امنیت و حکمرانی داده</span>
-      </button>
+      </a>
       <button id="mobileSecurityBtn" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-controls="securitySheet">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
         <span>گزارش مسئولانهٔ آسیب‌پذیری</span>

--- a/docs/security-policy/index.html
+++ b/docs/security-policy/index.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Language" content="fa-IR" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>سیاست امنیت و حکمرانی داده • WESH360</title>
+  <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="../assets/fonts.css" />
+  <link rel="stylesheet" href="../assets/global-footer.css" />
+  <link rel="stylesheet" href="../assets/unified-badge.css" />
+  <link rel="icon" type="image/png" href="../Logo.png" />
+</head>
+<body class="min-h-screen flex flex-col bg-slate-50">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="bg-white border-b border-slate-200">
+    <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
+      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+        <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" class="w-16 h-auto" loading="lazy" decoding="async" />
+        <span class="text-base md:text-lg">خانه هم‌افزایی انرژی و آب</span>
+      </a>
+      <nav class="hidden md:flex items-center gap-3 text-sm">
+        <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
+          <span>سیاست امنیت و حکمرانی داده</span>
+        </a>
+        <a href="/research/" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" /><path d="M6.453 15h11.094" /><path d="M8.5 2h7" /></svg>
+          <span>پژوهشگران</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="flex-grow">
+    <section class="bg-sky-900 text-white py-12">
+      <div class="max-w-3xl mx-auto px-4 text-center space-y-4">
+        <p class="text-sm font-semibold tracking-wide uppercase">WESH360</p>
+        <h1 class="text-2xl md:text-4xl font-extrabold">سیاست امنیت و حکمرانی داده</h1>
+        <p class="text-sm md:text-base text-slate-100 leading-7">شفافیت داده و خط قرمز امنیت: ما صرفاً داده‌های عملکرد زنجیرهٔ تأمین انرژی و آب را با تاخیر ایمن و به‌صورت تجمیعی ارائه می‌کنیم.</p>
+      </div>
+    </section>
+
+    <section class="max-w-4xl mx-auto px-4 py-10 md:py-14">
+      <article class="prose prose-slate rtl max-w-none text-sm md:text-base leading-7 bg-white/80 backdrop-blur-sm border border-slate-200 rounded-2xl shadow-sm p-6 md:p-10">
+        <h2 class="text-lg font-bold mb-4">بیانیهٔ شفافیت، امنیت و حکمرانی داده در WESH360</h2>
+        <p><strong>هدف ما:</strong> مصورسازی داده‌های <strong>عملکرد زنجیرهٔ تأمین انرژی و آب</strong> برای <strong>آگاهی‌بخشی، هم‌افزایی و اطلاع‌رسانی عمومی</strong>—به‌زبان ساده، دقیق و قابل‌اتکا.<br><strong>خط قرمز ما:</strong> <strong>امنیت سایبری و امنیت داده</strong>.</p>
+        <hr />
+        <h2>۱) دامنهٔ داده و فلسفهٔ انتشار</h2>
+        <ul>
+          <li>تنها <strong>داده‌های عمومی و عملیاتیِ غیرشخصی</strong> مرتبط با آب، برق، گاز و فرآورده‌های نفتی را در سطح <strong>استان/شهر</strong> نمایش می‌دهیم.</li>
+          <li>هدف از انتشار، <strong>تصویر کلان و آموزشی</strong> از وضعیت است؛ نه نمایش جزئیات حساس یا قابلیت سوء‌استفادهٔ عملیاتی.</li>
+        </ul>
+        <h2>۲) چه نمایش می‌دهیم / چه نمایش نمی‌دهیم</h2>
+        <p><strong>نمایش می‌دهیم:</strong></p>
+        <ul>
+          <li>روندها و شاخص‌های تجمیعی (مصرف/تقاضا، پیک روز گذشته، تلفات کلان، ترکیب سوخت و شدت کربن، شاخص‌های کیفیت خدمت در سطح استان/شهر، شبیه‌سازهای آموزشی مانند قبض).</li>
+          <li>متادادهٔ هر نمودار: <strong>زمان آخرین به‌روزرسانی</strong>، <strong>منبع داده</strong> (در صورت وجود)، و <strong>برچسب سطح انتشار</strong>.</li>
+        </ul>
+        <p><strong>نمایش نمی‌دهیم:</strong></p>
+        <ul>
+          <li><strong>مختصات دقیق شبکه</strong>، <strong>نقشه‌های تک‌لاین</strong>, <strong>نام و نشانی ریزدانهٔ تأسیسات/مخازن/خطوط</strong>, <strong>موجودی دقیق ذخایر</strong>, و <strong>اعداد بلادرنگ</strong> که حساسیت عملیاتی ایجاد می‌کنند.</li>
+          <li>هرگونه جزئیات قابل انتساب که به <strong>واحد مشخص</strong> (مثلاً یک نیروگاه/بلوک خاص) اشارهٔ مستقیم کند.</li>
+        </ul>
+        <h2>۳) اصول امنیت و محرمانگی</h2>
+        <ul>
+          <li><strong>تجمیع و تاخیر ایمن:</strong> انتشار عمومی با <strong>تاخیر حداقل ۴۸–۷۲ ساعت</strong> برای شاخص‌های حساس؛ مقادیر در نسخهٔ عمومی <strong>گرد</strong> می‌شوند.</li>
+          <li><strong>حداقل‌گرایی اطلاعاتی:</strong> تنها آنچه برای فهم عمومی لازم است نمایش می‌دهیم (اصل Minimum Necessary).</li>
+          <li><strong>سطح‌بندی دسترسی (RBAC):</strong> داده و داشبوردها با برچسب‌های <strong>Public / Internal / Restricted</strong> مدیریت می‌شوند.</li>
+          <li><strong>حذف ریزدانه‌گی مکانی/عملیاتی:</strong> از انتشار هر داده‌ای که امکان <strong>بازشناسایی تأسیسات</strong> یا <strong>بازسازی وضعیت لحظه‌ای شبکه</strong> بدهد، خودداری می‌کنیم.</li>
+          <li><strong>پایداری و تاب‌آوری:</strong> کنترل‌های امنیت سایبری، لاگ‌برداری دسترسی، و نسخه‌پشتیبان متناسب با ریسک.</li>
+        </ul>
+        <h2>۴) سیاست برچسب‌گذاری محتوا</h2>
+        <ul>
+          <li><strong>Public:</strong> دادهٔ تجمیعی استان/شهر با تاخیر ایمن و گردکردن؛ بدون نام/مختصات تأسیسات.</li>
+          <li><strong>Internal:</strong> جزئیات بیشتر در سطح شهر/بخش با تاخیر کوتاه‌تر؛ همچنان بدون نقشهٔ حساس یا موجودی دقیق.</li>
+          <li><strong>Restricted:</strong> مواردی مانند برنامه/حادثهٔ تعمیرات، قیود شبکه، یا تحلیل‌های حساس که صرفاً نزد متولیان باقی می‌ماند.</li>
+        </ul>
+        <blockquote>کنار هر کاشی، یک <strong>Badge</strong> شامل سطح انتشار + زمان آخرین به‌روزرسانی درج می‌شود.</blockquote>
+        <h2>۵) حکمرانی داده‌مبنا (Data Governance)</h2>
+        <ul>
+          <li><strong>نقش‌ها و مالکیت (RACI):</strong> برای هر جریان داده، مالک کسب‌وکاری و فنی مشخص است.</li>
+          <li><strong>کاتالوگ و شناسنامهٔ داده:</strong> تعریف یکنواخت میدان‌ها، واحدها و منابع برای جلوگیری از تفسیر سلیقه‌ای.</li>
+          <li><strong>کیفیت داده (DQ):</strong> کنترل کامل‌بودن، سازگاری زمانی/واحدی، و ثبت «نسخهٔ داده» روی هر انتشار.</li>
+          <li><strong>تبار داده (Lineage):</strong> مسیر تولید شاخص‌ها از منبع تا نمودار قابل ردیابی است.</li>
+          <li><strong>نسخه‌بندی و بایگانی:</strong> نگهداشت خروجی‌ها با شماره نسخه و تاریخ انتشار.</li>
+        </ul>
+        <h2>۶) انطباق با مادهٔ ۱۰۷ «برنامهٔ هفتم توسعه»</h2>
+        <p>WESH360 خود را با روح و مفاد مادهٔ ۱۰۷—در حوزهٔ دولت هوشمند و حکمرانی داده—هماهنگ می‌کند:</p>
+        <ul>
+          <li><strong>الف) یکپارچگی زیرساختی:</strong> استفاده از <strong>درگاه‌ها و APIهای رسمی</strong> دستگاه‌ها؛ پرهیز از ایجاد انباره‌های موازی.</li>
+          <li><strong>ب) پشتیبانی از نوآوری و امنیت:</strong> ارائهٔ داشبوردهای پایش کیفیت/پیشرفت برای معاونت‌های «نوآوری، هوشمندسازی و امنیت» دستگاه‌های همکار.</li>
+          <li><strong>پ) استقرار حکمرانی داده در چرخهٔ هوشمندسازی:</strong> الگوهای اجرایی (Policy JSON، کاتالوگ داده، چک‌لیست کیفیت) برای تسهیل تدوین برنامه و <strong>پایش‌پذیری</strong> آن.</li>
+          <li><strong>ت) حذف موازی‌کاری سامانه‌ها:</strong> هر توسعهٔ فرابخشی مشروط به مجوز مرجع ذی‌صلاح و هم‌راستا با سامانه‌های مشترک است.</li>
+          <li><strong>ث) ارتقای شاخص‌های دولت هوشمند:</strong> رصد دوره‌ای شاخص‌هایی مانند یکپارچگی تبادل داده، درصد خدمات دیجیتال و کیفیت تجربهٔ کاربر.</li>
+          <li><strong>ج) اتصال برخط امن و پنجرهٔ ملی:</strong> نمایش مسیرهای کاربر و پیوند به «پنجرهٔ ملی خدمات دولت هوشمند» برای خدمت‌رسانی یکپارچه.</li>
+          <li><strong>چ) تبادل بین‌دستگاهی و پایگاه‌های پایه:</strong> به‌محض تکمیل پایگاه‌های پایه، تبادل <strong>برخط و قانونی</strong> و ثبت تبار داده در انتشار شاخص‌ها.</li>
+          <li><strong>ح) حذف دریافت دستی مدارک پایه:</strong> تکیه بر <strong>استعلام‌های برخط</strong> و عدم مطالبهٔ مدارک تکراری از مخاطبان.</li>
+          <li><strong>خ) پایش طرح‌های پیشران تحول دیجیتال:</strong> داشبوردهای مدیریتی برای رصد اجرا، تامین مالی و ریسک‌های طرح‌ها.</li>
+        </ul>
+        <h2>۷) روش‌شناسی و شفافیت محاسبات</h2>
+        <ul>
+          <li>هر نمودار/کارت با <strong>Tooltip روش محاسبه</strong> (فرمول، واحد، دامنهٔ زمانی) و در صورت لزوم <strong>بازهٔ ضرایب</strong> همراه است.</li>
+          <li>در نبود دادهٔ رسمیِ باز، از <strong>نمونه‌سازی آموزشی</strong> با برچسب صریح «آموزشی/تقریبی» استفاده می‌شود تا مخاطب دچار خطا نشود.</li>
+        </ul>
+        <h2>۸) مشارکت و هم‌افزایی</h2>
+        <ul>
+          <li>ما از <strong>بازخورد تخصصی</strong> و <strong>گزارش‌های مردمی</strong> برای بهبود کیفیت و پوشش شاخص‌ها استقبال می‌کنیم.</li>
+          <li>پیشنهادهای شما برای توسعهٔ داشبوردها، باعث <strong>ارتقای فهم مشترک</strong> بین شهروندان، رسانه و تصمیم‌گیران می‌شود.</li>
+        </ul>
+        <h2>۹) گزارش مسئولانهٔ آسیب‌پذیری</h2>
+        <ul>
+          <li>اگر نکته‌ای امنیتی مشاهده کردید، لطفاً در صفحهٔ <strong><a href="/security">/security</a></strong> اطلاع دهید یا ایمیل بزنید به: <strong>security@wesh360.ir</strong> (در صورت تغییر، در سایت به‌روزرسانی می‌شود).</li>
+          <li>ما گزارش‌های با حسن نیت را ارج می‌نهیم و پس از رفع، نتیجه را به‌صورت شفاف اعلام می‌کنیم.</li>
+        </ul>
+      </article>
+    </section>
+  </main>
+
+  <footer class="mt-auto" data-component="global-footer"></footer>
+  <script defer src="../assets/global-footer.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `docs/security-policy/index.html` page that surfaces the security and data governance policy content
- update homepage and research navigation links to point to `/security-policy` instead of the removed modal triggers

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68dccdff20508328a741d28a358aea14