### PR TITLE
test(responsive): add stable Playwright audit (serves docs/, blocks 3…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,10 @@ backend/.env
 
 # MCP artifacts
 .mcp-artifacts/
+
+# Audit artifacts
+/docs/dev/reports/responsive/
+/test-results/
+/playwright-report/
+/blob-report/
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,11 @@
       "devDependencies": {
         "@babel/cli": "^7.28.3",
         "@babel/preset-react": "^7.27.1",
+        "@playwright/test": "^1.55.1",
         "@tsconfig/recommended": "^1.0.10",
         "clean-css": "^5.3.3",
         "cross-env": "^10.0.0",
+        "fast-glob": "^3.3.3",
         "fs-extra": "^11.3.1",
         "glob": "^11.0.3",
         "http-server": "^14.1.1",
@@ -1512,6 +1514,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@puppeteer/browsers": {
@@ -5574,6 +5592,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,11 @@
     "audit:cld:rewire": "node tools/cld-rewire-plan.js",
     "audit:cld:arch": "node tools/cld-data-architecture-audit.js",
     "audit:cld:connect": "node tools/cld-connection-audit.js",
-    "audit:cld:all": "npm run audit:cld:files && npm run audit:cld:runtime && npm run audit:cld:rewire"
+    "audit:cld:all": "npm run audit:cld:files && npm run audit:cld:runtime && npm run audit:cld:rewire",
+    "audit:responsive": "playwright test -c tests/playwright.config.ts --project=desktop --reporter=list",
+    "audit:responsive:all": "PW_ALL=1 playwright test -c tests/playwright.config.ts --project=desktop --reporter=list",
+    "audit:responsive:apply": "PW_APPLY=1 playwright test -c tests/playwright.config.ts --project=desktop --reporter=list",
+    "serve:docs": "http-server docs -p 5050 -c-1 --silent"
   },
   "keywords": [],
   "author": "",
@@ -54,9 +58,11 @@
   "devDependencies": {
     "@babel/cli": "^7.28.3",
     "@babel/preset-react": "^7.27.1",
+    "@playwright/test": "^1.55.1",
     "@tsconfig/recommended": "^1.0.10",
     "clean-css": "^5.3.3",
     "cross-env": "^10.0.0",
+    "fast-glob": "^3.3.3",
     "fs-extra": "^11.3.1",
     "glob": "^11.0.3",
     "http-server": "^14.1.1",

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -1,0 +1,22 @@
+﻿import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './specs',
+  timeout: 90_000,
+  retries: 1,
+  use: {
+    baseURL: 'http://127.0.0.1:5050',
+    viewport: { width: 1280, height: 800 },
+    screenshot: 'only-on-failure',
+    trace: 'off',
+  },
+  webServer: {
+    command: 'npm run serve:docs',
+    port: 5050,
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
+  projects: [
+    { name: 'desktop' },
+  ],
+});

--- a/tests/specs/responsive.spec.ts
+++ b/tests/specs/responsive.spec.ts
@@ -1,0 +1,193 @@
+﻿import { test, expect } from '@playwright/test';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+
+const VIEWPORTS = [
+  { width: 320, height: 640 },
+  { width: 360, height: 780 },
+  { width: 390, height: 844 },
+  { width: 414, height: 896 },
+  { width: 768, height: 1024 },
+  { width: 1024, height: 1366 },
+  { width: 1280, height: 800 },
+  { width: 1366, height: 768 },
+  { width: 1440, height: 900 },
+  { width: 1920, height: 1080 },
+] as const;
+
+const CSS_RULES = [
+  'img,svg,canvas,video,iframe{max-width:100%;height:auto}',
+  'table{display:block;overflow-x:auto;width:100%}',
+  '.row,.grid,.cards{flex-wrap:wrap}',
+  '[data-nowrap]{white-space:nowrap}',
+].join('\n');
+
+const CSS_PATH = resolve(process.cwd(), 'docs/assets/css/responsive-fixes.css');
+const INDEX_PATH = resolve(process.cwd(), 'docs/index.html');
+
+const viewportLabel = (viewport: { width: number; height: number }) => `${viewport.width}x${viewport.height}`;
+
+const shouldApplyFixes = () => {
+  const value = process.env.PW_APPLY;
+  if (!value) return false;
+  const lowered = value.toLowerCase();
+  return lowered !== '0' && lowered !== 'false';
+};
+
+const ensureCssFile = async () => {
+  await mkdir(dirname(CSS_PATH), { recursive: true });
+  if (!existsSync(CSS_PATH)) {
+    await writeFile(CSS_PATH, `${CSS_RULES}\n`, 'utf8');
+    return;
+  }
+  const current = await readFile(CSS_PATH, 'utf8');
+  if (!current.includes('img,svg,canvas,video,iframe{max-width:100%;height:auto}')) {
+    await writeFile(CSS_PATH, `${CSS_RULES}\n`, 'utf8');
+  }
+};
+
+const ensureCssLink = async () => {
+  if (!existsSync(INDEX_PATH)) return;
+  const html = await readFile(INDEX_PATH, 'utf8');
+  if (html.includes('responsive-fixes.css')) {
+    return;
+  }
+  const linkBlock = `\n  <!-- Responsive audit fixes -->\n  <link rel="stylesheet" href="./assets/css/responsive-fixes.css">`;
+  const updated = html.replace('</head>', `${linkBlock}\n</head>`);
+  if (updated === html) {
+    throw new Error('Could not inject responsive-fixes.css link into index.html');
+  }
+  await writeFile(INDEX_PATH, updated, 'utf8');
+};
+
+const offenderNote = (offenders: Array<{ selector: string; w: number; vw: number }>) => {
+  if (!offenders.length) return '';
+  const sample = offenders.slice(0, 3).map((item) => `${item.selector} (${item.w.toFixed(1)}px > ${item.vw}px)`).join('; ');
+  return ` offenders: ${sample}`;
+};
+
+test.describe.configure({ mode: 'serial' });
+
+test('Responsive pages stay within viewport bounds', async ({ page }, testInfo) => {
+  const baseURL = testInfo.project.use?.baseURL ?? 'http://127.0.0.1:5050';
+  const [{ getPageList }, { createReportWriter }] = await Promise.all([
+    import('../utils/pageList.mjs'),
+    import('../utils/report.mjs'),
+  ]);
+
+  const entries = await getPageList();
+  if (!entries.length) {
+    test.skip(true, 'No HTML pages found under docs/ for responsive audit');
+  }
+
+  const report = await createReportWriter();
+  const summaryPages: Array<{
+    url: string;
+    relativePath: string;
+    results: Array<{
+      viewport: { width: number; height: number };
+      overflow: boolean;
+      offenders: Array<{ selector: string; w: number; vw: number }>;
+      screenshot: string;
+      json: string;
+    }>;
+  }> = [];
+
+  const applyFixes = shouldApplyFixes();
+  let cssWritten = false;
+  let linkUpdated = false;
+
+  const allowedHost = /(?:localhost|127\.0\.0\.1)/i;
+
+  await page.route('**/*', (route) => {
+    const requestUrl = route.request().url();
+    if (requestUrl.startsWith('about:') || requestUrl.startsWith('data:') || requestUrl.startsWith('blob:')) {
+      return route.continue();
+    }
+    if (requestUrl.startsWith(baseURL)) {
+      return route.continue();
+    }
+    if (allowedHost.test(requestUrl)) {
+      return route.continue();
+    }
+    return route.abort();
+  });
+
+  try {
+    for (const entry of entries) {
+      const pageSummary = { url: entry.url, relativePath: entry.relativePath, results: [] as Array<{ viewport: { width: number; height: number }; overflow: boolean; offenders: Array<{ selector: string; w: number; vw: number }>; screenshot: string; json: string }> };
+      for (const viewport of VIEWPORTS) {
+        const label = viewportLabel(viewport);
+        await test.step(`${entry.url} @ ${label}`, async () => {
+          await page.setViewportSize(viewport);
+          const target = new URL(entry.url, baseURL).toString();
+          await page.goto(target, { waitUntil: 'domcontentloaded' });
+          await page.waitForSelector('body', { timeout: 15_000 });
+          const evaluation = await page.evaluate(() => {
+            const doc = document.documentElement;
+            const overflow = doc.scrollWidth > doc.clientWidth;
+            const offenders: Array<{ selector: string; w: number; vw: number }> = [];
+            if (overflow) {
+              const elements = Array.from(document.querySelectorAll('body *')) as HTMLElement[];
+              for (const el of elements) {
+                const rect = el.getBoundingClientRect();
+                if (rect.width > window.innerWidth + 1) {
+                  let selector = '';
+                  if (el.id) {
+                    selector = `#${el.id}`;
+                  } else if (typeof el.className === 'string' && el.className.trim()) {
+                    selector = `.${el.className.trim().replace(/\s+/g, '.')}`;
+                  } else {
+                    selector = el.tagName.toLowerCase();
+                  }
+                  offenders.push({ selector, w: Number(rect.width.toFixed(2)), vw: window.innerWidth });
+                }
+              }
+            }
+            return { overflow, offenders };
+          });
+
+          const viewportLabelText = viewportLabel(viewport);
+          const expectation = expect.soft(evaluation.overflow, `${entry.url} overflow at ${viewportLabelText}${offenderNote(evaluation.offenders)}`);
+          expectation.toBeFalsy();
+
+          const artifacts = await report.artifactPaths(entry.safeName, viewportLabelText);
+          await page.screenshot({ path: artifacts.screenshotPath, fullPage: true });
+          const casePayload = {
+            url: entry.url,
+            relativePath: entry.relativePath,
+            viewport,
+            overflow: evaluation.overflow,
+            offenders: evaluation.offenders,
+          };
+          await writeFile(artifacts.jsonPath, `${JSON.stringify(casePayload, null, 2)}\n`, 'utf8');
+
+          pageSummary.results.push({
+            viewport,
+            overflow: evaluation.overflow,
+            offenders: evaluation.offenders,
+            screenshot: artifacts.relativeScreenshot,
+            json: artifacts.relativeJson,
+          });
+
+          if (evaluation.overflow && applyFixes) {
+            if (!cssWritten) {
+              await ensureCssFile();
+              cssWritten = true;
+            }
+            if (!linkUpdated) {
+              await ensureCssLink();
+              linkUpdated = true;
+            }
+          }
+        });
+      }
+      summaryPages.push(pageSummary);
+    }
+  } finally {
+    await page.unroute('**/*');
+  }
+
+  await report.writeSummary(summaryPages);
+});

--- a/tests/utils/pageList.mjs
+++ b/tests/utils/pageList.mjs
@@ -1,0 +1,86 @@
+﻿import fg from 'fast-glob';
+import { existsSync } from 'node:fs';
+import { resolve, join, relative, sep } from 'node:path';
+
+const DOCS_ROOT = resolve(process.cwd(), 'docs');
+const CURATED = [
+  '/index.html',
+  '/dash/',
+  '/water/',
+  '/electricity/',
+  '/gas/',
+  '/oil/',
+];
+
+const SLASH = '/';
+
+const toPosix = (value) => value.split(sep).join(SLASH);
+
+const toSafeName = (url) => {
+  const trimmed = url.replace(/^\/+/, '');
+  const dashed = trimmed.replace(/\//g, '-').replace(/\.+/g, '-');
+  const safe = dashed.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  return safe.length ? safe : 'root';
+};
+
+const dedupe = (list) => Array.from(new Set(list));
+
+const ensureCuratedPath = (entry) => {
+  const trimmed = entry.replace(/^\/+/, '');
+  if (!trimmed) return null;
+  const base = trimmed.replace(/\/$/, '');
+  const candidates = [];
+  if (trimmed.endsWith('/')) {
+    candidates.push(join(base, 'index.html'));
+    candidates.push(`${base}.html`);
+  } else {
+    candidates.push(trimmed);
+    candidates.push(join(trimmed, 'index.html'));
+  }
+
+  for (const candidate of dedupe(candidates)) {
+    const absolute = resolve(DOCS_ROOT, candidate);
+    if (existsSync(absolute)) {
+      return toPosix(candidate);
+    }
+  }
+  return null;
+};
+
+export const filePathToUrl = (filePath) => {
+  const rel = toPosix(relative(DOCS_ROOT, filePath));
+  const cleaned = rel.startsWith(SLASH) ? rel.slice(1) : rel;
+  return `${SLASH}${cleaned}`;
+};
+
+export const getPageList = async () => {
+  const shouldScanAll = Boolean(process.env.PW_ALL && process.env.PW_ALL !== '0');
+  if (shouldScanAll) {
+    const matches = await fg('**/*.html', {
+      cwd: DOCS_ROOT,
+      ignore: ['assets/**', 'dev/**'],
+      dot: false,
+    });
+    return matches
+      .map((rel) => ({
+        relativePath: toPosix(rel),
+        url: `${SLASH}${toPosix(rel)}`,
+        safeName: toSafeName(toPosix(rel)),
+        absolutePath: resolve(DOCS_ROOT, rel),
+      }))
+      .sort((a, b) => a.url.localeCompare(b.url));
+  }
+
+  const resolved = CURATED.map(ensureCuratedPath).filter(Boolean);
+  const unique = dedupe(resolved);
+  return unique
+    .map((rel) => ({
+      relativePath: rel,
+      url: `${SLASH}${rel}`,
+      safeName: toSafeName(rel),
+      absolutePath: resolve(DOCS_ROOT, rel),
+    }))
+    .sort((a, b) => a.url.localeCompare(b.url));
+};
+
+export const docsRoot = DOCS_ROOT;

--- a/tests/utils/report.mjs
+++ b/tests/utils/report.mjs
@@ -1,0 +1,82 @@
+﻿import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
+
+const REPORT_ROOT = resolve(process.cwd(), 'docs/dev/reports/responsive');
+
+const ensureDir = async (dir) => {
+  await mkdir(dir, { recursive: true });
+  return dir;
+};
+
+const stampRun = () => new Date().toISOString().replace(/[:.]/g, '-');
+
+const escapeHtml = (value) => String(value)
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
+const renderHtml = (payload) => {
+  const sections = payload.pages.map((page) => {
+    const items = page.results.map((result) => {
+      const offenderSummary = result.offenders && result.offenders.length
+        ? `<details><summary>Overflow offenders</summary><pre>${escapeHtml(JSON.stringify(result.offenders, null, 2))}</pre></details>`
+        : '';
+      const thumb = result.screenshot
+        ? `<a href="${result.screenshot}"><img src="${result.screenshot}" alt="${escapeHtml(page.url)} ${result.viewport.width}x${result.viewport.height}" width="320"></a>`
+        : '';
+      const dataLink = result.json ? ` (<a href="${result.json}">json</a>)` : '';
+      return `<li><strong>${result.viewport.width}x${result.viewport.height}</strong> - ${result.overflow ? 'FAIL' : 'PASS'}${dataLink}${thumb}${offenderSummary}</li>`;
+    }).join('\n');
+    return `<section><h2>${escapeHtml(page.url)}</h2><ul>${items}</ul></section>`;
+  }).join('\n');
+
+  return `<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><title>Responsive Audit ${payload.runId}</title></head><body><h1>Responsive Audit ${payload.runId}</h1><p>Generated at ${escapeHtml(payload.generatedAt)}</p>${sections}</body></html>`;
+};
+
+class ReportWriter {
+  constructor(runDir, stamp) {
+    this.runDir = runDir;
+    this.stamp = stamp;
+  }
+
+  get id() {
+    return this.stamp;
+  }
+
+  async ensurePageDir(pageSafeName) {
+    return ensureDir(join(this.runDir, pageSafeName));
+  }
+
+  async artifactPaths(pageSafeName, viewportLabel) {
+    const pageDir = await this.ensurePageDir(pageSafeName);
+    const screenshotPath = join(pageDir, `${viewportLabel}.png`);
+    const jsonPath = join(pageDir, `${viewportLabel}.json`);
+    return {
+      screenshotPath,
+      jsonPath,
+      relativeScreenshot: `${pageSafeName}/${viewportLabel}.png`,
+      relativeJson: `${pageSafeName}/${viewportLabel}.json`,
+    };
+  }
+
+  async writeSummary(pages) {
+    const payload = {
+      runId: this.stamp,
+      generatedAt: new Date().toISOString(),
+      pages,
+    };
+    await writeFile(join(this.runDir, 'summary.json'), `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+    await writeFile(join(this.runDir, 'index.html'), `${renderHtml(payload)}\n`, 'utf8');
+    return payload;
+  }
+}
+
+export const createReportWriter = async () => {
+  const stamp = stampRun();
+  const runDir = await ensureDir(resolve(REPORT_ROOT, stamp));
+  return new ReportWriter(runDir, stamp);
+};
+
+export const reportRoot = REPORT_ROOT;


### PR DESCRIPTION
…rd-party, reports artifacts)

chore: npm scripts & deps for audit pipeline
feat(home): soft-hide experimental CTAs + secret access (hotspots, URL, keyboard)
feat(forms): enable Netlify Forms (research-request/proposal) + thanks page
docs: add forms-audit for maintainers