### PR TITLE
Remove last updated sentence from dashboards

### DIFF
--- a/docs/assets/badge-updated.js
+++ b/docs/assets/badge-updated.js
@@ -25,18 +25,8 @@ import { setClass } from './css-classes.js';
     '[data-badge]'     // اگر کارت‌ها نشانه‌گذاری شده باشند
   ].join(',');
 
-  function makeBadge(text) {
-    const span = document.createElement('span');
-    span.className = [
-      'inline-flex','items-center','gap-1',
-      'rounded-full','border','border-gray-300/60',
-      'px-2','py-0.5','text-xs','font-medium',
-      'bg-white/60','backdrop-blur','text-gray-700',
-      'rtl'
-    ].join(' ');
-    span.setAttribute('dir', 'rtl');
-    span.innerHTML = `آخرین به‌روزرسانی: <time>${text}</time>`;
-    return span;
+  function makeBadge() {
+    return null;
   }
 
   function injectBadges(labelText) {
@@ -49,6 +39,7 @@ import { setClass } from './css-classes.js';
         : null;
 
       const badge = makeBadge(ownText || labelText);
+      if (!badge) return;
 
       // جای‌گذاری: گوشه‌ی بالا-چپ یا داخل هدر کارت اگر وجود داشت
       const header = card.querySelector('.card-header, header, .head, [data-card-header]');

--- a/docs/assets/shamsi-date.js
+++ b/docs/assets/shamsi-date.js
@@ -1,50 +1,10 @@
 (function () {
-  const fmt = new Intl.DateTimeFormat('fa-IR-u-ca-persian', {
-    year: 'numeric', month: 'long', day: '2-digit'
-  });
-
-  function parseInputDate(s, hint) {
-    if (!s) return null;
-    s = s.trim();
-    if (/^\d{4}-\d{2}-\d{2}$/.test(s) || hint === 'YYYY-MM-DD') {
-      const [y, m, d] = s.split('-').map(Number);
-      return new Date(y, m - 1, d);
-    }
-    if (/^\d{2}-\d{2}-\d{4}$/.test(s) || hint === 'DD-MM-YYYY') {
-      const [d, m, y] = s.split('-').map(Number);
-      return new Date(y, m - 1, d);
-    }
-    const dt = new Date(s);
-    return isNaN(dt) ? null : dt;
-  }
-
-  function renderBadge(el, date) {
-    if (!date) return;
-    const text = fmt.format(date);
-    el.innerHTML = `
-      <span class="date-chip" title="آخرین به‌روزرسانی">
-        <svg width="14" height="14" viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M7 2v2H5a2 2 0 0 0-2 2v2h18V6a2 2 0 0 0-2-2h-2V2h-2v2H9V2H7zm14 8H3v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V10zm-5 5h-4v4h4v-4z" fill="currentColor"/>
-        </svg>
-        <span>آخرین به‌روزرسانی: ${text}</span>
-      </span>
-    `;
-    el.classList.add('date-badge-mounted');
+  function removeBadge(el) {
+    if (el) el.remove();
   }
 
   document.addEventListener('DOMContentLoaded', () => {
-    document.querySelectorAll('.date-badge').forEach(el => {
-      const raw = el.getAttribute('data-gregorian') || el.textContent;
-      const dt = parseInputDate(raw, el.getAttribute('data-input-format'));
-      renderBadge(el, dt);
-    });
-    document.querySelectorAll('time.update-date').forEach(t => {
-      const raw = t.getAttribute('datetime') || t.textContent;
-      const dt = parseInputDate(raw, t.getAttribute('data-input-format'));
-      const wrap = document.createElement('div');
-      wrap.className = 'date-badge';
-      t.replaceWith(wrap);
-      renderBadge(wrap, dt);
-    });
+    document.querySelectorAll('.date-badge').forEach(removeBadge);
+    document.querySelectorAll('time.update-date').forEach(removeBadge);
   });
 })();

--- a/docs/assets/unified-badge.js
+++ b/docs/assets/unified-badge.js
@@ -2,28 +2,10 @@
   if (window.__UNIFIED_BADGE_LOADED__) return; // guard
   window.__UNIFIED_BADGE_LOADED__ = true;
 
-  const TEXT = 'آخرین به‌روزرسانی: ۲۶ مرداد ۱۴۰۴';
-
-  function makeBadge() {
-    const wrap = document.createElement('div');
-    wrap.className = 'dash-badge-wrap';
-    wrap.innerHTML = `
-      <span class="badge-update" aria-label="آخرین به‌روزرسانی">
-        <svg viewBox="0 0 24 24" aria-hidden="true">
-          <path d="M7 2v2H5a2 2 0 0 0-2 2v2h18V6a2 2 0 0 0-2-2h-2V2h-2v2H9V2H7zm14 8H3v10a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V10zm-5 5h-4v4h4v-4z"/>
-        </svg>
-        <span>${TEXT}</span>
-      </span>`;
-    return wrap;
-  }
-
   function installBadges(){
     document.querySelectorAll('.dash-card').forEach(card => {
       // هر نشانهٔ تاریخ قبلی را حذف کن تا دوتا نشود
       card.querySelectorAll('.dash-badge-wrap, .date-badge, .date-chip, time.update-date').forEach(el => el.remove());
-      // درج یک‌باره‌ی چیپ جدید
-      const badge = makeBadge();
-      card.insertBefore(badge, card.firstElementChild || card.firstChild);
     });
   }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -230,7 +230,6 @@
             <li>این بیانیه به‌صورت دوره‌ای بازبینی می‌شود. <strong>نسخه:</strong> 1.0 • <strong>تاریخ به‌روزرسانی:</strong> ۱۴۰۴/۰۵/۲۷</li>
           </ul>
         </div>
-        <p class="mt-6 text-xs text-slate-500">آخرین به‌روزرسانی: <span data-last-updated></span></p>
       </div>
     </div>
   </div>

--- a/docs/index.js
+++ b/docs/index.js
@@ -116,11 +116,6 @@ import { setClass } from './assets/css-classes.js';
 })();
 
 (function () {
-  const LAST_UPDATED = '۱۴۰۴/۰۵/۲۷';
-  document.querySelectorAll('[data-last-updated]').forEach(el => {
-    el.textContent = LAST_UPDATED;
-  });
-
   function openSheet(sheet) {
     if (!sheet) return;
     sheet.classList.remove('hidden');

--- a/docs/research/index.js
+++ b/docs/research/index.js
@@ -1,10 +1,5 @@
 'use strict';
 (function () {
-  const LAST_UPDATED = '۱۴۰۴/۰۵/۲۷';
-  document.querySelectorAll('[data-last-updated]').forEach(el => {
-    el.textContent = LAST_UPDATED;
-  });
-
   function openSheet(sheet) {
     if (!sheet) return;
     sheet.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- stop injecting the "آخرین به‌روزرسانی" badges so the dated sentence no longer appears on dashboard cards
- remove the landing and research page helpers that filled in the "آخرین به‌روزرسانی" sentence

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e204047b8c8328a03a0547cb251e38