### PR TITLE
Add privacy policy page for Wesh Telegram Publisher GPT

### DIFF
--- a/docs/legal/wesh-telegram-gpt-privacy.html
+++ b/docs/legal/wesh-telegram-gpt-privacy.html
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Privacy Policy for Wesh Telegram Publisher GPT</title>
+  <!-- برای جلوگیری از ایندکس شدن (اختیاری) -->
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 720px; margin: 3rem auto; padding: 0 1rem; line-height: 1.6; }
+    h1 { font-size: 1.6rem; margin-bottom: .5rem; }
+    small { color:#666 }
+  </style>
+</head>
+<body>
+  <h1>Privacy Policy for Wesh Telegram Publisher GPT</h1>
+  <small>Last updated: 2025-10-08</small>
+  <p>This page explains how data is processed when using this GPT to publish to a Telegram channel.</p>
+  <ul>
+    <li><b>What we collect:</b> The text you input (and optional photo URLs/captions) to be sent to Telegram.</li>
+    <li><b>How we use it:</b> We call the Telegram Bot API to post the content to your channel. No other use.</li>
+    <li><b>Sharing:</b> Telegram receives the content necessary to deliver the message. We do not share data elsewhere.</li>
+    <li><b>Retention:</b> We do not persist messages. Minimal transient state (e.g., last published IDs) may be kept for reliability.</li>
+    <li><b>Your rights:</b> Stop using the GPT any time; on request we can delete any retained operational state.</li>
+  </ul>
+  <p>Contact: <a href="mailto:info@wesh360.ir">info@wesh360.ir</a></p>
+  <hr>
+  <p>This policy applies to the custom GPT and complements OpenAI’s data policies.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone privacy policy HTML page for the Wesh Telegram Publisher GPT under docs/legal

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e61da7a4a48328b5e59c14edad989b