### PR TITLE
feat: add qualitative consumption label to household wizard

### DIFF
--- a/docs/assets/css/landing.css
+++ b/docs/assets/css/landing.css
@@ -162,6 +162,23 @@
 .wiz-results .kpi .k { font-size:12px; color:#64748b; }
 .wiz-results .kpi .v { font-size:18px; font-weight:800; color:#0f172a; }
 
+.chip {
+  display: inline-block;
+  padding: .25rem .5rem;
+  border-radius: 9999px;
+  font-weight: 600;
+  line-height: 1;
+  border: 1px solid transparent;
+}
+.chip[data-level="high"] { background:#fee2e2; color:#991b1b; border-color:#fecaca; }
+.chip[data-level="mid"]  { background:#e5e7eb; color:#111827; border-color:#d1d5db; }
+.chip[data-level="low"]  { background:#dcfce7; color:#065f46; border-color:#bbf7d0; }
+@media (prefers-color-scheme: dark){
+  .chip[data-level="high"] { background:#7f1d1d; color:#fecaca; border-color:#991b1b; }
+  .chip[data-level="mid"]  { background:#374151; color:#e5e7eb; border-color:#4b5563; }
+  .chip[data-level="low"]  { background:#064e3b; color:#bbf7d0; border-color:#065f46; }
+}
+
 .chart-wrap { margin: 12px auto; max-width: 560px; }
 .tips { margin: 8px 0 0; padding-inline-start: 18px; }
 .note { margin-top: 6px; font-size: 12px; color:#475569; }

--- a/docs/assets/household-wizard.js
+++ b/docs/assets/household-wizard.js
@@ -15,8 +15,22 @@
 
   // Targets & EF (provisional constants; do not modify global data)
   // Units: water(L/day/person), electricity(kWh/day/person), gas(kWh/day/person)
+  /*
+   * TODO(wesh360): Replace provisional TARGETS with sourced global benchmarks.
+   * Current placeholders (water=110 L/d/p, electricity=3.2 kWh/d/p, gas=18 kWh/d/p)
+   * are used for prototyping and must be updated once validated references are available.
+   */
   const TARGETS = { water: 110, electricity: 3.2, gas: 18 }; // provisional=true
   const EF = { electricity: 0.45, gas: 0.20, water: 0.0003 }; // kgCO2e per unit (provisional)
+
+  const LABEL_THRESHOLDS = { low: 0.90, high: 1.10 }; // 90% and 110%
+  function classify(perCapita, target){
+    if (!target || !Number.isFinite(perCapita)) return { key:'na', text:'—', level:'na' };
+    const ratio = perCapita / target;
+    if (ratio > LABEL_THRESHOLDS.high) return { key:'high', text:'پرمصرف', level:'high' };
+    if (ratio < LABEL_THRESHOLDS.low)  return { key:'low',  text:'کم‌مصرف', level:'low'  };
+    return { key:'mid', text:'نزدیکِ میانگین جهانی', level:'mid' };
+  }
 
   const unitFor = (u) => u==='water' ? 'L' : (u==='electricity' ? 'kWh' : 'm3');
 
@@ -100,6 +114,12 @@
     $('#k-delta').textContent = `${m.delta.toFixed(2)} (${m.percent.toFixed(1)}٪)`;
     $('#k-score').textContent = String(m.score);
     $('#k-co2e').textContent = m.co2e.toFixed(3) + ' kg';
+    const chip = document.getElementById('k-label');
+    if (chip){
+      const label = classify(m.perCapita, m.target);
+      chip.textContent = label.text;
+      chip.dataset.level = label.level;
+    }
     const note = m.provisional ? 'مقادیر هدف و ضرایب انتشار به‌صورت موقت و پارامتریک هستند.' : '';
     $('#wiz-note').textContent = note;
   }

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,12 @@
           <div class="kpi"><div class="k">Δ و ٪ اختلاف</div><div class="v" id="k-delta">—</div></div>
           <div class="kpi"><div class="k">امتیاز</div><div class="v" id="k-score">—</div></div>
           <div class="kpi"><div class="k">CO₂e</div><div class="v" id="k-co2e">—</div></div>
+          <div class="kpi">
+            <div class="k">برچسب مصرف</div>
+            <div class="v">
+              <span id="k-label" class="chip" aria-live="polite">—</span>
+            </div>
+          </div>
         </div>
         <div class="chart-wrap">
           <canvas id="wiz-chart" width="420" height="220" aria-label="مقایسه مصرف سرانه با هدف"></canvas>


### PR DESCRIPTION
## Summary
- add a sixth KPI card to display the qualitative consumption label with accessible chip styling
- centralize tweakable thresholds alongside provisional targets and classify per-capita usage vs global benchmarks

## Testing
- npm run csp:scan

------
https://chatgpt.com/codex/tasks/task_e_68e1f31790308328878298782d2cf504