### PR TITLE
Switch landing hero to HTML-driven imagery

### DIFF
--- a/docs/assets/css/landing.css
+++ b/docs/assets/css/landing.css
@@ -1,31 +1,42 @@
-﻿:root {
-  --overlay: 0.35;
-}
-
-.hero,
-.parallax-section {
-  background-image: url("/assets/img/hero/hero-desktop.webp");
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  background-attachment: fixed;
-  min-height: clamp(420px, 80vh, 920px);
+.site-header {
   position: relative;
+  z-index: 30;
 }
 
-.no-webp .hero,
-.no-webp .parallax-section {
-  background-image: url("/assets/hero2.jpg");
+.hero {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: clamp(60vh, 70svh, 80svh);
+  overflow: hidden;
 }
 
-.hero::after,
-.parallax-section::after {
+.hero .media {
+  position: absolute;
+  inset: 0;
+}
+
+.hero .hero-picture,
+.hero .hero-img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.hero .hero-img {
+  object-fit: cover;
+  object-position: center 40%;
+}
+
+.hero::before {
   content: "";
   position: absolute;
   inset: 0;
-  z-index: 1;
+  background:
+    linear-gradient(to bottom, rgba(0, 0, 0, 0.45), rgba(0, 0, 0, 0.2) 40%, rgba(0, 0, 0, 0.35)),
+    linear-gradient(to top, rgba(0, 0, 0, 0.35), transparent 60%);
   pointer-events: none;
-  background: linear-gradient(to bottom, rgba(0 0 0 / var(--overlay, 0.35)) 0%, rgba(0 0 0 / 0.15) 40%, rgba(0 0 0 / 0.55) 100%);
+  z-index: 1;
 }
 
 .hero-content {
@@ -84,14 +95,9 @@
 }
 
 @media (max-width: 768px) {
-  .hero,
-  .parallax-section {
-    background-image: url("/assets/img/hero/hero-mobile.webp");
+  .hero {
     background-attachment: scroll;
-  }
-  .hero::after,
-  .parallax-section::after {
-    background: linear-gradient(to bottom, rgba(0 0 0 / 0.25) 0%, rgba(0 0 0 / 0.1) 50%, rgba(0 0 0 / 0.35) 100%);
+    min-height: min(100svh, 85vh);
   }
   .hero-title {
     margin-top: 10vh;

--- a/docs/assets/parallax.js
+++ b/docs/assets/parallax.js
@@ -1,6 +1,6 @@
 (function(){
   const reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-  const hero = document.querySelector('.parallax-section');
+  const hero = document.querySelector('.hero');
   if (!hero) return;
 
   const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);

--- a/docs/index.html
+++ b/docs/index.html
@@ -81,7 +81,27 @@
         <div class="md:hidden" data-mobile-actions-container></div>
       </div>
     </header>
-    <section class="hero parallax-section" aria-label="hero">
+    <section class="hero">
+      <div class="media">
+        <picture class="hero-picture">
+          <!-- desktop -->
+          <source media="(min-width:1024px)" type="image/avif"
+                  srcset="/page/landing/hero/hero-wide-1920.avif?v=20251007 1920w,
+                          /page/landing/hero/hero-wide-1280.avif?v=20251007 1280w"
+                  sizes="100vw">
+          <source media="(min-width:1024px)" type="image/webp"
+                  srcset="/page/landing/hero/hero-wide-1920.webp?v=20251007 1920w,
+                          /page/landing/hero/hero-wide-1280.webp?v=20251007 1280w"
+                  sizes="100vw">
+          <!-- mobile -->
+          <source type="image/avif"
+                  srcset="/page/landing/hero/hero-tall-828.avif?v=20251007 828w,
+                          /page/landing/hero/hero-tall-576.avif?v=20251007 576w"
+                  sizes="100vw">
+          <img src="/page/landing/hero/hero-tall-828.webp?v=20251007"
+               alt="" width="1920" height="1080" decoding="async" fetchpriority="high" class="hero-img">
+        </picture>
+      </div>
       <div class="hero-content">
         <h1 class="hero-title">مدیریت هوشمند آب، برق و گاز در خراسان رضوی</h1>
         <p>داشبوردهای تعاملی برای آگاهی، بهینه‌سازی و تصمیم‌گیری بهتر</p>


### PR DESCRIPTION
## Summary
- replace the landing hero markup with a picture element sourcing the art-directed hero assets with cache-busting query strings
- restyle the hero container to size and overlay the HTML imagery while keeping the header layering and mobile height cap
- point the parallax helper at the updated hero selector to preserve scroll effects

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4da80cdac8328865ed0f184d91587