### PR TITLE
Fix landing hero assets and mobile actions fallback

### DIFF
--- a/docs/assets/js/mobile-actions.js
+++ b/docs/assets/js/mobile-actions.js
@@ -2,16 +2,40 @@
   const containers = document.querySelectorAll('[data-mobile-actions-container]');
   if(!containers.length) return;
 
+  const ICON_CHEVRON_LEFT = '<svg class="mobile-actions__trigger-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true"><path d="M15 19l-7-7 7-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
   let partialPromise;
   const loadPartial = ()=>{
     if(!partialPromise){
-      partialPromise = fetch('/assets/partials/mobile-actions.html', { credentials: 'same-origin' })
-        .then((response)=>{
-          if(!response.ok) throw new Error('Failed to load mobile actions partial');
-          return response.text();
-        });
+      partialPromise = (async ()=>{
+        try{
+          const response = await fetch('/assets/partials/mobile-actions.html', { credentials: 'same-origin' });
+          if(!response.ok) return null;
+          return await response.text();
+        }catch{
+          return null;
+        }
+      })();
     }
     return partialPromise;
+  };
+
+  const createFallback = ()=>{
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mobile-actions';
+    wrapper.setAttribute('data-mobile-actions-root', '');
+    wrapper.innerHTML = [
+      '<button id="mobileActionsBtn" class="mobile-actions__trigger" type="button" aria-controls="mobileActions" aria-expanded="false">',
+        '<span class="mobile-actions__trigger-label">منوی ناوبری</span>',
+        ICON_CHEVRON_LEFT,
+      '</button>',
+      '<div id="mobileActions" class="mobile-actions__popover" hidden>',
+        '<nav aria-label="منوی موبایل">',
+          '<ul class="mobile-actions__list" data-mobile-actions-list></ul>',
+        '</nav>',
+      '</div>'
+    ].join('');
+    return wrapper;
   };
 
   const copyLinkAttributes = (source, target)=>{
@@ -45,8 +69,16 @@
 
   containers.forEach((container)=>{
     loadPartial().then((html)=>{
-      container.innerHTML = html;
-      const root = container.querySelector('[data-mobile-actions-root]') || container;
+      let root;
+      if(html){
+        container.innerHTML = html;
+        root = container.querySelector('[data-mobile-actions-root]') || container;
+      } else {
+        const fallback = createFallback();
+        container.innerHTML = '';
+        container.appendChild(fallback);
+        root = fallback;
+      }
       populateLinks(root, container);
 
       const trigger = root.querySelector('#mobileActionsBtn');
@@ -92,8 +124,6 @@
           closePanel();
         }
       });
-    }).catch((error)=>{
-      console.error(error);
     });
   });
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,8 +17,10 @@
   <link rel="stylesheet" href="/assets/css/landing.css">
   <link rel="stylesheet" href="./assets/global-footer.css">
   <link rel="stylesheet" href="./assets/footer.css">
-  <link rel="preload" as="image" href="/assets/img/hero/hero-desktop.webp" imagesrcset="/assets/img/hero/hero-desktop.webp" media="(min-width: 769px)">
-  <link rel="preload" as="image" href="/assets/img/hero/hero-mobile.webp" imagesrcset="/assets/img/hero/hero-mobile.webp" media="(max-width: 768px)">
+  <link rel="preload" as="image"
+        href="/assets/img/hero/hero-mobile.webp"
+        imagesrcset="/assets/img/hero/hero-mobile.webp 828w"
+        imagesizes="100vw">
   <link rel="stylesheet" href="./assets/fonts.css">
   <link rel="stylesheet" href="./assets/unified-badge.css">
   <link rel="stylesheet" href="/assets/css/site.css">
@@ -39,7 +41,7 @@
         <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
           <picture class="site-topbar__brand">
             <source type="image/avif"
-              srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+              srcset="/page/landing/logo2.avif 357w"
               sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
             <source type="image/webp"
               srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
@@ -84,21 +86,7 @@
     <section class="hero">
       <div class="media">
         <picture class="hero-picture">
-          <!-- desktop -->
-          <source media="(min-width:1024px)" type="image/avif"
-                  srcset="/page/landing/hero/hero-wide-1920.avif?v=20251007 1920w,
-                          /page/landing/hero/hero-wide-1280.avif?v=20251007 1280w"
-                  sizes="100vw">
-          <source media="(min-width:1024px)" type="image/webp"
-                  srcset="/page/landing/hero/hero-wide-1920.webp?v=20251007 1920w,
-                          /page/landing/hero/hero-wide-1280.webp?v=20251007 1280w"
-                  sizes="100vw">
-          <!-- mobile -->
-          <source type="image/avif"
-                  srcset="/page/landing/hero/hero-tall-828.avif?v=20251007 828w,
-                          /page/landing/hero/hero-tall-576.avif?v=20251007 576w"
-                  sizes="100vw">
-          <img src="/page/landing/hero/hero-tall-828.webp?v=20251007"
+          <img src="/assets/img/hero/hero-mobile.webp"
                alt="" width="1920" height="1080" decoding="async" fetchpriority="high" class="hero-img">
         </picture>
       </div>


### PR DESCRIPTION
## Summary
- temporarily serve the landing hero from the existing `/assets/img/hero/hero-mobile.webp` and align the preload so the page only references shipped assets while the desktop binaries are added outside this PR
- make the mobile actions script gracefully handle a missing partial by generating a fallback menu without console errors
- update the topbar logo sources to avoid referencing non-existent AVIF variants

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4e6c643388328a182efdb05546470