### PR TITLE
Fix landing hero assets, mobile actions fallback, and water hero

### DIFF
--- a/docs/assets/js/mobile-actions.js
+++ b/docs/assets/js/mobile-actions.js
@@ -2,16 +2,40 @@
   const containers = document.querySelectorAll('[data-mobile-actions-container]');
   if(!containers.length) return;
 
+  const ICON_CHEVRON_LEFT = '<svg class="mobile-actions__trigger-icon" viewBox="0 0 24 24" width="20" height="20" aria-hidden="true"><path d="M15 19l-7-7 7-7" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>';
+
   let partialPromise;
   const loadPartial = ()=>{
     if(!partialPromise){
-      partialPromise = fetch('/assets/partials/mobile-actions.html', { credentials: 'same-origin' })
-        .then((response)=>{
-          if(!response.ok) throw new Error('Failed to load mobile actions partial');
-          return response.text();
-        });
+      partialPromise = (async ()=>{
+        try{
+          const response = await fetch('/assets/partials/mobile-actions.html', { credentials: 'same-origin' });
+          if(!response.ok) return null;
+          return await response.text();
+        }catch{
+          return null;
+        }
+      })();
     }
     return partialPromise;
+  };
+
+  const createFallback = ()=>{
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mobile-actions';
+    wrapper.setAttribute('data-mobile-actions-root', '');
+    wrapper.innerHTML = [
+      '<button id="mobileActionsBtn" class="mobile-actions__trigger" type="button" aria-controls="mobileActions" aria-expanded="false">',
+        '<span class="mobile-actions__trigger-label">منوی ناوبری</span>',
+        ICON_CHEVRON_LEFT,
+      '</button>',
+      '<div id="mobileActions" class="mobile-actions__popover" hidden>',
+        '<nav aria-label="منوی موبایل">',
+          '<ul class="mobile-actions__list" data-mobile-actions-list></ul>',
+        '</nav>',
+      '</div>'
+    ].join('');
+    return wrapper;
   };
 
   const copyLinkAttributes = (source, target)=>{
@@ -45,8 +69,16 @@
 
   containers.forEach((container)=>{
     loadPartial().then((html)=>{
-      container.innerHTML = html;
-      const root = container.querySelector('[data-mobile-actions-root]') || container;
+      let root;
+      if(html){
+        container.innerHTML = html;
+        root = container.querySelector('[data-mobile-actions-root]') || container;
+      } else {
+        const fallback = createFallback();
+        container.innerHTML = '';
+        container.appendChild(fallback);
+        root = fallback;
+      }
       populateLinks(root, container);
 
       const trigger = root.querySelector('#mobileActionsBtn');
@@ -92,8 +124,6 @@
           closePanel();
         }
       });
-    }).catch((error)=>{
-      console.error(error);
     });
   });
 })();

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,8 +17,11 @@
   <link rel="stylesheet" href="/assets/css/landing.css">
   <link rel="stylesheet" href="./assets/global-footer.css">
   <link rel="stylesheet" href="./assets/footer.css">
-  <link rel="preload" as="image" href="/assets/img/hero/hero-desktop.webp" imagesrcset="/assets/img/hero/hero-desktop.webp" media="(min-width: 769px)">
-  <link rel="preload" as="image" href="/assets/img/hero/hero-mobile.webp" imagesrcset="/assets/img/hero/hero-mobile.webp" media="(max-width: 768px)">
+  <link rel="preload" as="image"
+        href="/assets/img/hero/hero-mobile.webp"
+        imagesrcset="/assets/img/hero/hero-mobile.webp 828w"
+        imagesizes="100vw"
+        media="(max-width:1023.98px)">
   <link rel="stylesheet" href="./assets/fonts.css">
   <link rel="stylesheet" href="./assets/unified-badge.css">
   <link rel="stylesheet" href="/assets/css/site.css">
@@ -39,7 +42,7 @@
         <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
           <picture class="site-topbar__brand">
             <source type="image/avif"
-              srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+              srcset="/page/landing/logo2.avif 357w"
               sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
             <source type="image/webp"
               srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
@@ -84,21 +87,7 @@
     <section class="hero">
       <div class="media">
         <picture class="hero-picture">
-          <!-- desktop -->
-          <source media="(min-width:1024px)" type="image/avif"
-                  srcset="/page/landing/hero/hero-wide-1920.avif?v=20251007 1920w,
-                          /page/landing/hero/hero-wide-1280.avif?v=20251007 1280w"
-                  sizes="100vw">
-          <source media="(min-width:1024px)" type="image/webp"
-                  srcset="/page/landing/hero/hero-wide-1920.webp?v=20251007 1920w,
-                          /page/landing/hero/hero-wide-1280.webp?v=20251007 1280w"
-                  sizes="100vw">
-          <!-- mobile -->
-          <source type="image/avif"
-                  srcset="/page/landing/hero/hero-tall-828.avif?v=20251007 828w,
-                          /page/landing/hero/hero-tall-576.avif?v=20251007 576w"
-                  sizes="100vw">
-          <img src="/page/landing/hero/hero-tall-828.webp?v=20251007"
+          <img src="/assets/img/hero/hero-mobile.webp"
                alt="" width="1920" height="1080" decoding="async" fetchpriority="high" class="hero-img">
         </picture>
       </div>

--- a/docs/water/hub.html
+++ b/docs/water/hub.html
@@ -11,6 +11,17 @@
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
   <link rel="stylesheet" href="/assets/site-overrides.css">
+  <link rel="stylesheet" href="water.css">
+  <link rel="preload" as="image"
+        href="/assets/img/hero/hero-desktop-1280.webp"
+        imagesrcset="/assets/img/hero/hero-desktop-1280.webp 1280w, /assets/img/hero/hero-desktop-1920.webp 1920w"
+        imagesizes="100vw"
+        media="(min-width:1024px)">
+  <link rel="preload" as="image"
+        href="/assets/img/hero/hero-mobile.webp"
+        imagesrcset="/assets/img/hero/hero-mobile.webp 828w"
+        imagesizes="100vw"
+        media="(max-width:1023.98px)">
   <script charset="utf-8" defer src="/assets/unified-badge.js"></script>
   <script charset="utf-8" defer src="/assets/global-footer.js"></script>
   <script src="/assets/js/nav-utils.js" defer></script>
@@ -38,6 +49,24 @@
       </a>
     </div>
   </header>
+  <section class="hero">
+    <div class="media">
+      <picture class="hero-picture">
+        <source type="image/webp" media="(min-width:1024px)"
+                srcset="/assets/img/hero/hero-desktop-1280.webp 1280w, /assets/img/hero/hero-desktop-1920.webp 1920w"
+                sizes="100vw">
+        <img class="hero-img"
+             src="/assets/img/hero/hero-mobile.webp"
+             alt=""
+             decoding="async"
+             fetchpriority="high"
+             width="1920" height="1080">
+      </picture>
+    </div>
+    <div class="hero-content" aria-hidden="true">
+      <p class="hero-tagline">پلتفرم تخصصی آب wesh360</p>
+    </div>
+  </section>
   <main id="main" role="main" class="max-w-6xl mx-auto px-4 py-10 md:py-14">
     <h1 class="text-2xl md:text-3xl font-bold text-slate-800 text-center">یک داشبورد انتخاب کنید</h1>
     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 md:gap-8 mt-10">

--- a/docs/water/insights.html
+++ b/docs/water/insights.html
@@ -17,6 +17,16 @@
       <link rel="stylesheet" href="/assets/css/base.css">
 
   <link rel="stylesheet" href="water.css">
+  <link rel="preload" as="image"
+        href="/assets/img/hero/hero-desktop-1280.webp"
+        imagesrcset="/assets/img/hero/hero-desktop-1280.webp 1280w, /assets/img/hero/hero-desktop-1920.webp 1920w"
+        imagesizes="100vw"
+        media="(min-width:1024px)">
+  <link rel="preload" as="image"
+        href="/assets/img/hero/hero-mobile.webp"
+        imagesrcset="/assets/img/hero/hero-mobile.webp 828w"
+        imagesizes="100vw"
+        media="(max-width:1023.98px)">
   <!-- Vazirmatn -->
   <link rel="stylesheet" href="/assets/global-footer.css">
   <link rel="stylesheet" href="/assets/unified-badge.css">
@@ -39,6 +49,24 @@
         </a>
       </div>
     </header>
+    <section class="hero">
+      <div class="media">
+        <picture class="hero-picture">
+          <source type="image/webp" media="(min-width:1024px)"
+                  srcset="/assets/img/hero/hero-desktop-1280.webp 1280w, /assets/img/hero/hero-desktop-1920.webp 1920w"
+                  sizes="100vw">
+          <img class="hero-img"
+               src="/assets/img/hero/hero-mobile.webp"
+               alt=""
+               decoding="async"
+               fetchpriority="high"
+               width="1920" height="1080">
+        </picture>
+      </div>
+      <div class="hero-content" aria-hidden="true">
+        <p class="hero-tagline">داشبورد وضعیت آب مشهد</p>
+      </div>
+    </section>
     <main id="main" role="main" class="dashboard container mx-auto p-4 md:p-8">
         <header class="text-center mb-12">
             <h1 class="text-4xl md:text-5xl font-extrabold main-title">وضعیت بحرانی آب در مشهد</h1>

--- a/docs/water/water.css
+++ b/docs/water/water.css
@@ -1,6 +1,65 @@
 /* ===== Base (desktop) styles ===== */
 body { background-color: #f0f4f8; }
 
+.hero {
+  position: relative;
+  display: grid;
+  place-items: center;
+  min-height: clamp(40vh, 60vh, 72vh);
+  overflow: hidden;
+}
+
+.hero .media {
+  position: absolute;
+  inset: 0;
+}
+
+.hero .hero-picture,
+.hero .hero-img {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.hero .hero-img {
+  object-fit: cover;
+  object-position: center 40%;
+}
+
+.hero::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to bottom, rgba(6, 41, 82, 0.55), rgba(9, 105, 172, 0.35) 45%, rgba(12, 74, 110, 0.6)),
+              linear-gradient(to top, rgba(6, 41, 82, 0.45), transparent 60%);
+  pointer-events: none;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  color: #f8fafc;
+  padding: clamp(2rem, 6vw, 4rem);
+  display: grid;
+  gap: 1rem;
+}
+
+.hero-tagline {
+  font-size: clamp(1.125rem, 2.2vw, 1.75rem);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+@media (max-width: 768px) {
+  .hero {
+    min-height: min(100svh, 72vh);
+  }
+  .hero-content {
+    padding: clamp(1.5rem, 8vw, 3rem);
+  }
+}
+
 .main-title { font-weight: 800; color: #1e3a8a; font-size: var(--font-h1); line-height: 1.2; }
 
 .dashboard {

--- a/scripts/verify-hero-assets.mjs
+++ b/scripts/verify-hero-assets.mjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+import { readFile } from 'fs/promises';
+import path from 'path';
+import process from 'process';
+import fg from 'fast-glob';
+
+const allowedHeroPaths = new Set([
+  '/assets/img/hero/hero-mobile.webp',
+  '/assets/img/hero/hero-desktop-1280.webp',
+  '/assets/img/hero/hero-desktop-1920.webp'
+]);
+
+const summary = {
+  badPaths: [],
+  badAvifRefs: [],
+  badPreloads: [],
+  heroPictures: {},
+  cssBackgroundImageRefs: [],
+  status: 'PENDING'
+};
+
+const pageConfigs = new Map([
+  [
+    path.normalize('docs/index.html'),
+    {
+      pageKey: 'landing',
+      requireDesktopSource: false,
+      requireDesktopPreload: false,
+      requireMobilePreload: true
+    }
+  ],
+  [
+    path.normalize('docs/water/hub.html'),
+    {
+      pageKey: 'waterHub',
+      requireDesktopSource: true,
+      requireDesktopPreload: true,
+      requireMobilePreload: true
+    }
+  ],
+  [
+    path.normalize('docs/water/insights.html'),
+    {
+      pageKey: 'waterInsights',
+      requireDesktopSource: true,
+      requireDesktopPreload: true,
+      requireMobilePreload: true
+    }
+  ]
+]);
+
+function ensurePageSummary(pageKey) {
+  if (!summary.heroPictures[pageKey]) {
+    summary.heroPictures[pageKey] = {
+      imgSrc: null,
+      sourceWebp: [],
+      preloads: {
+        desktop: [],
+        mobile: []
+      }
+    };
+  }
+  return summary.heroPictures[pageKey];
+}
+
+function getAttr(tag, attr) {
+  const regex = new RegExp(`${attr}\\s*=\\s*("([^"]*)"|'([^']*)')`, 'i');
+  const match = tag.match(regex);
+  if (!match) return null;
+  return match[2] ?? match[3] ?? null;
+}
+
+function getPosition(content, index) {
+  const linesUntil = content.slice(0, index).split('\n');
+  const line = linesUntil.length;
+  const column = linesUntil[linesUntil.length - 1].length + 1;
+  return { line, column };
+}
+
+function pushIssue(arr, file, content, index, value, message) {
+  const pos = getPosition(content, index);
+  arr.push({ file, line: pos.line, column: pos.column, value, message });
+}
+
+async function collectFiles() {
+  const patterns = [
+    'docs/index.html',
+    'docs/**/*.html',
+    'docs/assets/css/**/*.css',
+    'docs/assets/js/**/*.js'
+  ];
+  const entries = await fg(patterns, {
+    ignore: ['**/node_modules/**', '**/vendor/**', '**/dist/**', '**/images/**'],
+    dot: false
+  });
+  return Array.from(new Set(entries.map((entry) => path.normalize(entry))));
+}
+
+function analyzeHeroReferences(file, content) {
+  const heroRegex = /(\/assets\/img\/hero|\/page\/landing\/hero)[^"'\s<>)]*/g;
+  for (const match of content.matchAll(heroRegex)) {
+    const value = match[0];
+    const index = match.index ?? 0;
+    if (value.startsWith('/page/landing/hero')) {
+      pushIssue(summary.badPaths, file, content, index, value, 'legacy hero path reference');
+      continue;
+    }
+    if (!allowedHeroPaths.has(value)) {
+      pushIssue(summary.badPaths, file, content, index, value, 'unexpected hero asset reference');
+    }
+    if (value.endsWith('.avif')) {
+      pushIssue(summary.badAvifRefs, file, content, index, value, 'hero AVIF reference is not allowed');
+    }
+  }
+}
+
+function checkCssBackground(file, content) {
+  const heroUrlRegex = /(^|\})\s*\.hero(?:[:]{1,2}[^{]+)?[^{}]*\{[^}]*url\(/gis;
+  for (const match of content.matchAll(heroUrlRegex)) {
+    const index = match.index ?? 0;
+    pushIssue(summary.cssBackgroundImageRefs, file, content, index, 'url(', 'hero should not define background images via url()');
+  }
+}
+
+function analyzeHeroPicture(file, content, { pageKey, requireDesktopSource }) {
+  const pageSummary = ensurePageSummary(pageKey);
+  pageSummary.sourceWebp = [];
+  const pictureMatch = content.match(/<picture[^>]*class=["']hero-picture["'][^>]*>[\s\S]*?<\/picture>/i);
+  if (!pictureMatch) {
+    summary.badPreloads.push({ file, line: null, column: null, value: null, message: 'hero <picture> not found' });
+    return;
+  }
+  const pictureHtml = pictureMatch[0];
+  const imgMatch = pictureHtml.match(/<img[^>]*>/i);
+  if (!imgMatch) {
+    summary.badPreloads.push({ file, line: null, column: null, value: null, message: 'hero <img> not found' });
+  } else {
+    const imgTag = imgMatch[0];
+    const imgSrc = getAttr(imgTag, 'src');
+    pageSummary.imgSrc = imgSrc;
+    if (imgSrc !== '/assets/img/hero/hero-mobile.webp') {
+      summary.badPreloads.push({ file, line: null, column: null, value: imgSrc, message: 'hero <img> src must be hero-mobile.webp' });
+    }
+  }
+
+  const sourceMatches = [...pictureHtml.matchAll(/<source[^>]*>/gi)];
+  const desktopSources = [];
+  for (const sourceMatch of sourceMatches) {
+    const sourceTag = sourceMatch[0];
+    const type = getAttr(sourceTag, 'type')?.toLowerCase() ?? '';
+    const media = getAttr(sourceTag, 'media') ?? '';
+    if (type.includes('image/avif')) {
+      summary.badAvifRefs.push({ file, line: null, column: null, value: '<source>', message: 'hero picture must not include AVIF sources' });
+    }
+    if (type.includes('image/webp') && media.includes('(min-width:1024px)')) {
+      const srcset = getAttr(sourceTag, 'srcset') ?? '';
+      const sizes = getAttr(sourceTag, 'sizes') ?? '';
+      const entries = srcset.split(',').map((item) => item.trim()).filter(Boolean);
+      pageSummary.sourceWebp = entries;
+      desktopSources.push({ entries, sizes, media });
+      const required = ['/assets/img/hero/hero-desktop-1280.webp 1280w', '/assets/img/hero/hero-desktop-1920.webp 1920w'];
+      const unexpected = entries.filter((entry) => !required.includes(entry));
+      const missing = required.filter((entry) => !entries.includes(entry));
+      if (unexpected.length) {
+        summary.badPreloads.push({ file, line: null, column: null, value: unexpected, message: 'desktop hero source has unexpected srcset entries' });
+      }
+      if (missing.length) {
+        summary.badPreloads.push({ file, line: null, column: null, value: missing, message: 'desktop hero source missing required srcset entries' });
+      }
+      if (sizes.trim() !== '100vw') {
+        summary.badPreloads.push({ file, line: null, column: null, value: sizes, message: 'desktop hero source sizes must be 100vw' });
+      }
+    }
+  }
+
+  if (requireDesktopSource && desktopSources.length === 0) {
+    summary.badPreloads.push({ file, line: null, column: null, value: '(missing desktop <source>)', message: 'hero picture must include a desktop <source>' });
+  }
+  if (desktopSources.length > 1) {
+    summary.badPreloads.push({ file, line: null, column: null, value: desktopSources.length, message: 'hero picture should include only one desktop <source>' });
+  }
+}
+
+function analyzePreloads(file, content, { pageKey, requireDesktopPreload, requireMobilePreload, expectDesktopSource }) {
+  const pageSummary = ensurePageSummary(pageKey);
+  pageSummary.preloads.desktop = [];
+  pageSummary.preloads.mobile = [];
+  const preloadMatches = [...content.matchAll(/<link[^>]+rel=["']preload["'][^>]*>/gi)];
+  const requiredDesktopEntries = ['/assets/img/hero/hero-desktop-1280.webp 1280w', '/assets/img/hero/hero-desktop-1920.webp 1920w'];
+
+  for (const match of preloadMatches) {
+    const tag = match[0];
+    const asAttr = getAttr(tag, 'as') ?? '';
+    if (asAttr !== 'image') continue;
+    const href = getAttr(tag, 'href');
+    if (!href) continue;
+    const imagesrcset = getAttr(tag, 'imagesrcset') ?? '';
+    const imagesizes = getAttr(tag, 'imagesizes') ?? '';
+    const media = getAttr(tag, 'media') ?? '';
+    if (!href.includes('/assets/img/hero/')) continue;
+    if (!allowedHeroPaths.has(href)) {
+      summary.badPreloads.push({ file, line: null, column: null, value: href, message: 'hero preload references unexpected asset' });
+    }
+    if (href.endsWith('.avif')) {
+      summary.badAvifRefs.push({ file, line: null, column: null, value: href, message: 'hero preload must not reference AVIF asset' });
+    }
+    if (href === '/assets/img/hero/hero-mobile.webp') {
+      const entries = imagesrcset.split(',').map((item) => item.trim()).filter(Boolean);
+      pageSummary.preloads.mobile.push({ href, media, imagesrcset: entries, imagesizes });
+      if (entries.some((entry) => entry !== '/assets/img/hero/hero-mobile.webp 828w')) {
+        summary.badPreloads.push({ file, line: null, column: null, value: imagesrcset, message: 'mobile hero preload imagesrcset must only include hero-mobile.webp 828w' });
+      }
+      if (imagesizes.trim() !== '100vw') {
+        summary.badPreloads.push({ file, line: null, column: null, value: imagesizes, message: 'mobile hero preload imagesizes must be 100vw' });
+      }
+      if (media.trim() !== '(max-width:1023.98px)') {
+        summary.badPreloads.push({ file, line: null, column: null, value: media || '(missing media)', message: 'mobile hero preload media must be (max-width:1023.98px)' });
+      }
+    } else if (href === '/assets/img/hero/hero-desktop-1280.webp') {
+      const entries = imagesrcset.split(',').map((item) => item.trim()).filter(Boolean);
+      pageSummary.preloads.desktop.push({ href, media, imagesrcset: entries, imagesizes });
+      const unexpected = entries.filter((entry) => !requiredDesktopEntries.includes(entry));
+      const missing = requiredDesktopEntries.filter((entry) => !entries.includes(entry));
+      if (unexpected.length) {
+        summary.badPreloads.push({ file, line: null, column: null, value: unexpected, message: 'desktop hero preload imagesrcset has unexpected entries' });
+      }
+      if (missing.length) {
+        summary.badPreloads.push({ file, line: null, column: null, value: missing, message: 'desktop hero preload imagesrcset missing entries' });
+      }
+      if (imagesizes.trim() !== '100vw') {
+        summary.badPreloads.push({ file, line: null, column: null, value: imagesizes, message: 'desktop hero preload imagesizes must be 100vw' });
+      }
+      if (media.trim() !== '(min-width:1024px)') {
+        summary.badPreloads.push({ file, line: null, column: null, value: media || '(missing media)', message: 'desktop hero preload media must be (min-width:1024px)' });
+      }
+    } else if (href === '/assets/img/hero/hero-desktop-1920.webp') {
+      summary.badPreloads.push({ file, line: null, column: null, value: href, message: 'desktop hero preload href must be hero-desktop-1280.webp' });
+    }
+  }
+
+  if (requireMobilePreload && pageSummary.preloads.mobile.length === 0) {
+    summary.badPreloads.push({ file, line: null, column: null, value: '(missing mobile preload)', message: 'mobile hero preload missing' });
+  }
+  if (pageSummary.preloads.mobile.length > 1) {
+    summary.badPreloads.push({ file, line: null, column: null, value: pageSummary.preloads.mobile.length, message: 'multiple mobile hero preloads found' });
+  }
+
+  if (requireDesktopPreload && pageSummary.preloads.desktop.length === 0) {
+    summary.badPreloads.push({ file, line: null, column: null, value: '(missing desktop preload)', message: 'desktop hero preload missing' });
+  }
+  if (!expectDesktopSource && pageSummary.preloads.desktop.length > 0) {
+    summary.badPreloads.push({ file, line: null, column: null, value: '(unused desktop preload)', message: 'desktop hero preload exists but hero picture has no matching desktop source' });
+  }
+  if (pageSummary.preloads.desktop.length > 1) {
+    summary.badPreloads.push({ file, line: null, column: null, value: pageSummary.preloads.desktop.length, message: 'multiple desktop hero preloads found' });
+  }
+}
+
+async function main() {
+  const files = await collectFiles();
+  await Promise.all(
+    files.map(async (file) => {
+      const content = await readFile(file, 'utf8');
+      analyzeHeroReferences(file, content);
+      if (file.endsWith('.css')) {
+        checkCssBackground(file, content);
+      }
+      const config = pageConfigs.get(file);
+      if (config) {
+        analyzeHeroPicture(file, content, config);
+        const pageSummary = ensurePageSummary(config.pageKey);
+        const expectDesktopSource = pageSummary.sourceWebp.length > 0;
+        analyzePreloads(file, content, {
+          pageKey: config.pageKey,
+          requireDesktopPreload: config.requireDesktopPreload,
+          requireMobilePreload: config.requireMobilePreload,
+          expectDesktopSource
+        });
+      }
+    })
+  );
+
+  const hasIssues = summary.badPaths.length || summary.badAvifRefs.length || summary.badPreloads.length || summary.cssBackgroundImageRefs.length;
+  summary.status = hasIssues ? 'FAIL' : 'PASS';
+  const output = JSON.stringify(summary, null, 2);
+  console.log(output);
+  process.exitCode = hasIssues ? 1 : 0;
+}
+
+main().catch((error) => {
+  console.error(JSON.stringify({ status: 'ERROR', message: error.message }, null, 2));
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- temporarily serve the landing hero from the existing `/assets/img/hero/hero-mobile.webp` and align the preload (including the mobile media condition) so the page only references shipped assets while the desktop binaries are added outside this PR
- make the mobile actions script gracefully handle a missing partial by generating a fallback menu without console errors
- update the topbar logo sources to avoid referencing non-existent AVIF variants
- add a `scripts/verify-hero-assets.mjs` checker that enforces the canonical hero asset filenames, preload wiring, CSS constraints, and now validates the water hub/insights pages
- switch the water hub and insights pages (plus shared CSS) to the shared hero `<picture>` markup and preload pair so the utility view no longer relies on background images

## Testing
- node scripts/verify-hero-assets.mjs

------
https://chatgpt.com/codex/tasks/task_e_68e4e6c643388328a182efdb05546470