### PR TITLE
Adjust homepage logo size

### DIFF
--- a/docs/assets/css/responsive-baseline.css
+++ b/docs/assets/css/responsive-baseline.css
@@ -3,7 +3,15 @@
 img, svg, video, canvas { max-width: 100%; height: auto; }
 iframe { max-width: 100%; }
 .logo { display: inline-flex; align-items: center; text-decoration: none; }
-.logo img, .logo svg { height: auto; }
+.logo img, .logo svg {
+  height: auto;
+  max-height: 3rem;
+}
+@media (min-width: 768px) {
+  .logo img, .logo svg {
+    max-height: 4rem;
+  }
+}
 .container { width: 100%; max-width: 72rem; margin-inline: auto; padding-inline: 1rem; }
 /* RTL-safe grid helpers */
 .grid-2 { display: grid; gap: 1rem; grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- cap the homepage logo image height on mobile and desktop viewports to match standard sizing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1f96141988328a1224764eaa4f2ee