### PR TITLE
Fix mobile actions link cloning for SVG safety

### DIFF
--- a/docs/assets/js/mobile-actions.js
+++ b/docs/assets/js/mobile-actions.js
@@ -36,8 +36,12 @@
       item.className = 'mobile-actions__item';
       const anchor = document.createElement('a');
       anchor.className = 'mobile-actions__link';
-      anchor.innerHTML = link.innerHTML;
+      // clone children to preserve SVG namespace and attributes:
+      link.childNodes.forEach((n)=> anchor.appendChild(n.cloneNode(true)));
       copyLinkAttributes(link, anchor);
+      if(anchor.getAttribute('target') === '_blank'){
+        anchor.setAttribute('rel','noopener noreferrer');
+      }
       item.appendChild(anchor);
       list.appendChild(item);
     });


### PR DESCRIPTION
## Summary
- clone source link children when building mobile action links to preserve SVG markup
- add rel="noopener noreferrer" to duplicated links that open in a new tab

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5ea174c348328bdbcefbb0b9b605c