### PR TITLE
Media & Type: fluid typography + picture wiring (no binaries)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+*.png  -text
+*.jpg  -text
+*.jpeg -text
+*.webp -text
+*.avif -text
+*.svg  -text

--- a/docs/assets/css/base.css
+++ b/docs/assets/css/base.css
@@ -1,3 +1,4 @@
+@import url("/assets/css/tokens.css");
 .skip-link{
   position:absolute;
   left:-9999px;

--- a/docs/assets/css/landing.css
+++ b/docs/assets/css/landing.css
@@ -40,14 +40,14 @@
 
 .hero-title {
   margin-top: 15vh;
-  font-size: 2rem;
+  font-size: var(--font-h1);
   line-height: 1.25;
   text-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
 }
 
 .hero-content p {
   margin-top: 0.75rem;
-  font-size: clamp(14px, 2.1vw, 18px);
+  font-size: var(--font-body);
   opacity: 0.95;
 }
 
@@ -95,7 +95,7 @@
   }
   .hero-title {
     margin-top: 10vh;
-    font-size: 1.6rem;
+    font-size: var(--font-h2);
     padding-inline: 16px;
   }
 }
@@ -118,9 +118,13 @@
   }
 }
 
+.cards-section h3 {
+  font-size: var(--font-h3);
+}
+
 .cards-section .card-sub {
   margin-top: 0.75rem;
-  font-size: 0.95rem;
+  font-size: var(--font-body);
   line-height: 1.7;
   color: #334155;
 }

--- a/docs/assets/css/tokens.css
+++ b/docs/assets/css/tokens.css
@@ -1,0 +1,18 @@
+:root{
+  /* breakpoints */
+  --bp-sm: 640px; --bp-md: 768px; --bp-lg: 1024px; --bp-xl: 1280px; --bp-2xl: 1440px;
+  /* spacing scale */
+  --space-1:.25rem; --space-2:.5rem; --space-3:.75rem; --space-4:1rem; --space-5:1.5rem; --space-6:2rem; --space-7:3rem;
+  /* type scale (fluid) */
+  --font-body: clamp(0.95rem, 0.9rem + 0.4vw, 1.05rem);
+  --font-h1:   clamp(1.8rem,  1.4rem + 2.4vw, 3rem);
+  --font-h2:   clamp(1.5rem,  1.2rem + 1.8vw, 2.4rem);
+  --font-h3:   clamp(1.25rem, 1.1rem + 1.2vw, 1.8rem);
+  /* line length */
+  --measure: 75ch;
+}
+body{ font-size:var(--font-body); line-height:1.65; }
+h1{ font-size:var(--font-h1); line-height:1.2; }
+h2{ font-size:var(--font-h2); line-height:1.25; }
+h3{ font-size:var(--font-h3); line-height:1.3; }
+p { max-width: var(--measure); }

--- a/docs/index.html
+++ b/docs/index.html
@@ -36,14 +36,23 @@
           <span class="label">بازگشت</span>
         </a>
         <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
-          <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
-          <span>wesh360</span>
+          <picture class="site-topbar__brand">
+            <source type="image/avif"
+              srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+              sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
+            <source type="image/webp"
+              srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
+              sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
+            <img src="/page/landing/logo2.webp"
+                 width="357" height="357" style="height:auto"
+                 alt="خانه هم‌افزایی انرژی و آب" decoding="async" fetchpriority="high">
+          </picture>
         </a>
       </div>
     </header>
     <header class="site-header relative flex justify-center items-center px-4">
       <a class="logo inline-flex items-center justify-center" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
-        <img src="page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
+        <img src="/page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
       </a>
       <div class="absolute top-4 right-4 flex items-center gap-2">
         <a href="/security-policy" class="hidden md:inline-flex items-center gap-1 rounded-lg border border-slate-300 bg-white/80 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-sky-500" title="سیاست امنیت و حکمرانی داده">

--- a/docs/solar/index.html
+++ b/docs/solar/index.html
@@ -26,15 +26,24 @@
         <span class="label">بازگشت</span>
       </a>
       <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
-        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
-        <span>wesh360</span>
+        <picture class="site-topbar__brand">
+          <source type="image/avif"
+            srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+            sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
+          <source type="image/webp"
+            srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
+            sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
+          <img src="/page/landing/logo2.webp"
+               width="357" height="357" style="height:auto"
+               alt="خانه هم‌افزایی انرژی و آب" decoding="async">
+        </picture>
       </a>
     </div>
   </header>
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
-        <img src="../page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
+        <img src="/page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
         <span class="text-base md:text-lg">WESH360</span>
       </a>
       <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>

--- a/docs/water/hub.html
+++ b/docs/water/hub.html
@@ -24,8 +24,17 @@
         <span class="label">بازگشت</span>
       </a>
       <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
-        <img src="/page/landing/logo2.webp" alt="لوگوی wesh360" loading="lazy" decoding="async">
-        <span>wesh360</span>
+        <picture class="site-topbar__brand">
+          <source type="image/avif"
+            srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+            sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
+          <source type="image/webp"
+            srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
+            sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
+          <img src="/page/landing/logo2.webp"
+               width="357" height="357" style="height:auto"
+               alt="خانه هم‌افزایی انرژی و آب" decoding="async">
+        </picture>
       </a>
     </div>
   </header>

--- a/docs/water/water.css
+++ b/docs/water/water.css
@@ -1,13 +1,16 @@
 /* ===== Base (desktop) styles ===== */
 body { background-color: #f0f4f8; }
 
-.main-title { font-weight: 800; color: #1e3a8a; }
+.main-title { font-weight: 800; color: #1e3a8a; font-size: var(--font-h1); line-height: 1.2; }
 
 .dashboard {
   max-width: 1200px;
   margin: 0 auto;
   width: 100%;
 }
+
+.cards h2 { font-size: var(--font-h2); }
+.cards h3 { font-size: var(--font-h3); }
 
 .cards {
   display: grid;
@@ -41,6 +44,7 @@ body { background-color: #f0f4f8; }
   position: relative;
   width: 150px;
   height: 150px;
+  aspect-ratio: 1 / 1;
   margin: 0 auto;
 }
 
@@ -132,7 +136,7 @@ input[type=range]::-moz-range-thumb {
 #solution-result {
   margin-top: .75rem;
   line-height: 1.9;
-  font-size: .9rem;
+  font-size: var(--font-body);
 }
 
 .site-logo {
@@ -141,6 +145,7 @@ input[type=range]::-moz-range-thumb {
   right: 10px;
   width: 150px;
   height: auto;
+  aspect-ratio: 1 / 1;
   max-width: 150px;
   max-height: 150px;
   z-index: 1000;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "glob": "^11.0.3",
         "http-server": "^14.1.1",
         "puppeteer": "^24.20.0",
+        "sharp": "^0.34.4",
         "supercluster": "^7.1.5",
         "tailwindcss": "^3.4.17",
         "terser": "^5.43.1",
@@ -675,6 +676,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
+      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@envelop/instrumentation": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@envelop/instrumentation/-/instrumentation-1.0.0.tgz",
@@ -1116,6 +1128,456 @@
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
       "license": "MIT"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
+      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
+      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
+      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
+      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
+      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
+      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
+      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
+      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
+      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
+      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
+      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
+      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
+      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
+      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
+      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
+      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
+      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
+      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.5.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
+      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
+      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
+      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@isaacs/balanced-match": {
       "version": "4.0.1",
@@ -3132,9 +3594,9 @@
       }
     },
     "node_modules/detect-libc": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.4.tgz",
-      "integrity": "sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -6363,6 +6825,49 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.4",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
+      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.0",
+        "semver": "^7.7.2"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.4",
+        "@img/sharp-darwin-x64": "0.34.4",
+        "@img/sharp-libvips-darwin-arm64": "1.2.3",
+        "@img/sharp-libvips-darwin-x64": "1.2.3",
+        "@img/sharp-libvips-linux-arm": "1.2.3",
+        "@img/sharp-libvips-linux-arm64": "1.2.3",
+        "@img/sharp-libvips-linux-ppc64": "1.2.3",
+        "@img/sharp-libvips-linux-s390x": "1.2.3",
+        "@img/sharp-libvips-linux-x64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
+        "@img/sharp-linux-arm": "0.34.4",
+        "@img/sharp-linux-arm64": "0.34.4",
+        "@img/sharp-linux-ppc64": "0.34.4",
+        "@img/sharp-linux-s390x": "0.34.4",
+        "@img/sharp-linux-x64": "0.34.4",
+        "@img/sharp-linuxmusl-arm64": "0.34.4",
+        "@img/sharp-linuxmusl-x64": "0.34.4",
+        "@img/sharp-wasm32": "0.34.4",
+        "@img/sharp-win32-arm64": "0.34.4",
+        "@img/sharp-win32-ia32": "0.34.4",
+        "@img/sharp-win32-x64": "0.34.4"
       }
     },
     "node_modules/shebang-command": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
     "serve:docs": "http-server docs -p 5050 -c-1 --silent",
     "audit:encoding": "node tools/audit-encoding.mjs",
     "fix:text:core": "node tools/fix-mojibake.js --relax",
-    "fix:text:landing": "node tools/fix-mojibake.js --paths docs/index.html --force"
+    "fix:text:landing": "node tools/fix-mojibake.js --paths docs/index.html --force",
+    "gen:logo": "node scripts/gen-logo-assets.mjs",
+    "assert:assets": "node scripts/assert-assets.mjs"
   },
   "keywords": [],
   "author": "",
@@ -71,6 +73,7 @@
     "glob": "^11.0.3",
     "http-server": "^14.1.1",
     "puppeteer": "^24.20.0",
+    "sharp": "^0.34.4",
     "supercluster": "^7.1.5",
     "tailwindcss": "^3.4.17",
     "terser": "^5.43.1",

--- a/scripts/assert-assets.mjs
+++ b/scripts/assert-assets.mjs
@@ -1,0 +1,12 @@
+import { statSync } from "fs";
+const files = [
+  "docs/page/landing/logo2.webp",
+  "docs/page/landing/logo2-240.webp",
+  "docs/page/landing/logo2-160.webp",
+  "docs/page/landing/logo2.avif",
+  "docs/page/landing/logo2-240.avif",
+  "docs/page/landing/logo2-160.avif",
+];
+const bad = files.filter(f => { try { return statSync(f).size === 0; } catch { return true; } });
+if (bad.length) { console.error("Zero-byte or missing:", bad); process.exit(1); }
+console.log("✓ Logo assets OK");

--- a/scripts/gen-logo-assets.mjs
+++ b/scripts/gen-logo-assets.mjs
@@ -1,0 +1,31 @@
+import sharp from "sharp";
+import { mkdirSync, statSync } from "fs";
+const src = "docs/page/landing/logo2-source.png"; // اگر png/svg است، همان مسیر/پسوند
+const out = "docs/page/landing";
+mkdirSync(out, { recursive: true });
+const SIZES = [160, 240, 357];
+const webpCfg = { lossless: true };
+const avifCfg = { quality: 55, effort: 6 };
+
+const results = [];
+for (const w of SIZES) {
+  const base = (w === 357) ? "logo2" : `logo2-${w}`;
+  // WebP
+  await sharp(src, { limitInputPixels: false })
+    .resize({ width: w, withoutEnlargement: true })
+    .toFile(`${out}/${base}.webp`, webpCfg);
+  // AVIF (با تحمل خطا)
+  try{
+    await sharp(src, { limitInputPixels: false })
+      .resize({ width: w, withoutEnlargement: true })
+      .toFile(`${out}/${base}.avif`, avifCfg);
+  }catch(e){
+    console.warn("AVIF encode failed, continuing with WebP only for", base, e?.message||e);
+  }
+  // گزارش اندازه‌ها
+  const files = [`${out}/${base}.webp`, `${out}/${base}.avif`];
+  for (const f of files) {
+    try { results.push({ file:f, bytes: statSync(f).size }); } catch {}
+  }
+}
+console.log(JSON.stringify({ generated: results }, null, 2));


### PR DESCRIPTION
## Summary
- introduce shared fluid typography and spacing tokens and import them globally
- update landing and water CSS plus top-bar markup to use responsive picture brand assets
- add Sharp-based logo generator, zero-byte asset guard, and npm scripts (binaries to be uploaded separately)

## Checklist
- [ ] Upload /page/landing/logo2*.{webp,avif} via GitHub UI
- [ ] Run `npm run assert:assets` after upload

------
https://chatgpt.com/codex/tasks/task_e_68e4abd337e483289fe7f2cc0ef5ecbe