### PR TITLE
Fix: align hero & logo paths to existing assets; remove mistaken binaries

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,8 +17,8 @@
   <link rel="stylesheet" href="/assets/css/landing.css">
   <link rel="stylesheet" href="./assets/global-footer.css">
   <link rel="stylesheet" href="./assets/footer.css">
-  <link rel="preload" as="image" href="/assets/img/hero/hero-desktop.webp" imagesrcset="/assets/img/hero/hero-desktop.webp" media="(min-width: 769px)">
-  <link rel="preload" as="image" href="/assets/img/hero/hero-mobile.webp" imagesrcset="/assets/img/hero/hero-mobile.webp" media="(max-width: 768px)">
+  <link rel="preload" as="image" href="/assets/img/hero/hero-desktop.webp" imagesrcset="/assets/img/hero/hero-desktop.webp" media="(min-width:1024px)">
+  <link rel="preload" as="image" href="/assets/img/hero/hero-mobile.webp" imagesrcset="/assets/img/hero/hero-mobile.webp" media="(max-width:1023px)">
   <link rel="stylesheet" href="./assets/fonts.css">
   <link rel="stylesheet" href="./assets/unified-badge.css">
   <link rel="stylesheet" href="/assets/css/site.css">
@@ -38,13 +38,11 @@
         </a>
         <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
           <picture class="site-topbar__brand">
-            <source type="image/avif"
-              srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+            <source type="image/avif" srcset="/page/landing/logo2.avif"
               sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
-            <source type="image/webp"
-              srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
+            <source type="image/webp" srcset="/page/landing/logo2.webp"
               sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
-            <img src="/page/landing/logo2.webp"
+            <img src="/logo.png"
                  width="357" height="357" class="h-auto aspect-square"
                  alt="خانه هم‌افزایی انرژی و آب" decoding="async" fetchpriority="high">
           </picture>
@@ -53,7 +51,11 @@
     </header>
     <header class="site-header relative flex justify-center items-center px-4">
       <a class="logo inline-flex items-center justify-center" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
-        <img src="/page/landing/logo2.webp" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
+        <picture>
+          <source type="image/avif" srcset="/page/landing/logo2.avif">
+          <source type="image/webp" srcset="/page/landing/logo2.webp">
+          <img src="/logo.png" alt="لوگوی خانه هم‌افزایی انرژی و آب" loading="lazy" decoding="async" class="h-12 md:h-16 w-auto" />
+        </picture>
       </a>
       <div class="absolute top-4 right-4 flex items-center gap-2">
         <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>
@@ -84,21 +86,16 @@
     <section class="hero">
       <div class="media">
         <picture class="hero-picture">
-          <!-- desktop -->
-          <source media="(min-width:1024px)" type="image/avif"
-                  srcset="/page/landing/hero/hero-wide-1920.avif?v=20251007 1920w,
-                          /page/landing/hero/hero-wide-1280.avif?v=20251007 1280w"
-                  sizes="100vw">
           <source media="(min-width:1024px)" type="image/webp"
-                  srcset="/page/landing/hero/hero-wide-1920.webp?v=20251007 1920w,
-                          /page/landing/hero/hero-wide-1280.webp?v=20251007 1280w"
+                  srcset="/assets/img/hero/hero-desktop.webp"
                   sizes="100vw">
-          <!-- mobile -->
-          <source type="image/avif"
-                  srcset="/page/landing/hero/hero-tall-828.avif?v=20251007 828w,
-                          /page/landing/hero/hero-tall-576.avif?v=20251007 576w"
+          <source type="image/webp"
+                  srcset="/assets/img/hero/hero-mobile.webp"
                   sizes="100vw">
-          <img src="/page/landing/hero/hero-tall-828.webp?v=20251007"
+          <source type="image/jpeg"
+                  srcset="/assets/hero2.jpg"
+                  sizes="100vw">
+          <img src="/assets/img/hero/hero-mobile.webp"
                alt="" width="1920" height="1080" decoding="async" fetchpriority="high" class="hero-img">
         </picture>
       </div>

--- a/docs/solar/index.html
+++ b/docs/solar/index.html
@@ -27,13 +27,11 @@
       </a>
       <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
         <picture class="site-topbar__brand">
-          <source type="image/avif"
-            srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+          <source type="image/avif" srcset="/page/landing/logo2.avif"
             sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
-          <source type="image/webp"
-            srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
+          <source type="image/webp" srcset="/page/landing/logo2.webp"
             sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
-          <img src="/page/landing/logo2.webp"
+          <img src="/logo.png"
                width="357" height="357" class="h-auto aspect-square"
                alt="خانه هم‌افزایی انرژی و آب" decoding="async">
         </picture>
@@ -43,7 +41,11 @@
   <header class="bg-white border-b border-slate-200">
     <div class="max-w-6xl mx-auto px-4 py-6 flex items-center justify-between gap-4">
       <a class="logo flex items-center gap-3 text-slate-800 font-semibold" href="/" aria-label="صفحه اصلی" rel="home" data-logo="home">
-        <img src="/page/landing/logo2.webp" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
+        <picture>
+          <source type="image/avif" srcset="/page/landing/logo2.avif">
+          <source type="image/webp" srcset="/page/landing/logo2.webp">
+          <img src="/logo.png" alt="نشان وِش۳۶۰" class="w-16 h-auto" loading="lazy" decoding="async" />
+        </picture>
         <span class="text-base md:text-lg">WESH360</span>
       </a>
       <nav class="hidden md:flex items-center gap-3 text-sm" data-mobile-actions-source>

--- a/docs/water/hub.html
+++ b/docs/water/hub.html
@@ -25,13 +25,11 @@
       </a>
       <a class="site-topbar__brand" href="/" aria-label="صفحه اصلی">
         <picture class="site-topbar__brand">
-          <source type="image/avif"
-            srcset="/page/landing/logo2-160.avif 160w, /page/landing/logo2-240.avif 240w, /page/landing/logo2.avif 357w"
+          <source type="image/avif" srcset="/page/landing/logo2.avif"
             sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
-          <source type="image/webp"
-            srcset="/page/landing/logo2-160.webp 160w, /page/landing/logo2-240.webp 240w, /page/landing/logo2.webp 357w"
+          <source type="image/webp" srcset="/page/landing/logo2.webp"
             sizes="(min-width:1024px) 64px, (min-width:640px) 56px, 48px">
-          <img src="/page/landing/logo2.webp"
+          <img src="/logo.png"
                width="357" height="357" class="h-auto aspect-square"
                alt="خانه هم‌افزایی انرژی و آب" decoding="async">
         </picture>


### PR DESCRIPTION
## Summary
- stop creating new image files; reuse existing /page/landing/logo2.(avif|webp) and /assets/img/hero/* so preloads match usage; no new binaries.

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5e52437888328b20c8c009e90c09e