### PR TITLE
feat: add accessible skip link and consistent back button

### DIFF
--- a/docs/agrovoltaics/index.html
+++ b/docs/agrovoltaics/index.html
@@ -4,9 +4,26 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Agrovoltaics Runner</title>
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body>
-  <div id="app"></div>
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main">
+    <div id="app"></div>
+  </main>
   <script type="module" src="/agrovoltaics/app.js"></script>
 </body>
 </html>

--- a/docs/amaayesh/index.html
+++ b/docs/amaayesh/index.html
@@ -6,19 +6,33 @@
   <title>نقشه آمایش انرژی — خراسان رضوی | WESH360</title>
   <link rel="icon" href="../page/landing/favicon.ico"/>
   <link rel="stylesheet" href="../assets/tailwind.css"/>
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="../assets/vendor/leaflet/leaflet.css" />
   <link rel="stylesheet" href="/assets/css/map-overrides.css" />
   <link rel="stylesheet" href="../assets/legend.css"/>
   <link rel="stylesheet" href="/assets/css/map-inline.css" />
+  <script src="/assets/js/nav-utils.js" defer></script>
   <meta name="build-id" content="ama-20250906">
 </head>
 <body class="min-h-screen bg-slate-950 text-slate-100 flex flex-col">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="w-full px-4 py-3 flex items-center justify-between">
     <h1 class="text-lg md:text-2xl font-bold">نقشه تعاملی آمایش انرژی — خراسان رضوی</h1>
-    <nav class="text-sm md:text-base"><a href="../index.html" class="underline decoration-dotted">صفحه اصلی</a></nav>
   </header>
 
-  <main class="flex relative ama-main is-mobile">
+  <main id="main" role="main" class="flex relative ama-main is-mobile">
     <!-- ظرف نقشه: id باید «map» بماند -->
     <div id="map"></div>
 

--- a/docs/assets/css/base.css
+++ b/docs/assets/css/base.css
@@ -1,0 +1,87 @@
+.skip-link{
+  position:absolute;
+  left:-9999px;
+  top:auto;
+  width:1px;
+  height:1px;
+  overflow:hidden;
+}
+.skip-link:focus,
+.skip-link:focus-visible{
+  left:1rem;
+  top:1rem;
+  width:auto;
+  height:auto;
+  padding:.5rem .75rem;
+  z-index:1000;
+  border-radius:.5rem;
+  font-weight:600;
+  background:#111827;
+  color:#fff;
+  outline:2px solid #fff;
+  outline-offset:2px;
+}
+@media (prefers-color-scheme: light){
+  .skip-link:focus,
+  .skip-link:focus-visible{
+    background:#fff;
+    color:#111827;
+    outline-color:#111827;
+  }
+}
+
+.site-topbar{
+  position:relative;
+  z-index:900;
+  padding:1rem 1.5rem;
+}
+.site-topbar__inner{
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  gap:1rem;
+}
+html[dir="rtl"] .site-topbar__inner{
+  flex-direction:row-reverse;
+}
+.site-topbar__brand{
+  display:inline-flex;
+  align-items:center;
+  gap:.75rem;
+  font-weight:700;
+  color:inherit;
+  text-decoration:none;
+}
+.site-topbar__brand img{
+  height:2.5rem;
+  width:auto;
+}
+.back-btn{
+  display:inline-flex;
+  align-items:center;
+  gap:.5rem;
+  padding:.5rem .75rem;
+  border-radius:.75rem;
+  text-decoration:none;
+  font-weight:600;
+  border:1px solid var(--border, #e5e7eb);
+  background:var(--bg, #f9fafb);
+  color:var(--fg, #111827);
+}
+.back-btn .icon{
+  display:inline-block;
+  transform:scale(1.2);
+}
+.back-btn:hover{
+  filter:brightness(0.97);
+}
+.back-btn:active{
+  transform:translateY(1px);
+}
+@media (prefers-color-scheme: dark){
+  .back-btn{
+    --bg:#111827;
+    --fg:#e5e7eb;
+    --border:#374151;
+  }
+}

--- a/docs/assets/js/nav-utils.js
+++ b/docs/assets/js/nav-utils.js
@@ -1,0 +1,24 @@
+(function(){
+  const el = document.querySelector('[data-back-button]');
+  if(!el) return;
+  try{
+    const ref = document.referrer;
+    const sameOrigin = ref && new URL(ref).origin === location.origin;
+    const canGoBack = history.length > 1;
+    if (sameOrigin && canGoBack){
+      el.addEventListener('click', (e)=>{
+        if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+        e.preventDefault();
+        history.back();
+      });
+      el.setAttribute('href', ref);
+      el.dataset.mode = 'history';
+    } else {
+      el.setAttribute('href','/');
+      el.dataset.mode = 'home';
+    }
+  }catch(_){
+    el.setAttribute('href','/');
+    el.dataset.mode = 'home';
+  }
+})();

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -7,14 +7,28 @@
   <meta property="og:title" content="ارتباط با ما • WESH360" />
   <title>ارتباط با ما • WESH360</title>
   <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
   <link rel="stylesheet" href="../assets/fonts.css" />
   <link rel="stylesheet" href="../assets/global-footer.css" />
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
@@ -42,7 +56,7 @@
     </div>
   </header>
 
-  <main id="main" class="flex-grow">
+  <main id="main" role="main" class="flex-grow">
     <section class="bg-sky-900 text-white py-12">
       <div class="max-w-3xl mx-auto px-4 text-center space-y-4">
         <p class="text-sm font-semibold tracking-wide uppercase">WESH360</p>

--- a/docs/contact/thanks.html
+++ b/docs/contact/thanks.html
@@ -7,12 +7,26 @@
   <title>پیام شما ثبت شد | WESH360</title>
   <link rel="stylesheet" href="/assets/tailwind.css" />
   <link rel="stylesheet" href="/assets/fonts.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/global-footer.css" />
   <link rel="stylesheet" href="/assets/unified-badge.css" />
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-  <main id="main" class="flex-grow">
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main" class="flex-grow">
     <section class="max-w-2xl mx-auto px-4 py-24 text-center space-y-6">
       <h1 class="text-3xl font-extrabold text-slate-900">پیام شما ثبت شد</h1>
       <p class="text-slate-600 leading-8">از تماس شما سپاسگزاریم. تیم ما پیام را بررسی می‌کند و در صورت نیاز پاسخ می‌دهد.</p>

--- a/docs/electricity/index.html
+++ b/docs/electricity/index.html
@@ -13,6 +13,7 @@
   <title>برق - wesh360</title>
   <meta name="section" content="electricity" />
   <link rel="stylesheet" href="/assets/fonts.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/electricity-theme.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
@@ -23,10 +24,23 @@
   <link rel="stylesheet" href="/assets/inline-migration.css" />
   <script charset="utf-8" defer src="/assets/shamsi-date.js"></script>
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body>
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-  <main id="main" class="container">
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main" class="container">
     <h1 class="page-title">⚡ صفحه برق</h1>
 
     <section class="grid" aria-label="Electricity dashboards">
@@ -54,10 +68,6 @@
         </div>
       </article>
     </section>
-
-    <div class="actions mt-26">
-      <a class="btn btn-ghost" href="../index.html" aria-label="بازگشت به صفحه اصلی">بازگشت به صفحه اصلی</a>
-    </div>
 
     <!-- فوتر موجود سایت شما همان‌طور که هست بماند -->
   </main>

--- a/docs/electricity/peak.html
+++ b/docs/electricity/peak.html
@@ -6,6 +6,7 @@
     <title>داشبورد مدیریت مصرف برق — استان خراسان رضوی</title>
     <meta name="section" content="electricity" />
     <link rel="stylesheet" href="../assets/fonts.css">
+    <link rel="stylesheet" href="/assets/css/base.css">
     <link rel="stylesheet" href="../assets/tailwind.css">
     <link rel="stylesheet" href="/assets/global-footer.css">
     <link rel="stylesheet" href="/assets/unified-badge.css">
@@ -15,13 +16,27 @@
     <script src="../assets/electricity-management.js"></script>
     <script defer src="/assets/unified-badge.js"></script>
     <script defer src="/assets/global-footer.js"></script>
+    <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="bg-slate-100 text-slate-800">
+    <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+    <header class="site-topbar" role="banner">
+      <div class="site-topbar__inner">
+        <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+          <span class="icon" aria-hidden="true">‹</span>
+          <span class="label">بازگشت</span>
+        </a>
+        <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+          <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+          <span>wesh360</span>
+        </a>
+      </div>
+    </header>
     <div class="container mx-auto p-4 md:p-6 lg:p-8">
         <header class="mb-8">
             <h1 class="text-3xl md:text-4xl font-bold text-slate-900">داشبورد مدیریت مصرف برق — استان خراسان رضوی</h1>
         </header>
-        <main class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <main id="main" role="main" class="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <div class="lg:col-span-2 space-y-6">
                 <section id="total-consumption" class="bg-white p-6 rounded-2xl shadow-md hover:shadow-lg transition-shadow duration-300 dash-card">
                     <h2 class="text-xl font-semibold mb-4 border-b pb-3 border-slate-200">تقاضا و مصرف کل</h2>

--- a/docs/electricity/power-tariff.html
+++ b/docs/electricity/power-tariff.html
@@ -6,6 +6,7 @@
   <title>تحلیل و شبیه‌سازی قبض برق</title>
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/fonts.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="../assets/power-tariff.css">
   <script defer src="../assets/power-tariff.js"></script>
   <link rel="stylesheet" href="/assets/global-footer.css">
@@ -13,8 +14,22 @@
   <link rel="stylesheet" href="../assets/inline-migration.css" />
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="bg-slate-100 text-slate-800">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
 <div id="etf-root" class="container mx-auto p-4 md:p-8">
     <!-- Header -->
     <header class="text-center mb-6">
@@ -32,7 +47,7 @@
     </div>
 
     <!-- Tab Content -->
-    <main>
+    <main id="main" role="main">
         <!-- Tariffs Tab -->
         <div id="etf-tariffs" class="etf-tab-content space-y-8">
             <div class="grid grid-cols-1 md:grid-cols-2 gap-8">

--- a/docs/electricity/quality.html
+++ b/docs/electricity/quality.html
@@ -14,6 +14,7 @@
 
     <!-- فونت محلی Vazirmatn -->
   <link rel="stylesheet" href="../assets/fonts.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
 
     <style>
         body {
@@ -31,8 +32,22 @@
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="bg-gray-900 text-gray-200">
+    <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+    <header class="site-topbar" role="banner">
+      <div class="site-topbar__inner">
+        <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+          <span class="icon" aria-hidden="true">‹</span>
+          <span class="label">بازگشت</span>
+        </a>
+        <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+          <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+          <span>wesh360</span>
+        </a>
+      </div>
+    </header>
 
     <div class="container mx-auto p-4 md:p-8">
         <nav aria-label="breadcrumb" class="mb-6 text-sm text-gray-400">
@@ -52,7 +67,7 @@
         </header>
 
         <!-- Main Dashboard -->
-        <main class="space-y-8">
+        <main id="main" role="main" class="space-y-8">
             <!-- Section 1: Overview & Trends -->
             <section class="bg-gray-800/50 rounded-2xl p-6 backdrop-blur-sm border border-gray-700 dash-card">
                 <h3 class="text-xl font-semibold mb-6 text-cyan-400">نمای کلی استان (ماه جاری)</h3>

--- a/docs/environment/index.html
+++ b/docs/environment/index.html
@@ -7,14 +7,28 @@
   <meta property="og:title" content="محیط زیست و پسماند | WESH360" />
   <title>محیط زیست و پسماند | WESH360</title>
   <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
   <link rel="stylesheet" href="../assets/fonts.css" />
   <link rel="stylesheet" href="../assets/global-footer.css" />
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
@@ -42,7 +56,7 @@
     </div>
   </header>
 
-  <main id="main" class="flex-grow">
+  <main id="main" role="main" class="flex-grow">
     <section class="bg-emerald-900 text-white py-16">
       <div class="max-w-3xl mx-auto px-4 text-center space-y-4">
         <p class="text-sm font-semibold tracking-wide uppercase">WESH360</p>

--- a/docs/gas/energy.html
+++ b/docs/gas/energy.html
@@ -12,13 +12,27 @@
   <!-- استایل‌های محلی پروژه -->
   <link rel="stylesheet" href="../assets/tailwind.css" />
   <link rel="stylesheet" href="../assets/fonts.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen bg-slate-900 text-slate-200 antialiased">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
 
   <div class="container mx-auto p-4 sm:p-6 lg:p-8">
     <header class="mb-8">
@@ -27,7 +41,6 @@
           <h1 class="text-3xl font-extrabold text-white">داشبورد مدیریت انرژی</h1>
           <p class="text-lg text-cyan-400 mt-1">استان خراسان رضوی (نمای عمومی)</p>
         </div>
-        <a href="../" class="text-sm text-cyan-300 hover:underline">بازگشت به گاز</a>
       </div>
 
       <!-- فیلترها -->
@@ -48,7 +61,7 @@
       </div>
     </header>
 
-    <main id="main" class="space-y-8">
+    <main id="main" role="main" class="space-y-8">
       <!-- KPI ها -->
       <section id="kpi-section">
         <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">

--- a/docs/gas/fuel-carbon.html
+++ b/docs/gas/fuel-carbon.html
@@ -8,6 +8,7 @@
   <!-- Tailwind CSS -->
   <link rel="stylesheet" href="../assets/tailwind.css" />
   <link rel="stylesheet" href="../assets/fonts.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
 
 
   <style>
@@ -40,8 +41,22 @@
   <script defer src="/assets/unified-badge.js"></script>
   <link rel="stylesheet" href="/assets/global-footer.css">
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
   <body class="bg-slate-50 text-slate-800">
+    <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+    <header class="site-topbar" role="banner">
+      <div class="site-topbar__inner">
+        <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+          <span class="icon" aria-hidden="true">‹</span>
+          <span class="label">بازگشت</span>
+        </a>
+        <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+          <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+          <span>wesh360</span>
+        </a>
+      </div>
+    </header>
     <span id="fc-js-status" class="hidden">X</span>
     <nav class="container mx-auto p-4 md:p-8 mb-4 text-sm text-slate-500">
       <a href="../index.html" class="hover:text-slate-700">خانه</a>
@@ -50,7 +65,7 @@
       <span class="mx-2">/</span>
       <span class="text-slate-700">سوخت و کربن برق</span>
     </nav>
-    <div class="container mx-auto p-4 md:p-8">
+    <main id="main" role="main" class="container mx-auto p-4 md:p-8">
       <!-- Header -->
     <header class="text-center mb-8">
       <h1 class="text-3xl md:text-4xl font-bold text-slate-900">برق استان از چه سوختی می‌آید؟</h1>
@@ -196,7 +211,7 @@
         </div>
       </div>
     </section>
-  </div>
+  </main>
 
   <!-- اسکریپت اختصاصی این صفحه (JS جداگانه) -->
   <script src="../assets/vendor/chart.umd.min.js" defer></script>

--- a/docs/gas/index.html
+++ b/docs/gas/index.html
@@ -12,17 +12,31 @@
   <meta name="twitter:image" content="https://wesh360.ir/page/landing/logo2.jfif"> 
   <meta name="section" content="gas" />
   <title>گاز - wesh360</title>
-  <link rel="stylesheet" href="../assets/tailwind.css"> 
+  <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/fonts.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="../assets/gas.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-  <main id="main" class="flex-grow flex flex-col items-center justify-center text-center space-y-8 p-6">
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main" class="flex-grow flex flex-col items-center justify-center text-center space-y-8 p-6">
     <div class="space-y-2">
       <h1 class="text-3xl font-extrabold text-slate-800">صفحه گاز و فرآورده‌های نفتی</h1>
       <p class="text-slate-600">محتوای این بخش به زودی اضافه می‌شود.</p>
@@ -32,9 +46,6 @@
       <a href="./fuel-carbon.html" class="px-6 py-3 rounded-lg shadow-md bg-gradient-to-r from-gray-700 to-black text-orange-400 font-bold hover:text-orange-300 hover:from-gray-800 hover:to-black transition">سوخت و کربن برق</a>
     </div>
   </main>
-  <div class="py-6 flex justify-center">
-    <a href="../" class="px-6 py-3 rounded-lg shadow-md bg-slate-700 text-white font-bold hover:bg-slate-800 transition">بازگشت به صفحه اصلی</a>
-  </div>
   <script type="module" src="/index.js" defer charset="utf-8"></script>
   <script defer src="../assets/numfmt.js"></script>
   <script defer src="../assets/badge-updated.js"></script>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,7 @@
   <title>wesh360</title>
   <script>if(!document.createElement('canvas').toDataURL('image/webp').includes('data:image/webp')){document.documentElement.classList.add('no-webp');}</script>
   <link rel="stylesheet" href="./assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
   <link rel="stylesheet" href="/assets/css/landing.css">
   <link rel="stylesheet" href="./assets/global-footer.css">
@@ -24,9 +25,22 @@
   <link rel="icon" type="image/x-icon" href="./page/landing/favicon.ico">
   <script defer src="./assets/unified-badge.js"></script>
   <script defer src="./assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
   <body data-page="home" class="min-h-screen flex flex-col">
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+    <header class="site-topbar" role="banner">
+      <div class="site-topbar__inner">
+        <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+          <span class="icon" aria-hidden="true">‹</span>
+          <span class="label">بازگشت</span>
+        </a>
+        <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+          <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+          <span>wesh360</span>
+        </a>
+      </div>
+    </header>
     <header class="site-header relative flex justify-center items-center px-4">
       <a class="logo inline-flex items-center justify-center" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
         <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
@@ -59,7 +73,7 @@
         <p>داشبوردهای تعاملی برای آگاهی، بهینه‌سازی و تصمیم‌گیری بهتر</p>
       </div>
     </section>
-  <main id="main" class="flex-grow">
+  <main id="main" role="main" class="flex-grow">
     <a data-cta="amaayesh" href="./amaayesh/index.html"
        class="inline-flex items-center gap-2 px-4 py-2 my-4 rounded-xl bg-sky-600/90 hover:bg-sky-500 text-white">
       نقشه آمایش انرژی خراسان رضوی

--- a/docs/research/index.html
+++ b/docs/research/index.html
@@ -6,16 +6,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>درگاه درخواست دادهٔ پژوهشی WESH360</title>
   <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
   <link rel="stylesheet" href="../assets/fonts.css" />
   <link rel="stylesheet" href="/assets/global-footer.css" />
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 
 </head>
 <body class="min-h-screen flex flex-col bg-gradient-to-b from-slate-50 via-sky-50/70 to-white">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="relative p-4 flex justify-center items-center">
     <a class="logo inline-flex items-center justify-center" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
       <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="w-24 md:w-28 h-auto" />
@@ -42,7 +56,7 @@
       </button>
     </div>
   </header>
-  <main id="main" class="flex-grow space-y-10">
+  <main id="main" role="main" class="flex-grow space-y-10">
     <section class="text-center max-w-4xl mx-auto px-4 py-10 md:py-14">
       <h1 class="text-2xl md:text-4xl font-extrabold text-slate-900">درگاه درخواست دادهٔ پژوهشی WESH360</h1>
       <p class="mt-3 md:mt-4 text-slate-600 md:text-lg">مطابق مادهٔ 107 قانون برنامه پنجساله هفتم پیشرفت، خانهٔ هم‌افزایی انرژی و آب با هدف تسهیل اجرای این ماده و ایجاد سازوکار امن، قانونی، معقول و هدفمند، درگاه درخواست دادهٔ پژوهشی از سازمان‌های آب و انرژی استان خراسان رضوی را فراهم می‌کند. این درگاه صرفاً داده‌های عمومی، تجمیعی و با تاخیر ایمن را پیگیری می‌کند و از انتشار جزئیات عملیاتی/بلادرنگ خودداری می‌شود.</p>

--- a/docs/research/thanks.html
+++ b/docs/research/thanks.html
@@ -7,12 +7,26 @@
   <title>درخواست شما ثبت شد | WESH360</title>
   <link rel="stylesheet" href="/assets/tailwind.css" />
   <link rel="stylesheet" href="/assets/fonts.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/global-footer.css" />
   <link rel="stylesheet" href="/assets/unified-badge.css" />
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-  <main id="main" class="flex-grow">
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main" class="flex-grow">
     <section class="max-w-2xl mx-auto px-4 py-24 text-center space-y-6">
       <h1 class="text-3xl font-extrabold text-slate-900">درخواست شما ثبت شد</h1>
       <p class="text-slate-600 leading-8">از همراهی شما سپاسگزاریم. تیم ما درخواست یا پیشنهاد پژوهشی شما را بررسی می‌کند و در صورت نیاز با شما تماس خواهد گرفت.</p>

--- a/docs/responsible-disclosure/index.html
+++ b/docs/responsible-disclosure/index.html
@@ -7,14 +7,28 @@
   <meta property="og:title" content="گزارش مسئولانهٔ آسیب‌پذیری • WESH360" />
   <title>گزارش مسئولانهٔ آسیب‌پذیری • WESH360</title>
   <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
   <link rel="stylesheet" href="../assets/fonts.css" />
   <link rel="stylesheet" href="../assets/global-footer.css" />
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
@@ -42,7 +56,7 @@
     </div>
   </header>
 
-  <main id="main" class="flex-grow">
+  <main id="main" role="main" class="flex-grow">
     <section class="bg-sky-900 text-white py-12">
       <div class="max-w-3xl mx-auto px-4 text-center space-y-4">
         <p class="text-sm font-semibold tracking-wide uppercase">WESH360</p>

--- a/docs/responsible-disclosure/thanks.html
+++ b/docs/responsible-disclosure/thanks.html
@@ -7,13 +7,27 @@
   <meta property="og:title" content="سپاس از ارسال شما • WESH360" />
   <title>سپاس از ارسال شما • WESH360</title>
   <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="../assets/fonts.css" />
   <link rel="stylesheet" href="../assets/global-footer.css" />
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
@@ -41,7 +55,7 @@
     </div>
   </header>
 
-  <main id="main" class="flex-grow">
+  <main id="main" role="main" class="flex-grow">
     <section class="max-w-3xl mx-auto px-4 py-20 text-center space-y-6">
       <h1 class="text-2xl md:text-4xl font-extrabold text-slate-900">دریافت شد؛ متشکریم.</h1>
       <p class="text-slate-600 md:text-lg leading-8">بررسی و در صورت نیاز با شما تماس می‌گیریم. می‌توانید دوباره به <a class="text-sky-700 hover:underline" href="/responsible-disclosure">فرم گزارش</a> یا <a class="text-sky-700 hover:underline" href="/">صفحهٔ اصلی</a> برگردید.</p>

--- a/docs/security-policy/index.html
+++ b/docs/security-policy/index.html
@@ -6,13 +6,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>سیاست امنیت و حکمرانی داده • WESH360</title>
   <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="../assets/fonts.css" />
   <link rel="stylesheet" href="../assets/global-footer.css" />
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-5xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
@@ -32,7 +46,7 @@
     </div>
   </header>
 
-  <main id="main" class="flex-grow">
+  <main id="main" role="main" class="flex-grow">
     <section class="bg-sky-900 text-white py-12">
       <div class="max-w-3xl mx-auto px-4 text-center space-y-4">
         <p class="text-sm font-semibold tracking-wide uppercase">WESH360</p>

--- a/docs/solar/agrivoltaics/index.dev.html
+++ b/docs/solar/agrivoltaics/index.dev.html
@@ -6,13 +6,30 @@
   <title>ماشین‌حساب فوتوکشت — wesh360</title>
   <!-- CSS -->
   <link rel="stylesheet" href="/assets/tailwind.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/site-overrides.css">
   <link rel="stylesheet" href="/assets/inline-migration.css">
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body>
-  <div id="root"></div>
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main">
+    <div id="root"></div>
+  </main>
 
   <!-- vendor+app (local) -->
   <script charset="utf-8" defer src="/solar/agrivoltaics/vendor/react.production.min.js"></script>

--- a/docs/solar/agrivoltaics/index.html
+++ b/docs/solar/agrivoltaics/index.html
@@ -7,13 +7,30 @@
   <!-- CSS -->
   <link rel="stylesheet" href="/assets/tailwind.css">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/site-overrides.css">
   <link rel="stylesheet" href="/assets/inline-migration.css">
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body>
-  <div id="root"></div>
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main">
+    <div id="root"></div>
+  </main>
 
   <!-- vendor+app (local) -->
   <script charset="utf-8" defer src="/solar/agrivoltaics/vendor/react.production.min.js"></script>

--- a/docs/solar/index.html
+++ b/docs/solar/index.html
@@ -7,15 +7,29 @@
   <meta property="og:title" content="ماشین‌حساب خورشیدی • WESH360" />
   <title>ماشین‌حساب خورشیدی • WESH360</title>
   <link rel="stylesheet" href="../assets/tailwind.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="../assets/fonts.css" />
   <link rel="stylesheet" href="../assets/global-footer.css" />
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
   <script defer src="../assets/unified-badge.js"></script>
   <script defer src="../assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
@@ -43,7 +57,7 @@
     </div>
   </header>
 
-  <main id="main" class="flex-grow">
+  <main id="main" role="main" class="flex-grow">
     <section class="bg-gradient-to-b from-sky-900 to-sky-700 text-white py-16">
       <div class="max-w-3xl mx-auto px-4 text-center space-y-5">
         <p class="text-sm font-semibold tracking-wide uppercase">WESH360</p>

--- a/docs/solar/plant/index.html
+++ b/docs/solar/plant/index.html
@@ -9,9 +9,24 @@
   <link rel="stylesheet" href="../../assets/css/solar-calc.css">
   <link rel="icon" type="image/png" href="../../Logo.png">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body>
-  <main>
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main">
     <h1>محاسبه‌گر نیروگاه خورشیدی</h1>
     <div class="legend">
       <p>تنظیمات پیش‌فرض از فایل پیکربندی خوانده می‌شود و با ورودی‌های شما ترکیب خواهد شد.</p>

--- a/docs/test/water-cld.html
+++ b/docs/test/water-cld.html
@@ -10,15 +10,31 @@
   <!-- Base styles -->
   <link rel="stylesheet" href="../assets/tailwind.css" />
   <link rel="stylesheet" href="../assets/chart.autofix.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
 
   <!-- Bundled CLD styles -->
   <link rel="stylesheet" href="../assets/dist/water-cld.bundle.css" />
   <link rel="stylesheet" href="../assets/water-cld.css" />
   <link rel="stylesheet" href="../assets/inline-migration.css" />
 
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 
 <body class="rtl">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main">
   <!-- ===== HERO KPI BAR (start) ===== -->
   <section id="hero-kpi" class="hero-kpi">
     <div class="hero-left">
@@ -236,6 +252,7 @@
   </div>
 
   <script defer src="../assets/vendor/cytoscape.min.js"></script>
+  </main>
   <script defer src="../assets/vendor/elk.bundled.js"></script>
   <script defer src="../assets/vendor/cytoscape-elk.js"></script>
   <script defer src="../assets/vendor/dagre.min.js"></script>

--- a/docs/water/cld/index.html
+++ b/docs/water/cld/index.html
@@ -11,15 +11,31 @@
   <!-- Base styles -->
   <link rel="stylesheet" href="/assets/tailwind.css" />
   <link rel="stylesheet" href="/assets/chart.autofix.css" />
+  <link rel="stylesheet" href="/assets/css/base.css">
 
   <!-- Bundled CLD styles -->
   <link rel="stylesheet" href="/assets/dist/water-cld.bundle.css" />
   <link rel="stylesheet" href="/assets/water-cld.css" />
   <link rel="stylesheet" href="/assets/inline-migration.css" />
 
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 
 <body class="rtl">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main">
   <!-- ===== HERO KPI BAR (start) ===== -->
   <section id="hero-kpi" class="hero-kpi">
     <div class="hero-left">
@@ -237,6 +253,7 @@
   </div>
 
   <script defer src="/assets/vendor/cytoscape.min.js"></script>
+  </main>
   <script defer src="/assets/vendor/elk.bundled.js"></script>
   <script defer src="/assets/vendor/cytoscape-elk.js"></script>
   <script defer src="/assets/vendor/dagre.min.js"></script>

--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -5,15 +5,30 @@
   <title>ماشین‌حساب پیشرفته قیمت تمام‌شده آب در مشهد</title>
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/fonts.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="../assets/water-cost.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <link rel="stylesheet" href="../assets/inline-migration.css" />
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body>
-  <main class="container">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main" class="container">
   <h1 class="page-title">ماشین‌حساب پیشرفته قیمت تمام‌شده آب در مشهد</h1>
   <div class="page-sub">شِمای تمیز و کادربندی‌شده؛ ورودی‌ها در راست، خروجی‌ها در چپ</div>
 
@@ -120,7 +135,6 @@
 
       <div class="actions">
         <button id="recalc" class="btn btn-primary" type="button">به‌روزرسانی محاسبات</button>
-        <a class="btn" href="../index.html">بازگشت</a>
       </div>
     </div>
   </section>

--- a/docs/water/hub.html
+++ b/docs/water/hub.html
@@ -6,15 +6,30 @@
   <title>انتخاب داشبورد آب</title>
   <link rel="stylesheet" href="/assets/fonts.css">
   <link rel="stylesheet" href="/assets/tailwind.css">
+  <link rel="stylesheet" href="/assets/css/base.css">
   <link rel="stylesheet" href="/assets/css/responsive-baseline.css">
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <link rel="stylesheet" href="/assets/site-overrides.css">
   <script charset="utf-8" defer src="/assets/unified-badge.js"></script>
   <script charset="utf-8" defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body class="bg-gradient-to-b from-slate-50 via-sky-50/60 to-white text-slate-800 min-h-screen relative overflow-hidden text-sm md:text-base">
-  <main class="max-w-6xl mx-auto px-4 py-10 md:py-14">
+  <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
+  <header class="site-topbar" role="banner">
+    <div class="site-topbar__inner">
+      <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+        <span class="icon" aria-hidden="true">‹</span>
+        <span class="label">بازگشت</span>
+      </a>
+      <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+        <span>wesh360</span>
+      </a>
+    </div>
+  </header>
+  <main id="main" role="main" class="max-w-6xl mx-auto px-4 py-10 md:py-14">
     <h1 class="text-2xl md:text-3xl font-bold text-slate-800 text-center">یک داشبورد انتخاب کنید</h1>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mt-10">
       <!-- Card 1: Insights -->
@@ -60,9 +75,6 @@
           </div>
         </div>
       </article>
-    </div>
-    <div class="text-center mt-12">
-      <a href="../" class="text-slate-500 hover:text-slate-700 underline underline-offset-4">بازگشت به صفحه اصلی</a>
     </div>
   </main>
   <svg class="absolute bottom-0 left-0 w-full opacity-30 text-sky-200 pointer-events-none animate-[float_12s_ease-in-out_infinite]" viewBox="0 0 1440 320" aria-hidden="true"><path fill="currentColor" d="M0 224L48 218.7C96 213 192 203 288 176C384 149 480 107 576 117.3C672 128 768 192 864 213.3C960 235 1056 213 1152 208C1248 203 1344 213 1392 218.7L1440 224V320H1392C1344 320 1248 320 1152 320C1056 320 960 320 864 320C768 320 672 320 576 320C480 320 384 320 288 320C192 320 96 320 48 320H0Z"></path></svg>

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -14,6 +14,7 @@
     <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='30' fill='%231f7aff'/%3E%3Cpath d='M20 36c8 4 16-4 24 0' stroke='white' stroke-width='4' fill='none'/%3E%3C/svg%3E" />
       <link rel="stylesheet" href="../assets/tailwind.css">
       <link rel="stylesheet" href="../assets/fonts.css">
+      <link rel="stylesheet" href="/assets/css/base.css">
 
   <link rel="stylesheet" href="water.css">
   <!-- Vazirmatn -->
@@ -22,13 +23,23 @@
   <link rel="stylesheet" href="../assets/inline-migration.css" />
   <script defer src="/assets/unified-badge.js"></script>
   <script defer src="/assets/global-footer.js"></script>
+  <script src="/assets/js/nav-utils.js" defer></script>
 </head>
 <body>
     <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
-    <nav class="container mx-auto p-4 md:p-8 mb-4 text-sm text-slate-500">
-        <a href="./hub.html" class="hover:text-slate-700">بازگشت به انتخاب داشبورد</a>
-    </nav>
-    <main id="main" class="dashboard container mx-auto p-4 md:p-8">
+    <header class="site-topbar" role="banner">
+      <div class="site-topbar__inner">
+        <a class="back-btn" href="/" rel="prev" aria-label="بازگشت" data-back-button>
+          <span class="icon" aria-hidden="true">‹</span>
+          <span class="label">بازگشت</span>
+        </a>
+        <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
+          <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
+          <span>wesh360</span>
+        </a>
+      </div>
+    </header>
+    <main id="main" role="main" class="dashboard container mx-auto p-4 md:p-8">
         <header class="text-center mb-12">
             <h1 class="text-4xl md:text-5xl font-extrabold main-title">وضعیت بحرانی آب در مشهد</h1>
             <p class="text-slate-600 text-lg mt-4">آخرین بروزرسانی: شنبه 25مرداد ۱۴۰۴</p>


### PR DESCRIPTION
## Summary
- add shared base stylesheet for focus-only skip link styling and the new top navigation pattern across documentation pages
- introduce a CSP-safe back button script that upgrades to history navigation when possible and fallbacks to home, wiring it into electricity, water, gas, solar, research, and other sections
- refresh per-page layouts to include <main> landmarks and remove redundant inline "بازگشت" links in favor of the shared back button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20396463883289498db4367ad330b