### PR TITLE
Add viewport meta tag to water cost calculator page

### DIFF
--- a/docs/water/cost-calculator.html
+++ b/docs/water/cost-calculator.html
@@ -2,6 +2,7 @@
 <html lang="fa" dir="rtl">
 <head>
   <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>ماشین‌حساب پیشرفته قیمت تمام‌شده آب در مشهد</title>
   <link rel="stylesheet" href="../assets/tailwind.css">
   <link rel="stylesheet" href="../assets/fonts.css">


### PR DESCRIPTION
## Summary
- add a standard viewport meta tag to the water cost calculator page to ensure mobile-friendly scaling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f65300d08328bc7b2f104f764bca