### PR TITLE
Improve household wizard chart responsiveness

### DIFF
--- a/docs/assets/css/landing.css
+++ b/docs/assets/css/landing.css
@@ -196,8 +196,8 @@
   .chip[data-level="low"]  { background:#064e3b; color:#bbf7d0; border-color:#065f46; }
 }
 
-.chart-wrap { margin: 12px auto; max-width: 560px; height: clamp(200px, 35vh, 360px); }
-.wiz-chart { width: 100%; aspect-ratio: 21 / 11; display: block; }
+.chart-wrap{ margin:12px auto; max-width:560px; height:clamp(200px, 35vh, 360px); }
+.wiz-chart{ width:100%; aspect-ratio: 21/11; display:block; }
 .tips { margin: 8px 0 0; padding-inline-start: 18px; }
 .note { margin-top: 6px; font-size: 12px; color:#475569; }
 

--- a/docs/assets/household-wizard.js
+++ b/docs/assets/household-wizard.js
@@ -11,6 +11,7 @@
     chart: null,
     chartLib: null,
     chartObserver: null,
+    chartObserverTarget: null,
     storageKey: 'wesh.household.v1'
   };
 
@@ -146,7 +147,10 @@
     const canvas = $('#wiz-chart');
     if (!canvas) return;
     const ctx = canvas.getContext('2d');
-    if (state.chart) { state.chart.destroy(); state.chart = null; }
+    if (state.chart) {
+      state.chart.destroy();
+      state.chart = null;
+    }
     const unit = state.utility==='water' ? 'L' : 'kWh';
     state.chart = new state.chartLib.Chart(ctx, {
       type: 'bar',
@@ -169,7 +173,13 @@
             state.chart.resize();
           }
         });
+      }
+      if (state.chartObserverTarget && state.chartObserverTarget !== wrap) {
+        state.chartObserver.unobserve(state.chartObserverTarget);
+      }
+      if (state.chartObserverTarget !== wrap) {
         state.chartObserver.observe(wrap);
+        state.chartObserverTarget = wrap;
       }
     }
   }


### PR DESCRIPTION
## Summary
- normalize wizard chart canvas styling to use responsive width and aspect ratio utilities
- ensure the household wizard chart resizes with its container by wiring Chart.js for responsive rendering and observing container size changes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4e0b9beec832883520b33a91f3645