### PR TITLE
Add reusable mobile navigation for docs pages

### DIFF
--- a/docs/assets/css/base.css
+++ b/docs/assets/css/base.css
@@ -85,3 +85,111 @@ html[dir="rtl"] .site-topbar__inner{
     --border:#374151;
   }
 }
+
+.mobile-actions{
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  align-items:flex-end;
+}
+
+.mobile-actions__trigger{
+  display:inline-flex;
+  align-items:center;
+  gap:.5rem;
+  border-radius:.75rem;
+  border:1px solid rgba(148,163,184,.5);
+  background-color:rgba(255,255,255,.9);
+  color:#0f172a;
+  font-weight:600;
+  min-block-size:44px;
+  padding-block:.5rem;
+  padding-inline:1rem;
+  box-shadow:0 1px 2px rgba(15,23,42,.08);
+  transition:background-color .2s ease, box-shadow .2s ease, transform .2s ease;
+}
+
+.mobile-actions__trigger:hover{
+  background-color:#e2e8f0;
+  box-shadow:0 4px 12px rgba(15,23,42,.08);
+}
+
+.mobile-actions__trigger:focus-visible{
+  outline:3px solid #0ea5e9;
+  outline-offset:3px;
+  box-shadow:0 0 0 4px rgba(14,165,233,.2);
+}
+
+.mobile-actions__trigger-icon{
+  inline-size:1.5rem;
+  block-size:1.5rem;
+}
+
+.mobile-actions__popover{
+  position:absolute;
+  inset-inline-end:0;
+  margin-block-start:.75rem;
+  inline-size:min(85vw, 20rem);
+  border-radius:1rem;
+  border:1px solid rgba(148,163,184,.4);
+  background-color:#fff;
+  box-shadow:0 30px 60px rgba(15,23,42,.18);
+  padding-block:1rem;
+  padding-inline:1rem;
+  z-index:60;
+}
+
+.mobile-actions__list{
+  display:flex;
+  flex-direction:column;
+  gap:.75rem;
+  list-style:none;
+  margin:0;
+  padding:0;
+}
+
+.mobile-actions__item{
+  margin:0;
+  padding:0;
+}
+
+.mobile-actions__link{
+  display:flex;
+  align-items:center;
+  justify-content:flex-start;
+  gap:.75rem;
+  border-radius:.75rem;
+  border:1px solid rgba(148,163,184,.4);
+  background-color:#f8fafc;
+  color:#0f172a;
+  text-decoration:none;
+  font-weight:600;
+  min-block-size:44px;
+  padding-block:.5rem;
+  padding-inline:1rem;
+  box-shadow:0 1px 2px rgba(148,163,184,.16);
+  transition:background-color .2s ease, transform .2s ease;
+}
+
+.mobile-actions__link:hover{
+  background-color:#e0f2fe;
+  transform:translateY(-1px);
+}
+
+.mobile-actions__link:focus-visible{
+  outline:3px solid #0ea5e9;
+  outline-offset:3px;
+  background-color:#e0f2fe;
+}
+
+.mobile-actions__link svg{
+  inline-size:1.25rem;
+  block-size:1.25rem;
+  flex-shrink:0;
+}
+
+@media (min-width:768px){
+  .mobile-actions__popover{
+    display:none;
+  }
+}

--- a/docs/assets/js/mobile-actions.js
+++ b/docs/assets/js/mobile-actions.js
@@ -1,0 +1,99 @@
+(function(){
+  const containers = document.querySelectorAll('[data-mobile-actions-container]');
+  if(!containers.length) return;
+
+  let partialPromise;
+  const loadPartial = ()=>{
+    if(!partialPromise){
+      partialPromise = fetch('/assets/partials/mobile-actions.html', { credentials: 'same-origin' })
+        .then((response)=>{
+          if(!response.ok) throw new Error('Failed to load mobile actions partial');
+          return response.text();
+        });
+    }
+    return partialPromise;
+  };
+
+  const copyLinkAttributes = (source, target)=>{
+    ['href','title','aria-label','aria-current','target','rel'].forEach((attr)=>{
+      if(source.hasAttribute(attr)){
+        target.setAttribute(attr, source.getAttribute(attr));
+      }
+    });
+  };
+
+  const populateLinks = (root, container)=>{
+    const list = root.querySelector('[data-mobile-actions-list]');
+    if(!list) return;
+    const header = container.closest('header');
+    const sourceNav = header ? header.querySelector('[data-mobile-actions-source]') : document.querySelector('[data-mobile-actions-source]');
+    if(!sourceNav) return;
+
+    const links = sourceNav.querySelectorAll('a[href]');
+    list.innerHTML = '';
+    links.forEach((link)=>{
+      const item = document.createElement('li');
+      item.className = 'mobile-actions__item';
+      const anchor = document.createElement('a');
+      anchor.className = 'mobile-actions__link';
+      anchor.innerHTML = link.innerHTML;
+      copyLinkAttributes(link, anchor);
+      item.appendChild(anchor);
+      list.appendChild(item);
+    });
+  };
+
+  containers.forEach((container)=>{
+    loadPartial().then((html)=>{
+      container.innerHTML = html;
+      const root = container.querySelector('[data-mobile-actions-root]') || container;
+      populateLinks(root, container);
+
+      const trigger = root.querySelector('#mobileActionsBtn');
+      const panel = root.querySelector('#mobileActions');
+      if(!trigger || !panel) return;
+
+      const closePanel = (focusTrigger = true)=>{
+        if(panel.hidden) return;
+        panel.hidden = true;
+        trigger.setAttribute('aria-expanded','false');
+        if(focusTrigger) trigger.focus();
+      };
+
+      const openPanel = ()=>{
+        if(!panel.hidden) return;
+        panel.hidden = false;
+        trigger.setAttribute('aria-expanded','true');
+        const firstLink = panel.querySelector('a');
+        if(firstLink){
+          firstLink.focus();
+        }
+      };
+
+      trigger.addEventListener('click', ()=>{
+        const expanded = trigger.getAttribute('aria-expanded') === 'true';
+        if(expanded){
+          closePanel(false);
+        } else {
+          openPanel();
+        }
+      });
+
+      panel.addEventListener('click', (event)=>{
+        const target = event.target.closest('a');
+        if(target){
+          closePanel(false);
+        }
+      });
+
+      document.addEventListener('keydown', (event)=>{
+        if(event.key === 'Escape' && trigger.getAttribute('aria-expanded') === 'true'){
+          event.preventDefault();
+          closePanel();
+        }
+      });
+    }).catch((error)=>{
+      console.error(error);
+    });
+  });
+})();

--- a/docs/assets/partials/mobile-actions.html
+++ b/docs/assets/partials/mobile-actions.html
@@ -1,0 +1,15 @@
+<div class="mobile-actions" data-mobile-actions-root>
+  <button id="mobileActionsBtn" class="mobile-actions__trigger" type="button" aria-controls="mobileActions" aria-expanded="false">
+    <span class="mobile-actions__trigger-label">منوی ناوبری</span>
+    <svg class="mobile-actions__trigger-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+      <line x1="3" y1="6" x2="21" y2="6" />
+      <line x1="3" y1="12" x2="21" y2="12" />
+      <line x1="3" y1="18" x2="21" y2="18" />
+    </svg>
+  </button>
+  <div id="mobileActions" class="mobile-actions__popover" hidden>
+    <nav aria-label="منوی موبایل">
+      <ul class="mobile-actions__list" data-mobile-actions-list></ul>
+    </nav>
+  </div>
+</div>

--- a/docs/contact/index.html
+++ b/docs/contact/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
   <script src="/assets/js/nav-utils.js" defer></script>
+  <script src="/assets/js/mobile-actions.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
@@ -35,7 +36,7 @@
         <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">WESH360</span>
       </a>
-      <nav class="hidden md:flex items-center gap-3 text-sm">
+      <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>
         <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و گزارش‌گری</span>
@@ -53,6 +54,7 @@
           <span>پژوهش</span>
         </a>
       </nav>
+      <div class="md:hidden" data-mobile-actions-container></div>
     </div>
   </header>
 

--- a/docs/environment/index.html
+++ b/docs/environment/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
   <script src="/assets/js/nav-utils.js" defer></script>
+  <script src="/assets/js/mobile-actions.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
@@ -35,7 +36,7 @@
         <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">WESH360</span>
       </a>
-      <nav class="hidden md:flex items-center gap-3 text-sm">
+      <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>
         <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و حکمرانی داده</span>
@@ -53,6 +54,7 @@
           <span>ماشین‌حساب خورشیدی</span>
         </a>
       </nav>
+      <div class="md:hidden" data-mobile-actions-container></div>
     </div>
   </header>
 

--- a/docs/responsible-disclosure/index.html
+++ b/docs/responsible-disclosure/index.html
@@ -14,6 +14,7 @@
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
   <script src="/assets/js/nav-utils.js" defer></script>
+  <script src="/assets/js/mobile-actions.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
@@ -35,7 +36,7 @@
         <img src="../page/landing/logo2.webp" alt="لوگوی وش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">وش۳۶۰</span>
       </a>
-      <nav class="hidden md:flex items-center gap-3 text-sm">
+      <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>
         <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و حکمرانی داده</span>
@@ -53,6 +54,7 @@
           <span>پژوهشگران</span>
         </a>
       </nav>
+      <div class="md:hidden" data-mobile-actions-container></div>
     </div>
   </header>
 

--- a/docs/responsible-disclosure/thanks.html
+++ b/docs/responsible-disclosure/thanks.html
@@ -13,6 +13,7 @@
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
   <script src="/assets/js/nav-utils.js" defer></script>
+  <script src="/assets/js/mobile-actions.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
@@ -34,7 +35,7 @@
         <img src="../page/landing/logo2.webp" alt="لوگوی وش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">وش۳۶۰</span>
       </a>
-      <nav class="hidden md:flex items-center gap-3 text-sm">
+      <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>
         <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و حکمرانی داده</span>
@@ -52,6 +53,7 @@
           <span>پژوهشگران</span>
         </a>
       </nav>
+      <div class="md:hidden" data-mobile-actions-container></div>
     </div>
   </header>
 

--- a/docs/security-policy/index.html
+++ b/docs/security-policy/index.html
@@ -12,6 +12,7 @@
   <link rel="stylesheet" href="../assets/unified-badge.css" />
   <link rel="icon" type="image/png" href="../Logo.png" />
   <script src="/assets/js/nav-utils.js" defer></script>
+  <script src="/assets/js/mobile-actions.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
@@ -33,7 +34,7 @@
         <img src="../page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">خانه هم‌افزایی انرژی و آب</span>
       </a>
-      <nav class="hidden md:flex items-center gap-3 text-sm">
+      <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>
         <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و حکمرانی داده</span>
@@ -43,6 +44,7 @@
           <span>پژوهشگران</span>
         </a>
       </nav>
+      <div class="md:hidden" data-mobile-actions-container></div>
     </div>
   </header>
 

--- a/docs/solar/index.html
+++ b/docs/solar/index.html
@@ -15,6 +15,7 @@
   <script defer src="../assets/unified-badge.js"></script>
   <script defer src="../assets/global-footer.js"></script>
   <script src="/assets/js/nav-utils.js" defer></script>
+  <script src="/assets/js/mobile-actions.js" defer></script>
 </head>
 <body class="min-h-screen flex flex-col bg-slate-50">
   <a class="skip-link" href="#main">پرش به محتوای اصلی</a>
@@ -36,7 +37,7 @@
         <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">WESH360</span>
       </a>
-      <nav class="hidden md:flex items-center gap-3 text-sm">
+      <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>
         <a href="/security-policy" class="inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-2 font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500">
           <svg class="w-4 h-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" /><path d="m9 12 2 2 4-4" /></svg>
           <span>سیاست امنیت و حکمرانی داده</span>
@@ -54,6 +55,7 @@
           <span>پژوهش</span>
         </a>
       </nav>
+      <div class="md:hidden" data-mobile-actions-container></div>
     </div>
   </header>
 


### PR DESCRIPTION
## Summary
- add a reusable mobile actions partial and loader script to hydrate per-page navigation links
- style the shared component for accessible tap targets and focus states
- include the mobile menu on contact, security, environment, solar, and responsible disclosure pages

## Testing
- npm run serve:docs

------
https://chatgpt.com/codex/tasks/task_e_68e4991ae1e483288d0d4027e0ee9b61