### PR TITLE
Update landing cards for gas rename and environment stub

### DIFF
--- a/docs/assets/css/landing.css
+++ b/docs/assets/css/landing.css
@@ -117,6 +117,20 @@
     opacity: 1;
   }
 }
+
+.cards-section .card-sub {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: #334155;
+}
+
+/* cards grid: allow 4 columns on wide screens */
+@media (min-width: 1140px) {
+  .cards-section {
+    grid-template-columns: repeat(4, minmax(210px, 1fr));
+  }
+}
 /* === Household Wizard (landing) === */
 .wizard { max-width: 980px; margin: 24px auto 12px; padding: 16px; }
 .wiz-head { text-align: center; color: #0f172a; }

--- a/docs/environment/index.html
+++ b/docs/environment/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="fa" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Language" content="fa-IR" />
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta property="og:title" content="محیط زیست و پسماند | WESH360" />
+  <title>محیط زیست و پسماند | WESH360</title>
+  <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
+  <link rel="stylesheet" href="../assets/fonts.css" />
+  <link rel="stylesheet" href="../assets/global-footer.css" />
+  <link rel="stylesheet" href="../assets/unified-badge.css" />
+  <link rel="icon" type="image/png" href="../Logo.png" />
+</head>
+<body class="min-h-screen flex flex-col bg-slate-50">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="bg-white border-b border-slate-200">
+    <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
+      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+        <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
+        <span class="text-base md:text-lg">WESH360</span>
+      </a>
+      <nav class="hidden md:flex items-center gap-3 text-sm">
+        <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
+          <span>سیاست امنیت و حکمرانی داده</span>
+        </a>
+        <a href="/responsible-disclosure" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m8 2 1.88 1.88" /><path d="M14.12 3.88 16 2" /><path d="M9 7.13v-1a3.003 3.003 0 1 1 6 0v1" /><path d="M12 20c-3.3 0-6-2.7-6-6v-3a4 4 0 0 1 4-4h4a4 4 0 0 1 4 4v3c0 3.3-2.7 6-6 6" /><path d="M12 20v-9" /><path d="M6.53 9C4.6 8.8 3 7.1 3 5" /><path d="M6 13H2" /><path d="M3 21c0-2.1 1.7-3.9 3.8-4" /><path d="M20.97 5c0 2.1-1.6 3.8-3.5 4" /><path d="M22 13h-4" /><path d="M17.2 17c2.1.1 3.8 1.9 3.8 4" /></svg>
+          <span>ارتباط با ما</span>
+        </a>
+        <a href="/research/" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" aria-label="پژوهشگران" title="پژوهشگران">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2v6a2 2 0 0 0 .245.96l5.51 10.08A2 2 0 0 1 18 22H6a2 2 0 0 1-1.755-2.96l5.51-10.08A2 2 0 0 0 10 8V2" /><path d="M6.453 15h11.094" /><path d="M8.5 2h7" /></svg>
+          <span>پژوهشگران</span>
+        </a>
+        <a href="/solar/" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="ماشین‌حساب خورشیدی">
+          <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2v4" /><path d="m16.24 7.76 2.83-2.83" /><path d="M20 12h4" /><path d="m16.24 16.24 2.83 2.83" /><path d="M12 18v4" /><path d="m4.93 19.07 2.83-2.83" /><path d="M0 12h4" /><path d="m4.93 4.93 2.83 2.83" /><circle cx="12" cy="12" r="4" /></svg>
+          <span>ماشین‌حساب خورشیدی</span>
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="flex-grow">
+    <section class="bg-emerald-900 text-white py-16">
+      <div class="max-w-3xl mx-auto px-4 text-center space-y-4">
+        <p class="text-sm font-semibold tracking-wide uppercase">WESH360</p>
+        <h1 class="text-3xl md:text-4xl font-extrabold">محیط زیست و پسماند</h1>
+        <p class="text-base md:text-lg text-emerald-100 leading-8">پایش پایدار آلودگی، کیفیت هوا و آب، و مدیریت پسماند شهری و صنعتی.</p>
+      </div>
+    </section>
+    <section class="max-w-3xl mx-auto px-4 py-12 md:py-16">
+      <div class="bg-white border border-slate-200 rounded-2xl shadow-sm p-8 space-y-4 text-center">
+        <h2 class="text-2xl font-bold text-slate-800">این بخش به‌زودی در دسترس خواهد بود.</h2>
+        <p class="text-slate-600 leading-7">در حال آماده‌سازی داشبوردهای محیط زیست، کیفیت هوا و آب، و مدیریت پسماند هستیم. برای اطلاع از انتشار این بخش، ما را دنبال کنید.</p>
+        <a href="/" class="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-5 py-2 text-sm font-medium text-white hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-400">بازگشت به صفحهٔ اصلی</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="mt-auto" data-component="global-footer"></footer>
+  <script defer src="../assets/global-footer.js"></script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -69,7 +69,7 @@
         <div class="wiz-tabs" role="tablist" aria-label="Utilities">
           <button role="tab" data-utility="water" aria-selected="true" class="tab">آب</button>
           <button role="tab" data-utility="electricity" aria-selected="false" class="tab">برق</button>
-          <button role="tab" data-utility="gas" aria-selected="false" class="tab">گاز</button>
+          <button role="tab" data-utility="gas" aria-selected="false" class="tab">گاز و فرآورده‌های نفتی</button>
         </div>
       </div>
 
@@ -120,9 +120,14 @@
         <span class="icon" aria-hidden="true">⚡</span>
         <h3>برق</h3>
       </a>
-      <a href="/gas/" data-utility="gas" class="card gas" aria-label="ورود به داشبورد گاز">
+      <a href="/gas/" data-utility="gas" class="card gas" aria-label="ورود به داشبورد گاز و فرآورده‌های نفتی">
         <span class="icon" aria-hidden="true">🔥</span>
-        <h3>گاز</h3>
+        <h3>گاز و فرآورده‌های نفتی</h3>
+      </a>
+      <a href="/environment/" class="card environment" aria-label="ورود به بخش محیط زیست و پسماند">
+        <span class="icon" aria-hidden="true">🌿</span>
+        <h3>محیط زیست و پسماند</h3>
+        <p class="card-sub">پایش آلودگی، کیفیت هوا/آب، مدیریت پسماند (به‌زودی)</p>
       </a>
     </section>
     <section class="flex justify-center py-6">


### PR DESCRIPTION
## Summary
- rename the landing page gas tab and CTA to «گاز و فرآورده‌های نفتی»
- add a fourth landing card for محیط زیست و پسماند with subtitle copy
- introduce a minimal محیط زیست و پسماند placeholder page and allow four-card grid layout on wide screens

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e0f5680b1c832899cbd21d07464167