### PR TITLE
Adjust CLD tour layout for mobile

### DIFF
--- a/docs/assets/water-cld.tour.css
+++ b/docs/assets/water-cld.tour.css
@@ -24,6 +24,8 @@
   border: 1px solid var(--tour-bd); color: var(--tour-fg);
   border-radius: 12px; padding: 12px 14px; z-index: calc(var(--tour-z) + 3);
   box-shadow: 0 10px 28px rgba(0,0,0,.35);
+  bottom: 1rem; left: 50%; right: auto; top: auto; transform: translateX(-50%);
+  width: min(90vw, 360px);
 }
 .cld-tour-pop h4{margin:0 0 6px 0; font-size:15px}
 .cld-tour-pop p{margin:0; font-size:13px; opacity:.9; line-height:1.6}
@@ -33,7 +35,18 @@
   border-radius: 10px; padding: 6px 10px; cursor: pointer; font-size: 12px;
 }
 .cld-tour-btn.primary{ background: var(--tour-accent); border-color: var(--tour-accent); color:#fff }
-.cld-tour-badge{ position: fixed; top: 8px; left: 8px; z-index: calc(var(--tour-z)+4);
-  background: var(--tour-card); border:1px solid var(--tour-bd); color: var(--tour-fg);
-  border-radius: 999px; font-size: 11px; padding: 4px 8px; opacity:.9 }
-@media (max-width: 560px){ .cld-tour-pop{ max-width: 92vw } }
+.cld-tour-badge{ position: fixed; bottom: 1rem; left: 50%; right: auto; top: auto; transform: translateX(-50%);
+  z-index: calc(var(--tour-z)+4); background: var(--tour-card); border:1px solid var(--tour-bd);
+  color: var(--tour-fg); border-radius: 999px; font-size: 11px; opacity:.9;
+  min-width: 44px; min-height: 44px; padding: .5rem .75rem;
+  display: inline-flex; align-items: center; justify-content: center;
+}
+@media (min-width: 768px){
+  .cld-tour-pop{
+    left: auto; right: 1rem; top: 1rem; bottom: auto; transform: none;
+    width: 20rem;
+  }
+  .cld-tour-badge{
+    top: 8px; bottom: auto; left: 8px; transform: none;
+  }
+}


### PR DESCRIPTION
## Summary
- center the CLD tour popup on small screens and constrain its width so it remains within the viewport
- move the CLD tour badge to the bottom center on mobile and expand its tap target to 44px minimum
- restore desktop-specific positioning for the popup and badge at wider breakpoints

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5f926704c83288eeee88fc0af91e1