### PR TITLE
feat: normalize docs header logos

### DIFF
--- a/docs/assets/css/responsive-baseline.css
+++ b/docs/assets/css/responsive-baseline.css
@@ -2,6 +2,8 @@
 *, *::before, *::after { box-sizing: inherit; }
 img, svg, video, canvas { max-width: 100%; height: auto; }
 iframe { max-width: 100%; }
+.logo { display: inline-flex; align-items: center; text-decoration: none; }
+.logo img, .logo svg { height: auto; }
 .container { width: 100%; max-width: 72rem; margin-inline: auto; padding-inline: 1rem; }
 /* RTL-safe grid helpers */
 .grid-2 { display: grid; gap: 1rem; grid-template-columns: 1fr; }

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -17,7 +17,7 @@
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
-      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+      <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
         <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">WESH360</span>
       </a>

--- a/docs/environment/index.html
+++ b/docs/environment/index.html
@@ -17,7 +17,7 @@
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
-      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+      <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
         <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">WESH360</span>
       </a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,9 @@
   <body data-page="home" class="min-h-screen flex flex-col">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
     <header class="site-header relative flex justify-center items-center px-4">
-      <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
+      <a class="logo inline-flex items-center justify-center" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
+        <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
+      </a>
       <div class="absolute top-4 right-4 flex items-center gap-2">
         <a href="/security-policy" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="سیاست امنیت و حکمرانی داده">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -17,7 +17,9 @@
 <body class="min-h-screen flex flex-col bg-gradient-to-b from-slate-50 via-sky-50/70 to-white">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <header class="relative p-4 flex justify-center items-center">
-    <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
+    <a class="logo inline-flex items-center justify-center" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
+      <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
+    </a>
     <div class="absolute top-4 right-4 flex items-center gap-2">
       <a href="/security-policy" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="سیاست امنیت و حکمرانی داده">
         <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>

--- a/docs/responsible-disclosure/index.html
+++ b/docs/responsible-disclosure/index.html
@@ -17,7 +17,7 @@
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
-      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+      <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
         <img src="../page/landing/logo2.webp" alt="لوگوی وش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">وش۳۶۰</span>
       </a>

--- a/docs/responsible-disclosure/thanks.html
+++ b/docs/responsible-disclosure/thanks.html
@@ -16,7 +16,7 @@
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
-      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+      <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
         <img src="../page/landing/logo2.webp" alt="لوگوی وش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">وش۳۶۰</span>
       </a>

--- a/docs/security-policy/index.html
+++ b/docs/security-policy/index.html
@@ -15,7 +15,7 @@
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
-      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+      <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
         <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">خانه هم‌افزایی انرژی و آب</span>
       </a>

--- a/docs/solar/index.html
+++ b/docs/solar/index.html
@@ -18,7 +18,7 @@
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
-      <a href="/" class="flex items-center gap-3 text-slate-800 font-semibold">
+      <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
         <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">WESH360</span>
       </a>


### PR DESCRIPTION
## Summary
- wrap the header logo on docs landing, research, and marketing pages with a consistent home link and accessibility metadata
- add a shared `.logo` utility in the responsive baseline stylesheet to keep logo links aligned without altering RTL layouts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f1b2efd083289059047719b10e00