### PR TITLE
Add static responsible disclosure page and update nav

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -31,10 +31,10 @@
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و حکمرانی داده</span>
         </a>
-        <button id="securityBtn" type="button" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-haspopup="dialog" aria-controls="securitySheet" title="گزارش مسئولانهٔ آسیب‌پذیری">
+        <a href="/responsible-disclosure/" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="گزارش مسئولانهٔ آسیب‌پذیری">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
           <span>گزارش مسئولانهٔ آسیب‌پذیری</span>
-        </button>
+        </a>
         <a href="/research/" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-label="پژوهشگران" title="پژوهشگران">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" /><path d="M6.453 15h11.094" /><path d="M8.5 2h7" /></svg>
           <span>پژوهشگران</span>
@@ -169,39 +169,6 @@
     </div>
   </div>
 
-  <!-- Security Sheet -->
-  <div id="securitySheet" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true" aria-labelledby="securityTitle">
-    <div class="absolute inset-0 bg-black/60" data-close></div>
-    <div class="fixed inset-y-0 right-0 w-full md:inset-0 md:flex md:items-center md:justify-center">
-      <div class="w-full md:max-w-screen-md h-full md:h-auto md:max-h-[90vh] bg-white overflow-y-auto p-6 shadow-lg">
-        <div class="flex items-start justify-between mb-4">
-          <h2 id="securityTitle" class="text-lg font-bold" tabindex="-1">گزارش مسئولانهٔ آسیب‌پذیری</h2>
-          <button class="text-slate-500 hover:text-slate-700" data-close aria-label="بستن">×</button>
-        </div>
-        <div class="prose prose-slate rtl max-w-none text-sm leading-7">
-          <h2>گزارش مسئولانهٔ آسیب‌پذیری</h2>
-          <p>ما قدردان گزارش‌های با حسن نیت هستیم. امنیت سایبری و امنیت داده، خط قرمز ماست.<br>لطفاً پیش از انتشار عمومی، موضوع را به‌صورت محرمانه برای ما ارسال کنید تا بررسی و برطرف شود.</p>
-          <h3>چگونه گزارش بدهم؟</h3>
-          <ol>
-            <li>شرح مختصر مسئله، گام‌های بازتولید، دامنه/URL‌های درگیر</li>
-            <li>اسکرین‌شات یا PoC غیر مخرب (در حد امکان)</li>
-            <li>راه ارتباطی شما برای پیگیری</li>
-          </ol>
-          <h3>کانال‌های گزارش</h3>
-          <ul>
-            <li>صفحه اختصاصی: /security</li>
-            <li>ایمیل: security@wesh360.ir</li>
-          </ul>
-          <blockquote>پس از دریافت، ظرف مدت معقول پاسخ می‌دهیم و در صورت تایید، پس از رفع، نتیجه را به‌طور شفاف اعلام خواهیم کرد.</blockquote>
-        </div>
-        <div class="mt-6">
-          <a href="mailto:security@wesh360.ir?subject=WESH360%20Vulnerability%20Report" class="inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-sky-600 hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400">ارسال گزارش</a>
-        </div>
-        <p class="mt-6 text-xs text-slate-500">آخرین به‌روزرسانی: <span data-last-updated></span></p>
-      </div>
-    </div>
-  </div>
-
   <!-- Mobile actions sheet -->
   <div id="mobileActionsSheet" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true" aria-labelledby="mobileActionsTitle">
     <div class="absolute inset-0 bg-black/60" data-close></div>
@@ -211,10 +178,10 @@
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
         <span>سیاست امنیت و حکمرانی داده</span>
       </a>
-      <button id="mobileSecurityBtn" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-controls="securitySheet">
+      <a href="/responsible-disclosure/" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
         <span>گزارش مسئولانهٔ آسیب‌پذیری</span>
-      </button>
+      </a>
       <a href="/research/" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-label="پژوهشگران" title="پژوهشگران">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" /><path d="M6.453 15h11.094" /><path d="M8.5 2h7" /></svg>
         <span>پژوهشگران</span>

--- a/docs/index.js
+++ b/docs/index.js
@@ -136,7 +136,6 @@ import { setClass } from './assets/css-classes.js';
   }
 
   const policySheet = document.getElementById('policySheet');
-  const securitySheet = document.getElementById('securitySheet');
   const mobileSheet = document.getElementById('mobileActionsSheet');
 
   function bindTrigger(btn, targetSheet, closeSheetEl) {
@@ -145,26 +144,23 @@ import { setClass } from './assets/css-classes.js';
       if (closeSheetEl) closeSheet(closeSheetEl);
       openSheet(targetSheet);
       if (targetSheet === policySheet) console.log('policy_open');
-      else if (targetSheet === securitySheet) console.log('security_open');
     });
   }
 
   bindTrigger(document.getElementById('policyBtn'), policySheet);
-  bindTrigger(document.getElementById('securityBtn'), securitySheet);
   bindTrigger(document.getElementById('mobileActionsBtn'), mobileSheet);
   bindTrigger(document.getElementById('mobilePolicyBtn'), policySheet, mobileSheet);
-  bindTrigger(document.getElementById('mobileSecurityBtn'), securitySheet, mobileSheet);
 
   document.querySelectorAll('[data-close]').forEach(el => {
     el.addEventListener('click', e => {
-      const sheet = e.target.closest('#policySheet, #securitySheet, #mobileActionsSheet');
+      const sheet = e.target.closest('#policySheet, #mobileActionsSheet');
       closeSheet(sheet);
     });
   });
 
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
-      [policySheet, securitySheet, mobileSheet].forEach(closeSheet);
+      [policySheet, mobileSheet].forEach(closeSheet);
     }
   });
 })();

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -22,10 +22,10 @@
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
         <span>سیاست امنیت و حکمرانی داده</span>
       </a>
-      <button id="securityBtn" type="button" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-haspopup="dialog" aria-controls="securitySheet" title="گزارش مسئولانهٔ آسیب‌پذیری">
+      <a href="/responsible-disclosure/" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="گزارش مسئولانهٔ آسیب‌پذیری">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
         <span>گزارش مسئولانهٔ آسیب‌پذیری</span>
-      </button>
+      </a>
       <a href="/research/" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-label="پژوهشگران" title="پژوهشگران">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" /><path d="M6.453 15h11.094" /><path d="M8.5 2h7" /></svg>
         <span>پژوهشگران</span>
@@ -86,22 +86,6 @@
     </div>
   </div>
 
-  <div id="securitySheet" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true" aria-labelledby="securityTitle">
-    <div class="absolute inset-0 bg-black/60" data-close></div>
-    <div class="fixed inset-y-0 right-0 w-full md:inset-0 md:flex md:items-center md:justify-center">
-      <div class="w-full md:max-w-screen-md h-full md:h-auto md:max-h-[90vh] bg-white overflow-y-auto p-6 shadow-lg">
-        <div class="flex items-start justify-between mb-4">
-          <h2 id="securityTitle" class="text-lg font-bold" tabindex="-1">گزارش مسئولانهٔ آسیب‌پذیری</h2>
-          <button class="text-slate-500 hover:text-slate-700" data-close aria-label="بستن">×</button>
-        </div>
-        <p class="prose prose-slate rtl max-w-none text-sm leading-7">ما قدردان گزارش‌های با حسن نیت هستیم. امنیت سایبری و امنیت داده، خط قرمز ماست. لطفاً پیش از انتشار عمومی، موضوع را به‌صورت محرمانه برای ما ارسال کنید تا بررسی و برطرف شود.</p>
-        <div class="mt-6">
-          <a href="mailto:security@wesh360.ir?subject=WESH360%20Vulnerability%20Report" class="inline-flex items-center justify-center rounded-lg px-4 py-2 text-sm font-medium text-white bg-sky-600 hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400">ارسال گزارش</a>
-        </div>
-      </div>
-    </div>
-  </div>
-
   <div id="mobileActionsSheet" class="fixed inset-0 z-50 hidden" role="dialog" aria-modal="true" aria-labelledby="mobileActionsTitle">
     <div class="absolute inset-0 bg-black/60" data-close></div>
     <div class="fixed inset-y-0 right-0 w-64 bg-white p-6 shadow-lg overflow-y-auto flex flex-col gap-3">
@@ -110,10 +94,10 @@
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
         <span>سیاست امنیت و حکمرانی داده</span>
       </a>
-      <button id="mobileSecurityBtn" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-controls="securitySheet">
+      <a href="/responsible-disclosure/" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
         <span>گزارش مسئولانهٔ آسیب‌پذیری</span>
-      </button>
+      </a>
       <a href="/research/" class="flex items-center gap-2 text-sm font-medium text-slate-700 border border-slate-300 rounded-lg px-3 py-2 hover:bg-slate-100" aria-label="پژوهشگران" title="پژوهشگران">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" /><path d="M6.453 15h11.094" /><path d="M8.5 2h7" /></svg>
         <span>پژوهشگران</span>

--- a/docs/research/index.js
+++ b/docs/research/index.js
@@ -20,7 +20,6 @@
   }
 
   const policySheet = document.getElementById('policySheet');
-  const securitySheet = document.getElementById('securitySheet');
   const mobileSheet = document.getElementById('mobileActionsSheet');
   const requestSheet = document.getElementById('requestSheet');
   const proposalSheet = document.getElementById('proposalSheet');
@@ -34,23 +33,21 @@
   }
 
   bindTrigger(document.getElementById('policyBtn'), policySheet);
-  bindTrigger(document.getElementById('securityBtn'), securitySheet);
   bindTrigger(document.getElementById('mobileActionsBtn'), mobileSheet);
   bindTrigger(document.getElementById('mobilePolicyBtn'), policySheet, mobileSheet);
-  bindTrigger(document.getElementById('mobileSecurityBtn'), securitySheet, mobileSheet);
   bindTrigger(document.getElementById('openRequest'), requestSheet);
   bindTrigger(document.getElementById('openProposal'), proposalSheet);
 
   document.querySelectorAll('[data-close]').forEach(el => {
     el.addEventListener('click', e => {
-      const sheet = e.target.closest('#policySheet, #securitySheet, #mobileActionsSheet, #requestSheet, #proposalSheet');
+      const sheet = e.target.closest('#policySheet, #mobileActionsSheet, #requestSheet, #proposalSheet');
       closeSheet(sheet);
     });
   });
 
   document.addEventListener('keydown', e => {
     if (e.key === 'Escape') {
-      [policySheet, securitySheet, mobileSheet, requestSheet, proposalSheet].forEach(closeSheet);
+      [policySheet, mobileSheet, requestSheet, proposalSheet].forEach(closeSheet);
     }
   });
 

--- a/docs/responsible-disclosure/index.html
+++ b/docs/responsible-disclosure/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="Content-Language" content="fa-IR" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>گزارش مسئولانهٔ آسیب‌پذیری • WESH360</title>
+  <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="../assets/fonts.css" />
+  <link rel="stylesheet" href="/assets/global-footer.css" />
+  <link rel="stylesheet" href="/assets/unified-badge.css" />
+  <script defer src="/assets/unified-badge.js"></script>
+  <script defer src="/assets/global-footer.js"></script>
+</head>
+<body class="min-h-screen flex flex-col bg-gradient-to-b from-slate-50 via-sky-50/70 to-white">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="relative p-4 flex justify-center items-center">
+    <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
+    <div class="absolute top-4 right-4 flex items-center gap-2">
+      <a href="/security-policy" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="سیاست امنیت و حکمرانی داده">
+        <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
+        <span>سیاست امنیت و حکمرانی داده</span>
+      </a>
+      <a href="/responsible-disclosure/" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="گزارش مسئولانهٔ آسیب‌پذیری" aria-current="page">
+        <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
+        <span>گزارش مسئولانهٔ آسیب‌پذیری</span>
+      </a>
+      <a href="/research/" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-label="پژوهشگران" title="پژوهشگران">
+        <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" /><path d="M6.453 15h11.094" /><path d="M8.5 2h7" /></svg>
+        <span>پژوهشگران</span>
+      </a>
+      <a href="/responsible-disclosure/" class="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-lg border border-slate-300 bg-white/80 text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="گزارش مسئولانهٔ آسیب‌پذیری">
+        <svg class="w-5 h-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
+      </a>
+    </div>
+  </header>
+  <main id="main" class="flex-grow">
+    <section class="max-w-4xl mx-auto px-4 py-10 md:py-14 space-y-6">
+      <header class="space-y-3 text-center">
+        <h1 class="text-2xl md:text-4xl font-extrabold text-slate-900">گزارش مسئولانهٔ آسیب‌پذیری</h1>
+        <p class="text-slate-600 md:text-lg">امنیت سایبری و امنیت داده خط قرمز خانهٔ هم‌افزایی انرژی و آب است. پیش از انتشار عمومی، یافته‌های امنیتی را به‌صورت محرمانه گزارش کنید تا بررسی و برطرف شود.</p>
+      </header>
+      <article class="bg-white/90 border border-slate-200 rounded-2xl p-6 space-y-4 text-sm leading-7 text-slate-700 prose prose-slate rtl max-w-none">
+        <h2>اصول برنامه</h2>
+        <ul>
+          <li>گزارش‌های با حسن نیت را ارج می‌نهیم و از پژوهشگران امنیتی سپاسگزاریم.</li>
+          <li>فقط داده‌های عمومی، تجمیعی و با تاخیر ایمن در داشبوردها نمایش داده می‌شود.</li>
+          <li>مهلت معقولی برای بررسی، رفع و انتشار عمومی نتیجه در نظر گرفته می‌شود.</li>
+        </ul>
+        <h2>چه چیزی را گزارش دهیم؟</h2>
+        <ol>
+          <li>شرح مختصر مسئله، دامنه و گام‌های بازتولید.</li>
+          <li>محدودهٔ تأثیر و سطح دسترسی موردنیاز.</li>
+          <li>شواهد پشتیبان (اسکرین‌شات یا PoC غیرمخرب).</li>
+        </ol>
+        <h2>کانال‌های ارتباطی</h2>
+        <ul>
+          <li>ایمیل: <a href="mailto:security@wesh360.ir" class="text-sky-700 hover:underline">security@wesh360.ir</a></li>
+          <li>پیام رمزگذاری‌شدهٔ PGP (درخواست کلید از طریق ایمیل).</li>
+        </ul>
+        <h2>قواعد همکاری مسئولانه</h2>
+        <ul>
+          <li>از افشای عمومی قبل از رفع یا هماهنگی با ما خودداری کنید.</li>
+          <li>از بهره‌برداری فراتر از حداقل لازم برای اثبات آسیب‌پذیری بپرهیزید.</li>
+          <li>از تعامل با داده‌های شخصی، حساب‌های کاربری و زیرساخت‌های خارج از دامنهٔ رسمی خودداری کنید.</li>
+        </ul>
+      </article>
+      <div class="flex flex-col sm:flex-row gap-3 justify-center">
+        <a href="mailto:security@wesh360.ir?subject=WESH360%20Vulnerability%20Report" class="inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-medium text-white bg-sky-600 hover:bg-sky-700 focus:outline-none focus:ring-2 focus:ring-sky-400">
+          ارسال ایمیل گزارش
+        </a>
+        <a href="/security-policy" class="inline-flex items-center justify-center gap-2 rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-700 hover:bg-slate-50 focus:outline-none focus:ring-2 focus:ring-sky-400">
+          سیاست امنیت و حکمرانی داده
+        </a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `/responsible-disclosure/` page outlining the vulnerability reporting program
- update landing and research headers/mobile menus to link to the new page instead of opening the removed modal
- clean up related JavaScript bindings that referenced the old security sheet

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68dcd20cf6208328b44420b3c2f76ca6